### PR TITLE
chore: Remove old uuid endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -121,21 +121,6 @@ func main() {
 		),
 	)
 
-	// TODO: remove this when clients use the accounts endpoint
-	http.HandleFunc(
-		"OPTIONS /v1/uuid/{username}",
-		ports.BuildCORSHandler(allowedOrigins),
-	)
-	http.HandleFunc(
-		"GET /v1/uuid/{username}",
-		ports.MakeGetAccountByUsernameHandler(
-			getAccountByUsernameWithCache,
-			allowedOrigins,
-			logger.With("port", "getuuid"),
-			sentryMiddleware,
-		),
-	)
-
 	http.HandleFunc(
 		"OPTIONS /v1/history",
 		ports.BuildCORSHandler(allowedOrigins),


### PR DESCRIPTION
Only used by rainbow, which recently moved to the new account endpoint.
