### PR TITLE
chore: Gitignore `main`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ gha-creds-*.json
 
 # Binary outputs
 /flashlight
+/main


### PR DESCRIPTION
Can be produced by running go build on a cmd from the root dir e.g.
`go build ./cmd/get-stats/main.go`. The copilot coding agent did this.
