### PR TITLE
fix: Don't clobber the logger in the context

### DIFF
--- a/internal/logging/middleware.go
+++ b/internal/logging/middleware.go
@@ -7,10 +7,10 @@ import (
 	"os"
 )
 
-var requestLoggerContextKey = struct{}{}
+type requestLoggerContextKey struct{}
 
 func FromContext(ctx context.Context) *slog.Logger {
-	logger, ok := ctx.Value(requestLoggerContextKey).(*slog.Logger)
+	logger, ok := ctx.Value(requestLoggerContextKey{}).(*slog.Logger)
 	if !ok || logger == nil {
 		fallback := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 		fallback = fallback.With(slog.String("logger", "fallback"))
@@ -43,7 +43,7 @@ func NewRequestLoggerMiddleware(logger *slog.Logger) func(next http.HandlerFunc)
 				slog.String("userAgent", userAgent),
 			)
 
-			next(w, r.WithContext(context.WithValue(r.Context(), requestLoggerContextKey, requestLogger)))
+			next(w, r.WithContext(context.WithValue(r.Context(), requestLoggerContextKey{}, requestLogger)))
 		}
 	}
 }

--- a/internal/reporting/sentry.go
+++ b/internal/reporting/sentry.go
@@ -12,7 +12,7 @@ import (
 	sentryhttp "github.com/getsentry/sentry-go/http"
 )
 
-var startedAtContextKey = struct{}{}
+type startedAtContextKey struct{}
 
 var uuidRx = regexp.MustCompile(`[0-9a-f]{8}-?([0-9a-f]{4}-?){3}[0-9a-f]{12}`)
 var hostRx = regexp.MustCompile(`\[:{0,2}([0-9a-f]{0,4}:?){1,8}\]:\d+`)
@@ -41,7 +41,7 @@ func Report(ctx context.Context, err error, extras ...map[string]string) {
 			}
 		}
 
-		startedAt, ok := ctx.Value(startedAtContextKey).(time.Time)
+		startedAt, ok := ctx.Value(startedAtContextKey{}).(time.Time)
 		if ok {
 			scope.SetExtra("secondsSinceStart", time.Since(startedAt).Seconds())
 		}
@@ -79,7 +79,7 @@ func addTagsMiddleware(next http.HandlerFunc) http.HandlerFunc {
 			}
 		})
 
-		ctxWithStartedAt := context.WithValue(r.Context(), startedAtContextKey, time.Now())
+		ctxWithStartedAt := context.WithValue(r.Context(), startedAtContextKey{}, time.Now())
 		next(w, r.WithContext(ctxWithStartedAt))
 	}
 }


### PR DESCRIPTION
The logger and the "startedAt" timestamp accidentally used the same
context key `struct{}{}`. This is fixed by creating two unique types
with type definitions and using instances of them as context keys.
