### PR TITLE
more ratelimiting

### DIFF
--- a/.github/workflows/test-and-deploy.yaml
+++ b/.github/workflows/test-and-deploy.yaml
@@ -55,6 +55,18 @@ jobs:
           go build ./cmd/get-stats/main.go
           go build ./cmd/fix-minify-fixtures/main.go
 
+      - name: Make .env for local server
+        run: |
+          touch ./cmd/.env
+
+      - name: Test user id rate limit
+        run: |
+          ./cmd/test-user-id-rate-limit.sh
+
+      - name: Test ip rate limit
+        run: |
+          ./cmd/test-ip-rate-limit.sh
+
       - name: GCP login
         uses: google-github-actions/auth@v2
         with:

--- a/cmd/deploy.sh
+++ b/cmd/deploy.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 set -eu
+set -o pipefail
 
 function_name="${1:-}"
 
@@ -36,4 +37,5 @@ gcloud functions deploy "$function_name" \
 # Verify that newly deployed function works
 curl --fail \
 	-H "X-User-Id: github-actions-$function_name" \
-	"https://northamerica-northeast2-prism-overlay.cloudfunctions.net/${function_name}?uuid=a937646b-f115-44c3-8dbf-9ae4a65669a0"
+	"https://northamerica-northeast2-prism-overlay.cloudfunctions.net/${function_name}?uuid=a937646b-f115-44c3-8dbf-9ae4a65669a0" \
+	| grep 'Skydeath'

--- a/cmd/run.sh
+++ b/cmd/run.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -eu
+
 env_file="$(dirname "$0")/.env"
 
 if [ ! -f "$env_file" ]; then
@@ -12,5 +14,5 @@ fi
 
 FUNCTION_TARGET=flashlight \
 LOCAL_ONLY=true \
-PORT=8123 \
+PORT="${1:-8123}" \
 	go run cmd/main.go

--- a/cmd/test-ip-rate-limit.sh
+++ b/cmd/test-ip-rate-limit.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+set -eu
+
+PORT="${1:-8800}"
+
+# NOTE: Not doing any cleanup here. Couldn't figure out how to get the
+#		proper pid to kill.
+echo 'Starting server' >&2
+./cmd/run.sh "$PORT" >/dev/null 2>&1 &
+
+while ! curl \
+		--fail \
+		--silent \
+		"localhost:$PORT?uuid=some-requested-uuid" >/dev/null 2>&1; do
+	echo 'Waiting for server to start' >&2
+	sleep 0.5
+done
+
+# Should all be allowed
+echo 'Issuing initial (allowed) requests' >&2
+for i in $(seq 1 480); do
+	curl \
+		--fail \
+		--silent \
+		-H "X-User-Id: my-user-id-$i" \
+		"localhost:$PORT?uuid=some-requested-uuid" \
+		| grep 'some-requested-uuid' >/dev/null 2>&1
+done
+
+# Might get denied, depending on how long we took
+echo 'Issuing secondary (maybe disallowed) requests' >&2
+for i in $(seq 1 480); do
+	curl \
+		--silent \
+		-H "X-User-Id: my-user-id-$i" \
+		"localhost:$PORT?uuid=some-requested-uuid" >/dev/null 2>&1 \
+		|| true
+done
+
+echo 'Issuing final (disallowed) request' >&2
+if curl \
+		--fail \
+		-H "X-User-Id: my-user-id-$i" \
+		"localhost:$PORT?uuid=some-requested-uuid" >/dev/null 2>&1; then
+	echo 'Request succeeded when user should have been rate limited!'
+	exit 1
+fi

--- a/cmd/test-ip-rate-limit.sh
+++ b/cmd/test-ip-rate-limit.sh
@@ -38,11 +38,14 @@ for i in $(seq 1 480); do
 		|| true
 done
 
