### PR TITLE
chore: Factor out update player in interval

### DIFF
--- a/internal/app/history_test.go
+++ b/internal/app/history_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Amund211/flashlight/internal/adapters/playerrepository"
 	"github.com/Amund211/flashlight/internal/app"
 	"github.com/Amund211/flashlight/internal/domain"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,10 +48,6 @@ func TestBuildGetHistory(t *testing.T) {
 	t.Parallel()
 
 	now := time.Now()
-
-	nowFunc := func() time.Time {
-		return now
-	}
 
 	t.Run("now within range", func(t *testing.T) {
 		t.Parallel()
@@ -115,15 +112,26 @@ func TestBuildGetHistory(t *testing.T) {
 					t.Run(historyCase.name, func(t *testing.T) {
 						t.Parallel()
 
+						updatePlayerInIntervalCalled := false
+						updatePlayerInInterval := func(ctx context.Context, updateUUID string, start, end time.Time) error {
+							t.Helper()
+							require.Equal(t, uuid, updateUUID)
+							require.WithinDuration(t, timeCase.start, start, 0)
+							require.WithinDuration(t, timeCase.end, end, 0)
+							updatePlayerInIntervalCalled = true
+							return nil
+						}
+
 						getHistory := app.BuildGetHistory(
 							newMockHistoryRepository(t, historyCase.history, nil),
-							newGetAndPersistPlayerWithCacheForHistory(nil),
-							nowFunc,
+							updatePlayerInInterval,
 						)
 
 						history, err := getHistory(context.Background(), uuid, timeCase.start, timeCase.end, 10)
 						require.NoError(t, err)
 						require.Equal(t, historyCase.history, history)
+
+						require.True(t, updatePlayerInIntervalCalled)
 					})
 				}
 			})
@@ -193,23 +201,72 @@ func TestBuildGetHistory(t *testing.T) {
 					t.Run(historyCase.name, func(t *testing.T) {
 						t.Parallel()
 
-						getAndPersistPlayerWithCache := func(ctx context.Context, uuid string) (*domain.PlayerPIT, error) {
-							t.Fatal("should not call getAndPersistPlayerWithCache when now is outside range")
-							return nil, nil
+						updatePlayerInIntervalCalled := false
+						updatePlayerInInterval := func(ctx context.Context, updateUUID string, start, end time.Time) error {
+							t.Helper()
+							require.Equal(t, uuid, updateUUID)
+							require.WithinDuration(t, timeCase.start, start, 0)
+							require.WithinDuration(t, timeCase.end, end, 0)
+							updatePlayerInIntervalCalled = true
+							return nil
 						}
 
 						getHistory := app.BuildGetHistory(
 							newMockHistoryRepository(t, historyCase.history, nil),
-							getAndPersistPlayerWithCache,
-							nowFunc,
+							updatePlayerInInterval,
 						)
 
 						history, err := getHistory(context.Background(), uuid, timeCase.start, timeCase.end, 10)
 						require.NoError(t, err)
 						require.Equal(t, historyCase.history, history)
+
+						require.True(t, updatePlayerInIntervalCalled)
 					})
 				}
 			})
 		}
+	})
+
+	t.Run("update player in interval fails", func(t *testing.T) {
+		t.Parallel()
+
+		uuid := "12345678-1234-1234-1234-123456789012"
+
+		start := time.Date(2024, time.March, 1, 0, 0, 0, 0, time.UTC)
+		end := time.Date(2024, time.March, 31, 23, 59, 59, 999_999_999, time.UTC)
+
+		expectedHistory := []domain.PlayerPIT{
+			// NOTE: Stub players
+			{
+				UUID:       uuid,
+				Experience: 500,
+			},
+			{
+				UUID:       uuid,
+				Experience: 501,
+			},
+		}
+
+		updatePlayerInIntervalCalled := false
+		updatePlayerInInterval := func(ctx context.Context, updateUUID string, updateStart, updateEnd time.Time) error {
+			t.Helper()
+			require.Equal(t, uuid, updateUUID)
+			require.WithinDuration(t, start, updateStart, 0)
+			require.WithinDuration(t, end, updateEnd, 0)
+			updatePlayerInIntervalCalled = true
+			return assert.AnError
+		}
+
+		getHistory := app.BuildGetHistory(
+			newMockHistoryRepository(t, expectedHistory, nil),
+			updatePlayerInInterval,
+		)
+
+		history, err := getHistory(context.Background(), uuid, start, end, 10)
+		// Should not error even if updatePlayerInInterval fails
+		require.NoError(t, err)
+		require.Equal(t, expectedHistory, history)
+
+		require.True(t, updatePlayerInIntervalCalled)
 	})
 }

