### PR TITLE
chore: Stack errors only based on message

### DIFF
--- a/internal/reporting/sentry.go
+++ b/internal/reporting/sentry.go
@@ -42,7 +42,7 @@ func Report(ctx context.Context, err error, extras ...map[string]string) {
 			err = errors.New("No error provided")
 		}
 
-		scope.SetFingerprint([]string{"{{ default }}", sanitizeError(err.Error())})
+		scope.SetFingerprint([]string{sanitizeError(err.Error())})
 		hub.CaptureException(err)
 	})
 }


### PR DESCRIPTION
Sentry's {{ default }} includes, among other things, stack trace, which
can change between versions of flashlight due to structural changes in
the cloud function host.