-echo 'Issuing final (disallowed) request' >&2
-if curl \
-		--fail \
-		-H "X-User-Id: my-user-id-$i" \
-		"localhost:$PORT?uuid=some-requested-uuid" >/dev/null 2>&1; then
-	echo 'Request succeeded when user should have been rate limited!'
-	exit 1
-fi
+echo 'Issuing final (disallowed) requests' >&2
+for i in $(seq 1 10); do
+	if ! curl \
+			--fail \
+			-H "X-User-Id: my-user-id-$i" \
+			"localhost:$PORT?uuid=some-requested-uuid" >/dev/null 2>&1; then
+		exit 0
+	fi
+done
+echo 'All requests succeeded when ip should have been rate limited!' >&2
+exit 1

--- a/cmd/test-user-id-rate-limit.sh
+++ b/cmd/test-user-id-rate-limit.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+set -eu
+
+PORT="${1:-8900}"
+
+# NOTE: Not doing any cleanup here. Couldn't figure out how to get the
+#		proper pid to kill.
+echo 'Starting server' >&2
+./cmd/run.sh "$PORT" >/dev/null 2>&1 &
+
+while ! curl \
+		--fail \
+		--silent \
+		"localhost:$PORT?uuid=some-requested-uuid" >/dev/null 2>&1; do
+	echo 'Waiting for server to start' >&2
+	sleep 0.5
+done
+
+# Should all be allowed
+echo 'Issuing initial (allowed) requests' >&2
+for _ in $(seq 1 120); do
+	curl \
+		--fail \
+		--silent \
+		-H 'X-User-Id: my-user-id' \
+		"localhost:$PORT?uuid=some-requested-uuid" \
+		| grep 'some-requested-uuid' >/dev/null 2>&1
+done
+
+# Might get denied, depending on how long we took
+echo 'Issuing secondary (maybe disallowed) requests' >&2
+for _ in $(seq 1 120); do
+	curl \
+		--silent \
+		-H 'X-User-Id: my-user-id' \
+		"localhost:$PORT?uuid=some-requested-uuid" >/dev/null 2>&1 \
+		|| true
+done
+
+echo 'Issuing final (disallowed) request' >&2
+if curl \
+		--fail \
+		-H 'X-User-Id: my-user-id' \
+		"localhost:$PORT?uuid=some-requested-uuid" >/dev/null 2>&1; then
+	echo 'Request succeeded when user should have been rate limited!'
+	exit 1
+fi

--- a/cmd/test-user-id-rate-limit.sh
+++ b/cmd/test-user-id-rate-limit.sh
@@ -38,11 +38,14 @@ for _ in $(seq 1 120); do
 		|| true
 done
 
-echo 'Issuing final (disallowed) request' >&2
-if curl \
-		--fail \
-		-H 'X-User-Id: my-user-id' \
-		"localhost:$PORT?uuid=some-requested-uuid" >/dev/null 2>&1; then
-	echo 'Request succeeded when user should have been rate limited!'
-	exit 1
-fi
+echo 'Issuing final (disallowed) requests' >&2
+for _ in $(seq 1 10); do
+	if ! curl \
+			--fail \
+			-H 'X-User-Id: my-user-id' \
+			"localhost:$PORT?uuid=some-requested-uuid" >/dev/null 2>&1; then
+		exit 0
+	fi
+done
+echo 'All requests succeeded when user should have been rate limited!' >&2
+exit 1

