### PR TITLE
fix: Return CORS headers from /v1/uuid

### DIFF
--- a/internal/ports/get_uuid.go
+++ b/internal/ports/get_uuid.go
@@ -24,6 +24,7 @@ type response struct {
 
 func MakeGetUUIDHandler(
 	getUUID app.GetUUID,
+	allowedOrigins *DomainSuffixes,
 	rootLogger *slog.Logger,
 	sentryMiddleware func(http.HandlerFunc) http.HandlerFunc,
 ) http.HandlerFunc {
@@ -55,6 +56,7 @@ func MakeGetUUIDHandler(
 		logging.NewRequestLoggerMiddleware(rootLogger),
 		sentryMiddleware,
 		reporting.NewAddMetaMiddleware("getuuid"),
+		BuildCORSMiddleware(allowedOrigins),
 		NewRateLimitMiddleware(ipRateLimiter, makeOnLimitExceeded(ipRateLimiter)),
 		NewRateLimitMiddleware(userIDRateLimiter, makeOnLimitExceeded(userIDRateLimiter)),
 	)

--- a/main.go
+++ b/main.go
@@ -108,9 +108,14 @@ func main() {
 	)
 
 	http.HandleFunc(
+		"OPTIONS /v1/uuid/{username}",
+		ports.BuildCORSHandler(allowedOrigins),
+	)
+	http.HandleFunc(
 		"GET /v1/uuid/{username}",
 		ports.MakeGetUUIDHandler(
 			getUUID,
+			allowedOrigins,
 			logger.With("port", "getuuid"),
 			sentryMiddleware,
 		),


### PR DESCRIPTION
Plan to use this in rainbow, so it needs to support CORS like
/v1/history and /v1/sessions do.

Add a CORS middleware to the handler so it returns the
`Access-Control-Allow-Origin` header, and also add a handler for the
`OPTIONS` verb which additionally returns the `...-Methods` and
`...-Headers` headers :^)
