### PR TITLE
errors

### DIFF
--- a/internal/adapters/playerprovider/hypixel_api.go
+++ b/internal/adapters/playerprovider/hypixel_api.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/Amund211/flashlight/internal/config"
 	"github.com/Amund211/flashlight/internal/constants"
-	e "github.com/Amund211/flashlight/internal/errors"
 	"github.com/Amund211/flashlight/internal/logging"
 )
 
@@ -39,7 +38,7 @@ func (hypixelAPI hypixelAPIImpl) GetPlayerData(ctx context.Context, uuid string)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		logger.Error("Failed to create request", "error", err)
-		return []byte{}, -1, time.Time{}, fmt.Errorf("%w: %w", e.APIServerError, err)
+		return []byte{}, -1, time.Time{}, fmt.Errorf("failed to create request: %w", err)
 	}
 
 	req.Header.Set("User-Agent", constants.USER_AGENT)
@@ -48,7 +47,7 @@ func (hypixelAPI hypixelAPIImpl) GetPlayerData(ctx context.Context, uuid string)
 	resp, err := hypixelAPI.httpClient.Do(req)
 	if err != nil {
 		logger.Error("Failed to send request", "error", err)
-		return []byte{}, -1, time.Time{}, fmt.Errorf("%w: %w", e.APIServerError, err)
+		return []byte{}, -1, time.Time{}, fmt.Errorf("failed to send request: %w", err)
 	}
 
 	queriedAt := time.Now()
@@ -57,7 +56,7 @@ func (hypixelAPI hypixelAPIImpl) GetPlayerData(ctx context.Context, uuid string)
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		logger.Error("Failed to read response body", "error", err)
-		return []byte{}, -1, time.Time{}, fmt.Errorf("%w: %w", e.APIServerError, err)
+		return []byte{}, -1, time.Time{}, fmt.Errorf("failed to read response body: %w", err)
 	}
 
 	return data, resp.StatusCode, queriedAt, nil

--- a/internal/adapters/playerprovider/hypixel_api_test.go
+++ b/internal/adapters/playerprovider/hypixel_api_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	e "github.com/Amund211/flashlight/internal/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -89,8 +88,6 @@ func TestGetPlayerData(t *testing.T) {
 		hypixelAPI := NewHypixelAPI(httpClient, apiKey)
 
 		_, _, _, err := hypixelAPI.GetPlayerData(context.Background(), "uuid123456")
-
-		assert.ErrorIs(t, err, e.APIServerError)
 		assert.ErrorIs(t, err, assert.AnError)
 	})
 
@@ -107,8 +104,6 @@ func TestGetPlayerData(t *testing.T) {
 		hypixelAPI := NewHypixelAPI(httpClient, apiKey)
 
 		_, _, _, err := hypixelAPI.GetPlayerData(context.Background(), "uuid")
-
-		assert.ErrorIs(t, err, e.APIServerError)
 		assert.ErrorIs(t, err, assert.AnError)
 	})
 }

--- a/internal/adapters/playerprovider/interface.go
+++ b/internal/adapters/playerprovider/interface.go
@@ -7,5 +7,8 @@ import (
 )
 
 type PlayerProvider interface {
+	// Raises domain.ErrPlayerNotFound if no player data is found for the given UUID
+	//
+	// Raises domain.ErrTemporarilyUnavailable if the provider implementation receives an error believed to be intermittent. The call may be retried later.
 	GetPlayer(ctx context.Context, uuid string) (*domain.PlayerPIT, error)
 }

--- a/internal/app/get_and_persist_test.go
+++ b/internal/app/get_and_persist_test.go
@@ -2,17 +2,16 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/Amund211/flashlight/internal/adapters/cache"
 	"github.com/Amund211/flashlight/internal/adapters/playerrepository"
 	"github.com/Amund211/flashlight/internal/domain"
-	e "github.com/Amund211/flashlight/internal/errors"
 	"github.com/stretchr/testify/require"
 )
 
