### PR TITLE
chore: Add more files to .gcloudignore

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -9,8 +9,19 @@
 .gcloudignore
 .git
 .gitignore
+
+# Repository config
+.github
+.pre-commit-config.yaml
+.rgignore
+LICENSE
+
+# Util binaries
 cmd/*
 
 # Test data
 fixtures/
 testdata/
+
+# Test code files
+*_test.go


### PR DESCRIPTION
Don't need these to build the cloud run instance, so we skip uploading
them to save on time and space :^)
