### PR TITLE
chore: Replace minecraftservices endpoints with mojang endpoints

### DIFF
--- a/internal/adapters/accountprovider/mojang.go
+++ b/internal/adapters/accountprovider/mojang.go
@@ -33,11 +33,11 @@ func NewMojang(httpClient HttpClient, nowFunc func() time.Time) *Mojang {
 }
 
 func (m *Mojang) GetAccountByUUID(ctx context.Context, uuid string) (domain.Account, error) {
-	return m.getProfile(ctx, fmt.Sprintf("https://api.minecraftservices.com/minecraft/profile/lookup/%s", uuid))
+	return m.getProfile(ctx, fmt.Sprintf("https://api.mojang.com/user/profile/%s", uuid))
 }
 
 func (m *Mojang) GetAccountByUsername(ctx context.Context, username string) (domain.Account, error) {
-	return m.getProfile(ctx, fmt.Sprintf("https://api.minecraftservices.com/minecraft/profile/lookup/name/%s", username))
+	return m.getProfile(ctx, fmt.Sprintf("https://api.mojang.com/users/profiles/minecraft/%s", username))
 }
 
 func (m *Mojang) getProfile(ctx context.Context, url string) (domain.Account, error) {


### PR DESCRIPTION
These endpoints have been returning a lot of strange 429s. Switching
back to the username -> uuid endpoint that prism has been using. Also
switching to a uuid -> username endpoint from api.mojang.com as well due
to the same issues.

Hopefully this will resolve the issues. The reason for the switch was
some strange 403s from the mojang API, but those seem to have been
intermittent, and not as consistent as these 429s are being.

https://bugs.mojang.com/browse/WEB/issues/WEB-7591