-const UUID = "01234567-89AB---CDEF-0123-456789abcdef"
-const NORMALIZED_UUID = "01234567-89ab-cdef-0123-456789abcdef"
+const UUID = "01234567-89ab-cdef-0123-456789abcdef"
 
 type panicPlayerProvider struct {
 	t *testing.T
@@ -33,7 +32,7 @@ type mockedPlayerProvider struct {
 func (m *mockedPlayerProvider) GetPlayer(ctx context.Context, uuid string) (*domain.PlayerPIT, error) {
 	m.t.Helper()
 
-	require.Equal(m.t, NORMALIZED_UUID, uuid)
+	require.Equal(m.t, UUID, uuid)
 
 	return m.player, m.err
 }
@@ -55,23 +54,6 @@ func TestGetAndPersistPlayer(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("cache keys are normalized", func(t *testing.T) {
-		// Requesting abcdef12-... and then ABCDEF12-... should only go to Hypixel once
-		provider := &mockedPlayerProvider{
-			t:      t,
-			player: &domain.PlayerPIT{UUID: UUID, Experience: 500, Overall: domain.GamemodeStatsPIT{FinalKills: 0}},
-			err:    nil,
-		}
-		panicProvider := &panicPlayerProvider{t: t}
-		cache := cache.NewBasicCache[*domain.PlayerPIT]()
-
-		_, err := BuildGetAndPersistPlayerWithCache(cache, provider, playerrepository.NewStubPlayerRepository())(context.Background(), "01234567-89ab-cdef-0123-456789abcdef")
-		require.NoError(t, err)
-
-		_, err = BuildGetAndPersistPlayerWithCache(cache, panicProvider, playerrepository.NewStubPlayerRepository())(context.Background(), "01---23456789aBCDef0123456789aBcdef")
-		require.NoError(t, err)
-	})
-
 	t.Run("provider errors are passed through", func(t *testing.T) {
 		for _, providerErr := range []error{
 			domain.ErrPlayerNotFound,
@@ -89,22 +71,25 @@ func TestGetAndPersistPlayer(t *testing.T) {
 		}
 	})
 
-	t.Run("invalid uuid", func(t *testing.T) {
+	t.Run("invalid uuids should not be passed to get and persist with cache", func(t *testing.T) {
 		provider := &panicPlayerProvider{t: t}
 		cache := cache.NewBasicCache[*domain.PlayerPIT]()
 
-		_, err := BuildGetAndPersistPlayerWithCache(cache, provider, playerrepository.NewStubPlayerRepository())(context.Background(), "invalid")
-		require.ErrorIs(t, err, e.APIClientError)
-
-		_, err = BuildGetAndPersistPlayerWithCache(cache, provider, playerrepository.NewStubPlayerRepository())(context.Background(), "01234567-89ab-xxxx-0123-456789abcdef")
-		require.ErrorIs(t, err, e.APIClientError)
-	})
-
-	t.Run("missing uuid", func(t *testing.T) {
-		provider := &panicPlayerProvider{t: t}
-		cache := cache.NewBasicCache[*domain.PlayerPIT]()
-
-		_, err := BuildGetAndPersistPlayerWithCache(cache, provider, playerrepository.NewStubPlayerRepository())(context.Background(), "")
-		require.ErrorIs(t, err, e.APIClientError)
+		for _, uuid := range []string{
+			"",
+			"invalid",
+			"01234567-89ab-xxxx-0123-456789abcdef",
+			"01234567-89ab-cdef-0123-456789abcde",
+			"01234567-89ab-cdef-0123-456789abcdefg",
+			"01234567-89ab-cdef-0123-456789abcdefg",
+			"01234567-89ab-cdef-0123-456789abcdefg1234",
+			"01---23456789aBCDef0123456789aBcdef",
+		} {
+			t.Run(fmt.Sprintf("UUID: '%s'", uuid), func(t *testing.T) {
+				t.Parallel()
+				_, err := BuildGetAndPersistPlayerWithCache(cache, provider, playerrepository.NewStubPlayerRepository())(context.Background(), uuid)
+				require.Error(t, err)
+			})
+		}
 	})
 }

--- a/internal/app/get_and_persist_test.go
+++ b/internal/app/get_and_persist_test.go
@@ -20,7 +20,7 @@ type panicPlayerProvider struct {
 func (p *panicPlayerProvider) GetPlayer(ctx context.Context, uuid string) (*domain.PlayerPIT, error) {
 	p.t.Helper()
 	p.t.Fatal("should not be called")
-	panic("unreachable")
+	return nil, nil
 }
 
 type mockedPlayerProvider struct {

--- a/internal/app/history.go
+++ b/internal/app/history.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/Amund211/flashlight/internal/adapters/playerrepository"
 	"github.com/Amund211/flashlight/internal/domain"
-	e "github.com/Amund211/flashlight/internal/errors"
 	"github.com/Amund211/flashlight/internal/logging"
 	"github.com/Amund211/flashlight/internal/reporting"
 	"github.com/Amund211/flashlight/internal/strutils"
@@ -34,7 +33,7 @@ func BuildGetHistory(
 		logger := logging.FromContext(ctx)
 
 		if !strutils.UUIDIsNormalized(uuid) {
-			return nil, fmt.Errorf("%w: UUID is not normalized", e.APIServerError)
+			return nil, fmt.Errorf("UUID is not normalized")
 		}
 
 		now := nowFunc()

--- a/internal/app/history.go
+++ b/internal/app/history.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -40,7 +41,7 @@ func BuildGetHistory(
 		if start.Before(now) && end.After(now) {
 			// This is a current interval -> update the repo with the latest data
 			_, err := getAndPersistPlayerWithCache(ctx, uuid)
-			if err != nil {
+			if err != nil && !errors.Is(err, domain.ErrPlayerNotFound) {
 				logger.Error("Failed to get player data", "error", err)
 				reporting.Report(ctx, err)
 			}

--- a/internal/app/history_test.go
+++ b/internal/app/history_test.go
@@ -194,8 +194,7 @@ func TestBuildGetHistory(t *testing.T) {
 						t.Parallel()
 
 						getAndPersistPlayerWithCache := func(ctx context.Context, uuid string) (*domain.PlayerPIT, error) {
-							t.Log("should not call getAndPersistPlayerWithCache when now is outside range")
-							t.FailNow()
+							t.Fatal("should not call getAndPersistPlayerWithCache when now is outside range")
 							return nil, nil
 						}
 

--- a/internal/app/sessions.go
+++ b/internal/app/sessions.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/Amund211/flashlight/internal/adapters/playerrepository"
 	"github.com/Amund211/flashlight/internal/domain"
-	e "github.com/Amund211/flashlight/internal/errors"
 	"github.com/Amund211/flashlight/internal/logging"
 	"github.com/Amund211/flashlight/internal/reporting"
 	"github.com/Amund211/flashlight/internal/strutils"
@@ -32,7 +31,7 @@ func BuildGetSessions(
 		logger := logging.FromContext(ctx)
 
 		if !strutils.UUIDIsNormalized(uuid) {
-			return nil, fmt.Errorf("%w: UUID is not normalized", e.APIServerError)
+			return nil, fmt.Errorf("UUID is not normalized")
 		}
 
 		now := nowFunc()

--- a/internal/app/sessions.go
+++ b/internal/app/sessions.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -38,7 +39,7 @@ func BuildGetSessions(
 		if start.Before(now) && end.After(now) {
 			// This is a current interval -> update the repo with the latest data
 			_, err := getAndPersistPlayerWithCache(ctx, uuid)
-			if err != nil {
+			if err != nil && !errors.Is(err, domain.ErrPlayerNotFound) {
 				logger.Error("Failed to get player data", "error", err)
 				reporting.Report(ctx, err)
 			}

--- a/internal/app/sessions_test.go
+++ b/internal/app/sessions_test.go
@@ -200,8 +200,7 @@ func TestBuildGetSessions(t *testing.T) {
 						t.Parallel()
 
 						getAndPersistPlayerWithCache := func(ctx context.Context, uuid string) (*domain.PlayerPIT, error) {
-							t.Log("should not call getAndPersistPlayerWithCache when now is outside range")
-							t.FailNow()
+							t.Fatal("should not call getAndPersistPlayerWithCache when now is outside range")
 							return nil, nil
 						}
 

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -1,0 +1,8 @@
+package domain
+
+import "errors"
+
+var (
+	ErrPlayerNotFound         = errors.New("player not found")
+	ErrTemporarilyUnavailable = errors.New("temporarily unavailable")
+)

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -3,8 +3,6 @@ package errors
 import "errors"
 
 var (
-	RetriableError         = errors.New("(retriable)")
-	APIServerError         = errors.New("Server error")
-	APIClientError         = errors.New("Client error")
-	RatelimitExceededError = errors.New("Ratelimit exceeded")
+	APIServerError = errors.New("Server error")
+	APIClientError = errors.New("Client error")
 )

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,7 +1,0 @@
-package errors
-
-import "errors"
-
-var (
-	APIClientError = errors.New("Client error")
-)

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -3,6 +3,5 @@ package errors
 import "errors"
 
 var (
-	APIServerError = errors.New("Server error")
 	APIClientError = errors.New("Client error")
 )

--- a/internal/ports/player_data.go
+++ b/internal/ports/player_data.go
@@ -68,7 +68,7 @@ func MakeGetPlayerDataHandler(
 			hypixelAPIResponseData, err := PlayerToPrismPlayerDataResponseData(nil)
 			if err != nil {
 				logger.Error("Failed to convert player to hypixel API response", "error", err)
-				err = fmt.Errorf("%w: failed to convert player to hypixel API response: %w", e.APIServerError, err)
+				err = fmt.Errorf("failed to convert player to hypixel API response: %w", err)
 				reporting.Report(ctx, err)
 				statusCode := writeHypixelStyleErrorResponse(r.Context(), w, err)
 				logger.Info("Returning response", "statusCode", statusCode, "reason", "error")
@@ -94,7 +94,7 @@ func MakeGetPlayerDataHandler(
 		if err != nil {
 			logger.Error("Failed to convert player to hypixel API response", "error", err)
 
-			err = fmt.Errorf("%w: failed to convert player to hypixel API response: %w", e.APIServerError, err)
+			err = fmt.Errorf("failed to convert player to hypixel API response: %w", err)
 			reporting.Report(ctx, err)
 
 			statusCode := writeHypixelStyleErrorResponse(r.Context(), w, err)


### PR DESCRIPTION
Remove old-style global errors from player provider through the app
layer to the player data port.
