### PR TITLE
fix: Keep same log key for user id

### DIFF
--- a/internal/ports/player_data.go
+++ b/internal/ports/player_data.go
@@ -69,7 +69,7 @@ func MakeGetPlayerDataHandler(
 			userID = "<missing>"
 		}
 		ctx = logging.AddMetaToContext(ctx,
-			slog.String("userID", userID),
+			slog.String("userId", userID),
 			slog.String("uuid", rawUUID),
 		)
 		logger := logging.FromContext(ctx)


### PR DESCRIPTION
We use this key in log-based metrics for now, so
611f554c69a51f154996021d9dcbad692cdb2203 broke that. Reverting the
change here to fix it again.