--- a/function.go
+++ b/function.go
@@ -41,11 +41,11 @@ func init() {
 	hypixelAPI := hypixel.NewHypixelAPI(httpClient, apiKey)
 
 	ipRateLimiter := ratelimiting.NewRequestBasedRateLimiter(
-		ratelimiting.NewKeyBasedRateLimiter(8, 480), ratelimiting.IPKeyFunc,
+		ratelimiting.NewTokenBucketRateLimiter(8, 480), ratelimiting.IPKeyFunc,
 	)
 	userIdRateLimiter := ratelimiting.NewRequestBasedRateLimiter(
 		// NOTE: Rate limiting based on user controlled value
-		ratelimiting.NewKeyBasedRateLimiter(2, 120), ratelimiting.UserIdKeyFunc,
+		ratelimiting.NewTokenBucketRateLimiter(2, 120), ratelimiting.UserIdKeyFunc,
 	)
 
 	var sentryMiddleware func(http.HandlerFunc) http.HandlerFunc

--- a/function.go
+++ b/function.go
@@ -40,9 +40,8 @@ func init() {
 
 	hypixelAPI := hypixel.NewHypixelAPI(httpClient, apiKey)
 
-	rateLimiter := ratelimiting.NewKeyBasedRateLimiter(2, 120)
 	ipRateLimiter := ratelimiting.NewRequestBasedRateLimiter(
-		rateLimiter, ratelimiting.IPKeyFunc,
+		ratelimiting.NewKeyBasedRateLimiter(2, 120), ratelimiting.IPKeyFunc,
 	)
 
 	var sentryMiddleware func(http.HandlerFunc) http.HandlerFunc

--- a/function.go
+++ b/function.go
@@ -43,6 +43,10 @@ func init() {
 	ipRateLimiter := ratelimiting.NewRequestBasedRateLimiter(
 		ratelimiting.NewKeyBasedRateLimiter(2, 120), ratelimiting.IPKeyFunc,
 	)
+	userIdRateLimiter := ratelimiting.NewRequestBasedRateLimiter(
+		// NOTE: Rate limiting based on user controlled value
+		ratelimiting.NewKeyBasedRateLimiter(2, 120), ratelimiting.UserIdKeyFunc,
+	)
 
 	var sentryMiddleware func(http.HandlerFunc) http.HandlerFunc
 	if localOnly && sentryDSN == "" {
@@ -65,6 +69,7 @@ func init() {
 		logging.NewRequestLoggerMiddleware(rootLogger),
 		sentryMiddleware,
 		server.NewRateLimitMiddleware(ipRateLimiter),
+		server.NewRateLimitMiddleware(userIdRateLimiter),
 	)
 
 	functions.HTTP(

--- a/function.go
+++ b/function.go
@@ -22,18 +22,19 @@ import (
 func init() {
 	localOnly := os.Getenv("LOCAL_ONLY") == "true"
 
-	apiKey := os.Getenv("HYPIXEL_API_KEY")
-	if apiKey == "" {
-		log.Fatalln("Missing Hypixel API key")
-	}
-
 	httpClient := &http.Client{
 		Timeout: 10 * time.Second,
 	}
 
 	playerCache := cache.NewPlayerCache(1 * time.Minute)
 
-	hypixelAPI := hypixel.NewHypixelAPI(httpClient, apiKey)
+	hypixelApiKey := os.Getenv("HYPIXEL_API_KEY")
+	var hypixelAPI hypixel.HypixelAPI
+	if hypixelApiKey != "" {
+		hypixelAPI = hypixel.NewHypixelAPI(httpClient, hypixelApiKey)
+	} else {
+		log.Fatalln("Missing Hypixel API key")
+	}
 
 	ipRateLimiter := ratelimiting.NewRequestBasedRateLimiter(
 		ratelimiting.NewTokenBucketRateLimiter(

--- a/function.go
+++ b/function.go
@@ -41,6 +41,9 @@ func init() {
 	hypixelAPI := hypixel.NewHypixelAPI(httpClient, apiKey)
 
 	rateLimiter := ratelimiting.NewKeyBasedRateLimiter(2, 120)
+	ipRateLimiter := ratelimiting.NewRequestBasedRateLimiter(
+		rateLimiter, ratelimiting.IPKeyFunc,
+	)
 
 	var sentryMiddleware func(http.HandlerFunc) http.HandlerFunc
 	if localOnly && sentryDSN == "" {
@@ -62,7 +65,7 @@ func init() {
 	middleware := server.ComposeMiddlewares(
 		logging.NewRequestLoggerMiddleware(rootLogger),
 		sentryMiddleware,
-		server.NewRateLimitMiddleware(rateLimiter),
+		server.NewRateLimitMiddleware(ipRateLimiter),
 	)
 
 	functions.HTTP(

--- a/function.go
+++ b/function.go
@@ -40,7 +40,7 @@ func init() {
 
 	hypixelAPI := hypixel.NewHypixelAPI(httpClient, apiKey)
 
-	rateLimiter := ratelimiting.NewIPBasedRateLimiter(2, 120)
+	rateLimiter := ratelimiting.NewKeyBasedRateLimiter(2, 120)
 
 	var sentryMiddleware func(http.HandlerFunc) http.HandlerFunc
 	if localOnly && sentryDSN == "" {

--- a/function.go
+++ b/function.go
@@ -41,7 +41,7 @@ func init() {
 	hypixelAPI := hypixel.NewHypixelAPI(httpClient, apiKey)
 
 	ipRateLimiter := ratelimiting.NewRequestBasedRateLimiter(
-		ratelimiting.NewKeyBasedRateLimiter(2, 120), ratelimiting.IPKeyFunc,
+		ratelimiting.NewKeyBasedRateLimiter(8, 480), ratelimiting.IPKeyFunc,
 	)
 	userIdRateLimiter := ratelimiting.NewRequestBasedRateLimiter(
 		// NOTE: Rate limiting based on user controlled value

--- a/function.go
+++ b/function.go
@@ -41,11 +41,19 @@ func init() {
 	hypixelAPI := hypixel.NewHypixelAPI(httpClient, apiKey)
 
 	ipRateLimiter := ratelimiting.NewRequestBasedRateLimiter(
-		ratelimiting.NewTokenBucketRateLimiter(8, 480), ratelimiting.IPKeyFunc,
+		ratelimiting.NewTokenBucketRateLimiter(
+			ratelimiting.RefillPerSecond(8),
+			ratelimiting.BurstSize(480),
+		),
+		ratelimiting.IPKeyFunc,
 	)
 	userIdRateLimiter := ratelimiting.NewRequestBasedRateLimiter(
 		// NOTE: Rate limiting based on user controlled value
-		ratelimiting.NewTokenBucketRateLimiter(2, 120), ratelimiting.UserIdKeyFunc,
+		ratelimiting.NewTokenBucketRateLimiter(
+			ratelimiting.RefillPerSecond(2),
+			ratelimiting.BurstSize(120),
+		),
+		ratelimiting.UserIdKeyFunc,
 	)
 
 	var sentryMiddleware func(http.HandlerFunc) http.HandlerFunc

--- a/internal/ratelimiting/ratelimiter.go
+++ b/internal/ratelimiting/ratelimiter.go
@@ -8,7 +8,7 @@ import (
 )
 
 type RateLimiter interface {
-	Allow(key string) bool
+	Consume(key string) bool
 }
 
 type keyBasedRateLimiter struct {
@@ -17,7 +17,7 @@ type keyBasedRateLimiter struct {
 	burstSize       int
 }
 
-func (rateLimiter keyBasedRateLimiter) Allow(key string) bool {
+func (rateLimiter keyBasedRateLimiter) Consume(key string) bool {
 	limiter, _ := rateLimiter.limiterByIP.GetOrSet(key, rate.NewLimiter(rate.Limit(rateLimiter.refillPerSecond), rateLimiter.burstSize))
 	return limiter.Value().Allow()
 }

--- a/internal/ratelimiting/ratelimiter.go
+++ b/internal/ratelimiting/ratelimiter.go
@@ -13,24 +13,24 @@ type RateLimiter interface {
 	Consume(key string) bool
 }
 
-type keyBasedRateLimiter struct {
+type tokenBucketRateLimiter struct {
 	limiterByIP     *ttlcache.Cache[string, *rate.Limiter]
 	refillPerSecond int
 	burstSize       int
 }
 
-func (rateLimiter keyBasedRateLimiter) Consume(key string) bool {
+func (rateLimiter tokenBucketRateLimiter) Consume(key string) bool {
 	limiter, _ := rateLimiter.limiterByIP.GetOrSet(key, rate.NewLimiter(rate.Limit(rateLimiter.refillPerSecond), rateLimiter.burstSize))
 	return limiter.Value().Allow()
 }
 
-func NewKeyBasedRateLimiter(refillPerSecond int, burstSize int) RateLimiter {
+func NewTokenBucketRateLimiter(refillPerSecond int, burstSize int) RateLimiter {
 	limiterTTLCache := ttlcache.New[string, *rate.Limiter](
 		ttlcache.WithTTL[string, *rate.Limiter](30 * time.Minute),
 	)
 	go limiterTTLCache.Start()
 
-	return keyBasedRateLimiter{
+	return tokenBucketRateLimiter{
 		limiterByIP:     limiterTTLCache,
 		refillPerSecond: refillPerSecond,
 		burstSize:       burstSize,

--- a/internal/ratelimiting/ratelimiter.go
+++ b/internal/ratelimiting/ratelimiter.go
@@ -24,7 +24,10 @@ func (rateLimiter tokenBucketRateLimiter) Consume(key string) bool {
 	return limiter.Value().Allow()
 }
 
-func NewTokenBucketRateLimiter(refillPerSecond int, burstSize int) RateLimiter {
+type RefillPerSecond int
+type BurstSize int
+
+func NewTokenBucketRateLimiter(refillPerSecond RefillPerSecond, burstSize BurstSize) RateLimiter {
 	limiterTTLCache := ttlcache.New[string, *rate.Limiter](
 		ttlcache.WithTTL[string, *rate.Limiter](30 * time.Minute),
 	)
@@ -32,8 +35,8 @@ func NewTokenBucketRateLimiter(refillPerSecond int, burstSize int) RateLimiter {
 
 	return tokenBucketRateLimiter{
 		limiterByIP:     limiterTTLCache,
-		refillPerSecond: refillPerSecond,
-		burstSize:       burstSize,
+		refillPerSecond: int(refillPerSecond),
+		burstSize:       int(burstSize),
 	}
 }
 

--- a/internal/ratelimiting/ratelimiter.go
+++ b/internal/ratelimiting/ratelimiter.go
@@ -3,6 +3,7 @@ package ratelimiting
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
@@ -66,7 +67,14 @@ func NewRequestBasedRateLimiter(limiter RateLimiter, keyFunc func(r *http.Reques
 }
 
 func IPKeyFunc(r *http.Request) string {
-	return fmt.Sprintf("ip: %s", r.RemoteAddr)
+	withoutPort := r.RemoteAddr
+
+	portIndex := strings.IndexByte(r.RemoteAddr, ':')
+	if portIndex != -1 {
+		withoutPort = r.RemoteAddr[:portIndex]
+	}
+
+	return fmt.Sprintf("ip: %s", withoutPort)
 }
 
 func UserIdKeyFunc(r *http.Request) string {

--- a/internal/ratelimiting/ratelimiter.go
+++ b/internal/ratelimiting/ratelimiter.go
@@ -65,3 +65,11 @@ func NewRequestBasedRateLimiter(limiter RateLimiter, keyFunc func(r *http.Reques
 func IPKeyFunc(r *http.Request) string {
 	return fmt.Sprintf("ip: %s", r.RemoteAddr)
 }
+
+func UserIdKeyFunc(r *http.Request) string {
+	userId := r.Header.Get("X-User-Id")
+	if userId == "" {
+		userId = "<missing>"
+	}
+	return fmt.Sprintf("user-id: %.50s", userId)
+}

--- a/internal/ratelimiting/ratelimiter_test.go
+++ b/internal/ratelimiting/ratelimiter_test.go
@@ -14,26 +14,26 @@ func TestKeyBasedRateLimiter(t *testing.T) {
 	}
 	rateLimiter := NewKeyBasedRateLimiter(1, 2)
 
-	assert.True(t, rateLimiter.Allow("user2"))
+	assert.True(t, rateLimiter.Consume("user2"))
 
 	// Burst of 2
-	assert.True(t, rateLimiter.Allow("user1"))
-	assert.True(t, rateLimiter.Allow("user1"))
-	assert.False(t, rateLimiter.Allow("user1"))
+	assert.True(t, rateLimiter.Consume("user1"))
+	assert.True(t, rateLimiter.Consume("user1"))
+	assert.False(t, rateLimiter.Consume("user1"))
 
 	time.Sleep(1000 * time.Millisecond)
 	runtime.Gosched()
 
 	// Refill rate of 1
-	assert.True(t, rateLimiter.Allow("user1"))
-	assert.False(t, rateLimiter.Allow("user1"))
+	assert.True(t, rateLimiter.Consume("user1"))
+	assert.False(t, rateLimiter.Consume("user1"))
 
 	// Burst of 2 - even after refill
-	assert.True(t, rateLimiter.Allow("user3"))
-	assert.True(t, rateLimiter.Allow("user3"))
-	assert.False(t, rateLimiter.Allow("user3"))
+	assert.True(t, rateLimiter.Consume("user3"))
+	assert.True(t, rateLimiter.Consume("user3"))
+	assert.False(t, rateLimiter.Consume("user3"))
 
-	assert.True(t, rateLimiter.Allow("user2"))
-	assert.True(t, rateLimiter.Allow("user2"))
-	assert.False(t, rateLimiter.Allow("user2"))
+	assert.True(t, rateLimiter.Consume("user2"))
+	assert.True(t, rateLimiter.Consume("user2"))
+	assert.False(t, rateLimiter.Consume("user2"))
 }

--- a/internal/ratelimiting/ratelimiter_test.go
+++ b/internal/ratelimiting/ratelimiter_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIPBasedRateLimiter(t *testing.T) {
+func TestKeyBasedRateLimiter(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping test in short mode")
 	}
-	rateLimiter := NewIPBasedRateLimiter(1, 2)
+	rateLimiter := NewKeyBasedRateLimiter(1, 2)
 
 	assert.True(t, rateLimiter.Allow("user2"))
 

--- a/internal/ratelimiting/ratelimiter_test.go
+++ b/internal/ratelimiting/ratelimiter_test.go
@@ -49,8 +49,20 @@ func TestTokenBucketRateLimiter(t *testing.T) {
 }
 
 func TestIPKeyFunc(t *testing.T) {
-	request := &http.Request{RemoteAddr: "123.123.123.123"}
-	assert.Equal(t, "ip: 123.123.123.123", IPKeyFunc(request))
+	cases := []struct {
+		remoteAddr string
+		key        string
+	}{
+		{"123.123.123.123", "ip: 123.123.123.123"},
+		// Port is stripped
+		{"127.0.0.1:52123", "ip: 127.0.0.1"},
+	}
+	for _, c := range cases {
+		t.Run(c.remoteAddr, func(t *testing.T) {
+			request := &http.Request{RemoteAddr: c.remoteAddr}
+			assert.Equal(t, c.key, IPKeyFunc(request))
+		})
+	}
 }
 
 func TestUserIdKeyFunc(t *testing.T) {

--- a/internal/ratelimiting/ratelimiter_test.go
+++ b/internal/ratelimiting/ratelimiter_test.go
@@ -22,7 +22,7 @@ func TestTokenBucketRateLimiter(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping test in short mode")
 	}
-	rateLimiter := NewTokenBucketRateLimiter(1, 2)
+	rateLimiter := NewTokenBucketRateLimiter(RefillPerSecond(1), BurstSize(2))
 
 	assert.True(t, rateLimiter.Consume("user2"))
 

--- a/internal/ratelimiting/ratelimiter_test.go
+++ b/internal/ratelimiting/ratelimiter_test.go
@@ -18,11 +18,11 @@ func (m *mockedRateLimiter) Consume(key string) bool {
 	return m.consumeFunc(key)
 }
 
-func TestKeyBasedRateLimiter(t *testing.T) {
+func TestTokenBucketRateLimiter(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping test in short mode")
 	}
-	rateLimiter := NewKeyBasedRateLimiter(1, 2)
+	rateLimiter := NewTokenBucketRateLimiter(1, 2)
 
 	assert.True(t, rateLimiter.Consume("user2"))
 

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -8,13 +8,13 @@ import (
 	"github.com/Amund211/flashlight/internal/ratelimiting"
 )
 
-func NewRateLimitMiddleware(rateLimiter ratelimiting.RateLimiter) func(http.HandlerFunc) http.HandlerFunc {
+func NewRateLimitMiddleware(rateLimiter ratelimiting.RequestRateLimiter) func(http.HandlerFunc) http.HandlerFunc {
 	return func(next http.HandlerFunc) http.HandlerFunc {
 		return func(w http.ResponseWriter, r *http.Request) {
-			if !rateLimiter.Consume(r.RemoteAddr) {
+			if !rateLimiter.Consume(r) {
 				logger := logging.FromContext(r.Context())
 				statusCode := writeErrorResponse(r.Context(), w, e.RatelimitExceededError)
-				logger.Info("Returning response", "statusCode", statusCode, "reason", "ratelimit exceeded")
+				logger.Info("Returning response", "statusCode", statusCode, "reason", "ratelimit exceeded", "key", rateLimiter.KeyFor(r))
 				return
 			}
 

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -11,7 +11,7 @@ import (
 func NewRateLimitMiddleware(rateLimiter ratelimiting.RateLimiter) func(http.HandlerFunc) http.HandlerFunc {
 	return func(next http.HandlerFunc) http.HandlerFunc {
 		return func(w http.ResponseWriter, r *http.Request) {
-			if !rateLimiter.Allow(r.RemoteAddr) {
+			if !rateLimiter.Consume(r.RemoteAddr) {
 				logger := logging.FromContext(r.Context())
 				statusCode := writeErrorResponse(r.Context(), w, e.RatelimitExceededError)
 				logger.Info("Returning response", "statusCode", statusCode, "reason", "ratelimit exceeded")

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -14,7 +14,7 @@ type mockedRateLimiter struct {
 	expectedKey string
 }
 
-func (m *mockedRateLimiter) Allow(key string) bool {
+func (m *mockedRateLimiter) Consume(key string) bool {
 	assert.Equal(m.t, m.expectedKey, key)
 	return m.allow
 }

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -26,7 +26,7 @@ func TestRateLimitMiddleware(t *testing.T) {
 		rateLimiter := &mockedRateLimiter{
 			t:           t,
 			allow:       allow,
-			expectedKey: "user1",
+			expectedKey: "127.0.0.1",
 		}
 
 		w := httptest.NewRecorder()
@@ -38,7 +38,7 @@ func TestRateLimitMiddleware(t *testing.T) {
 			},
 		)
 
-		handler(w, &http.Request{RemoteAddr: "user1"})
+		handler(w, &http.Request{RemoteAddr: "127.0.0.1"})
 
 		if allow {
 			assert.True(t, called, "Expected handler to be called")

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/Amund211/flashlight/internal/ratelimiting"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -26,11 +27,14 @@ func TestRateLimitMiddleware(t *testing.T) {
 		rateLimiter := &mockedRateLimiter{
 			t:           t,
 			allow:       allow,
-			expectedKey: "127.0.0.1",
+			expectedKey: "ip: 127.0.0.1",
 		}
+		ipRateLimiter := ratelimiting.NewRequestBasedRateLimiter(
+			rateLimiter, ratelimiting.IPKeyFunc,
+		)
 
 		w := httptest.NewRecorder()
-		middleware := NewRateLimitMiddleware(rateLimiter)
+		middleware := NewRateLimitMiddleware(ipRateLimiter)
 		handler := middleware(
 			func(w http.ResponseWriter, r *http.Request) {
 				called = true


### PR DESCRIPTION
- **chore: Rename to key based rate limiter**
- **chore: Rename Allow -> Consume**
- **chore: Use actual ip in ratelimit middleware test**
- **chore: Make generic struct for request based rate limiter**
- **chore: Add user id key func for rate limiter**
- **chore: Inline variable**
- **feat: Add rate limiter based on user id**
- **feat: Relax ip based rate limit**
- **chore: Rename to TokenBucketRateLimiter**
- **chore: Make TokenBucketRateLimiter arguments type safe**
- **chore: Merge sentry config validation + setup**
- **chore: Merge Hypixel API config validation + setup**
- **chore: Ensure output from deployed function is valid**
- **chore: Enable local only run with mocked Hypixel API**
- **fix: Strip port from address used in rate limiting**
- **chore: Enable specifying port in run.sh**
- **chore: Add integration test for rate limits**