--- a/internal/app/sessions.go
+++ b/internal/app/sessions.go
@@ -20,8 +20,7 @@ type GetSessions = func(
 
 func BuildGetSessions(
 	repo playerrepository.PlayerRepository,
-	getAndPersistPlayerWithCache GetAndPersistPlayerWithCache,
-	nowFunc func() time.Time,
+	updatePlayerInInterval UpdatePlayerInInterval,
 ) GetSessions {
 	return func(ctx context.Context,
 		uuid string,
@@ -35,17 +34,13 @@ func BuildGetSessions(
 			return nil, err
 		}
 
-		now := nowFunc()
-		if start.Before(now) && end.After(now) {
-			// This is a current interval -> update the repo with the latest data
-			_, err := getAndPersistPlayerWithCache(ctx, uuid)
-			if err != nil {
-				// NOTE: GetAndPersistPlayerWithCache implementations handle their own error reporting
-				logger.Error("Failed to get updated player data", "error", err)
+		err := updatePlayerInInterval(ctx, uuid, start, end)
+		if err != nil {
+			// NOTE: UpdatePlayerInInterval implementations handle their own error reporting
+			logger.Error("Failed to update player data in interval", "error", err)
 
-				// NOTE: We continue even though we failed to get updated player data
-				// We may still be able to get the history and fulfill the request
-			}
+			// NOTE: We continue even though we failed to update player data
+			// We may still be able to get the history and fulfill the request
 		}
 
 		sessions, err := repo.GetSessions(ctx, uuid, start, end)

--- a/internal/ports/history.go
+++ b/internal/ports/history.go
@@ -117,6 +117,12 @@ func MakeGetHistoryHandler(
 			slog.Int("limit", request.Limit),
 		)
 
+		if request.Start.After(request.End) {
+			reporting.Report(ctx, fmt.Errorf("start time is after end time"))
+			http.Error(w, "Start time cannot be after end time", http.StatusBadRequest)
+			return
+		}
+
 		history, err := getHistory(ctx, uuid, request.Start, request.End, request.Limit)
 		if err != nil {
 			// NOTE: GetHistory implementations handle their own error reporting

--- a/internal/ports/history_test.go
+++ b/internal/ports/history_test.go
@@ -1,0 +1,149 @@
+package ports_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Amund211/flashlight/internal/app"
+	"github.com/Amund211/flashlight/internal/domain"
+	"github.com/Amund211/flashlight/internal/ports"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeGetHistoryHandler(t *testing.T) {
+	allowedOrigins, err := ports.NewDomainSuffixes("example.com", "test.com")
+	require.NoError(t, err)
+
+	testLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	noopMiddleware := func(h http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			h(w, r)
+		}
+	}
+
+	makeGetHistory := func(t *testing.T, expectedUUID string, expectedStart, expectedEnd time.Time, expectedLimit int, history []domain.PlayerPIT, err error) (app.GetHistory, *bool) {
+		called := false
+		return func(ctx context.Context, uuid string, start, end time.Time, limit int) ([]domain.PlayerPIT, error) {
+			t.Helper()
+			require.Equal(t, expectedUUID, uuid)
+			require.Equal(t, expectedStart, start)
+			require.Equal(t, expectedEnd, end)
+			require.Equal(t, expectedLimit, limit)
+
+			called = true
+
+			return history, err
+		}, &called
+	}
+
+	makeGetHistoryHandler := func(getHistory app.GetHistory) http.HandlerFunc {
+		return ports.MakeGetHistoryHandler(
+			getHistory,
+			allowedOrigins,
+			testLogger,
+			noopMiddleware,
+		)
+	}
+
+	uuid := "01234567-89ab-cdef-0123-456789abcdef"
+	start := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+	startStr := "2023-01-01T00:00:00Z"
+	end := time.Date(2023, 1, 31, 23, 59, 59, 999999999, time.UTC)
+	endStr := "2023-01-31T23:59:59.999999999Z"
+	limit := 100
+	history := []domain.PlayerPIT{
+		{UUID: uuid, Experience: 500, Overall: domain.GamemodeStatsPIT{FinalKills: 10}},
+	}
+	historyJSON, err := ports.HistoryToRainbowHistoryData(history)
+	require.NoError(t, err)
+
+	makeRequest := func(
+		uuid string,
+		startStr, endStr string,
+		limit int,
+	) *http.Request {
+		body := io.NopCloser(
+			strings.NewReader(
+				fmt.Sprintf(
+					`{"uuid":"%s","start":"%s","end":"%s","limit":%d}`,
+					uuid,
+					startStr,
+					endStr,
+					limit,
+				),
+			),
+		)
+		return httptest.NewRequest("GET", "/history", body)
+
+	}
+
+	t.Run("successful history retrieval", func(t *testing.T) {
+		getHistoryFunc, called := makeGetHistory(t, uuid, start, end, limit, history, nil)
+		handler := makeGetHistoryHandler(getHistoryFunc)
+
+		req := makeRequest(uuid, startStr, endStr, limit)
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		require.NoError(t, err)
+		require.JSONEq(t, string(historyJSON), w.Body.String())
+		require.True(t, *called)
+	})
+
+	t.Run("start time == end time", func(t *testing.T) {
+		start := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+		startStr := "2023-01-01T00:00:00Z"
+		end := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+		endStr := "2023-01-01T00:00:00Z"
+
+		getHistoryFunc, called := makeGetHistory(t, uuid, start, end, limit, history, nil)
+		handler := makeGetHistoryHandler(getHistoryFunc)
+
+		req := makeRequest(uuid, startStr, endStr, limit)
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		require.NoError(t, err)
+		require.JSONEq(t, string(historyJSON), w.Body.String())
+		require.True(t, *called)
+	})
+
+	t.Run("invalid UUID format", func(t *testing.T) {
+		getHistoryFunc, called := makeGetHistory(t, uuid, start, end, limit, history, nil)
+		handler := makeGetHistoryHandler(getHistoryFunc)
+
+		req := makeRequest("invalid-uuid", startStr, endStr, limit)
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.Contains(t, w.Body.String(), "invalid uuid")
+		require.False(t, *called)
+	})
+
+	t.Run("start time after end time", func(t *testing.T) {
+		getHistoryFunc, called := makeGetHistory(t, uuid, start, end, limit, history, nil)
+		handler := makeGetHistoryHandler(getHistoryFunc)
+
+		req := makeRequest(uuid, "2023-01-01T00:00:00.000000001Z", "2023-01-01T00:00:00.000000000Z", limit)
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.Contains(t, w.Body.String(), "Start time cannot be after end time")
+		require.False(t, *called)
+	})
+}

--- a/internal/ports/sessions.go
+++ b/internal/ports/sessions.go
@@ -112,6 +112,12 @@ func MakeGetSessionsHandler(
 			slog.String("end", request.End.Format(time.RFC3339)),
 		)
 
+		if request.Start.After(request.End) {
+			reporting.Report(ctx, fmt.Errorf("start time is after end time"))
+			http.Error(w, "Start time cannot be after end time", http.StatusBadRequest)
+			return
+		}
+
 		sessions, err := getSessions(ctx, uuid, request.Start, request.End)
 		if err != nil {
 			// NOTE: GetSessions implementations handle their own error reporting

--- a/internal/ports/sessions_test.go
+++ b/internal/ports/sessions_test.go
@@ -1,0 +1,149 @@
+package ports_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Amund211/flashlight/internal/app"
+	"github.com/Amund211/flashlight/internal/domain"
+	"github.com/Amund211/flashlight/internal/ports"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeGetSessionsHandler(t *testing.T) {
+	allowedOrigins, err := ports.NewDomainSuffixes("example.com", "test.com")
+	require.NoError(t, err)
+
+	testLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	noopMiddleware := func(h http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			h(w, r)
+		}
+	}
+
+	makeGetSessions := func(t *testing.T, expectedUUID string, expectedStart, expectedEnd time.Time, sessions []domain.Session, err error) (app.GetSessions, *bool) {
+		called := false
+		return func(ctx context.Context, uuid string, start, end time.Time) ([]domain.Session, error) {
+			t.Helper()
+			require.Equal(t, expectedUUID, uuid)
+			require.Equal(t, expectedStart, start)
+			require.Equal(t, expectedEnd, end)
+
+			called = true
+
+			return sessions, err
+		}, &called
+	}
+
+	makeGetSessionsHandler := func(getSessions app.GetSessions) http.HandlerFunc {
+		return ports.MakeGetSessionsHandler(
+			getSessions,
+			allowedOrigins,
+			testLogger,
+			noopMiddleware,
+		)
+	}
+
+	uuid := "01234567-89ab-cdef-0123-456789abcdef"
+	start := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+	startStr := "2023-01-01T00:00:00Z"
+	end := time.Date(2023, 1, 31, 23, 59, 59, 999999999, time.UTC)
+	endStr := "2023-01-31T23:59:59.999999999Z"
+	sessions := []domain.Session{
+		{
+			Start:       domain.PlayerPIT{UUID: uuid, Experience: 500, Overall: domain.GamemodeStatsPIT{FinalKills: 10}},
+			End:         domain.PlayerPIT{UUID: uuid, Experience: 1000, Overall: domain.GamemodeStatsPIT{FinalKills: 11}},
+			Consecutive: true,
+		},
+	}
+	sessionsJSON, err := ports.SessionsToRainbowSessionsData(sessions)
+	require.NoError(t, err)
+
+	makeRequest := func(
+		uuid string,
+		startStr, endStr string,
+	) *http.Request {
+		body := io.NopCloser(
+			strings.NewReader(
+				fmt.Sprintf(
+					`{"uuid":"%s","start":"%s","end":"%s"}`,
+					uuid,
+					startStr,
+					endStr,
+				),
+			),
+		)
+		return httptest.NewRequest("GET", "/sessions", body)
+
+	}
+
+	t.Run("successful sessions retrieval", func(t *testing.T) {
+		getSessionsFunc, called := makeGetSessions(t, uuid, start, end, sessions, nil)
+		handler := makeGetSessionsHandler(getSessionsFunc)
+
+		req := makeRequest(uuid, startStr, endStr)
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		require.NoError(t, err)
+		require.JSONEq(t, string(sessionsJSON), w.Body.String())
+		require.True(t, *called)
+	})
+
+	t.Run("start time == end time", func(t *testing.T) {
+		start := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+		startStr := "2023-01-01T00:00:00Z"
+		end := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+		endStr := "2023-01-01T00:00:00Z"
+
+		getSessionsFunc, called := makeGetSessions(t, uuid, start, end, sessions, nil)
+		handler := makeGetSessionsHandler(getSessionsFunc)
+
+		req := makeRequest(uuid, startStr, endStr)
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		require.NoError(t, err)
+		require.JSONEq(t, string(sessionsJSON), w.Body.String())
+		require.True(t, *called)
+	})
+
+	t.Run("invalid UUID format", func(t *testing.T) {
+		getSessionsFunc, called := makeGetSessions(t, uuid, start, end, sessions, nil)
+		handler := makeGetSessionsHandler(getSessionsFunc)
+
+		req := makeRequest("invalid-uuid", startStr, endStr)
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.Contains(t, w.Body.String(), "invalid uuid")
+		require.False(t, *called)
+	})
+
+	t.Run("start time after end time", func(t *testing.T) {
+		getSessionsFunc, called := makeGetSessions(t, uuid, start, end, sessions, nil)
+		handler := makeGetSessionsHandler(getSessionsFunc)
+
+		req := makeRequest(uuid, "2023-01-01T00:00:00.000000001Z", "2023-01-01T00:00:00.000000000Z")
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.Contains(t, w.Body.String(), "Start time cannot be after end time")
+		require.False(t, *called)
+	})
+}

--- a/main.go
+++ b/main.go
@@ -70,10 +70,11 @@ func main() {
 	}
 
 	getAndPersistPlayerWithCache := app.BuildGetAndPersistPlayerWithCache(playerCache, provider, repo)
+	updatePlayerInInterval := app.BuildUpdatePlayerInInterval(getAndPersistPlayerWithCache, time.Now)
 
-	getHistory := app.BuildGetHistory(repo, getAndPersistPlayerWithCache, time.Now)
+	getHistory := app.BuildGetHistory(repo, updatePlayerInInterval)
 
-	getSessions := app.BuildGetSessions(repo, getAndPersistPlayerWithCache, time.Now)
+	getSessions := app.BuildGetSessions(repo, updatePlayerInInterval)
 
 	http.HandleFunc(
 		"GET /v1/playerdata",


### PR DESCRIPTION
Several use cases want to ensure that the interval they are looking at
has the most up-to-date player data. Factor this out to a separate use
case that others can call.
