### PR TITLE
fix: Don't return duplicate stats from history endpoint

### DIFF
--- a/internal/storage/persistor.go
+++ b/internal/storage/persistor.go
@@ -342,7 +342,8 @@ func (p *PostgresStatsPersistor) GetHistory(ctx context.Context, playerUUID stri
 	if len(stats) > 1 {
 		return nil, fmt.Errorf("GetHistory: expected at most one result, got %d", len(stats))
 	}
-	if len(stats) == 1 {
+	if len(stats) == 1 && (len(dbStats) == 0 || dbStats[len(dbStats)-1].ID != stats[0].ID) {
+		// We got stats, and they were not the same as the first one in this last interval
 		dbStats = append(dbStats, stats[0])
 	}
 


### PR DESCRIPTION
Our history algorithm divides the timespan into `limit - 1` interval,
and then gets the first stats instance in each of those intervals.
To also have the latest available data, we add the last stats instance
from the last interval. If there was only a single stats instance in the
entire last interval, this would get returned twice. This is now fixed
:^)

- **chore: Enable parallel tests for GetHistory**
- **fix: Don't return duplicate stats from history endpoint**
