### PR TITLE
chore: Add go dependency submission action

### DIFF
--- a/.github/workflows/go-dependency-submission.yaml
+++ b/.github/workflows/go-dependency-submission.yaml
@@ -1,0 +1,24 @@
+name: Go Dependency Submission
+on:
+  push:
+    branches:
+      - main
+
+# The API requires write permission on the repository to submit dependencies
+permissions:
+  contents: write
+
+jobs:
+  go-action-detection:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Submit Go dependencies to GitHub
+        uses: actions/go-dependency-submission@v2
+        with:
+          go-mod-path: 'go.mod'
+          # NOTE: Not specifying `go-build-target` to get all dependencies


### PR DESCRIPTION
Apparently, GitHub does not automatically detect all dependencies for
golang. They recommend running this action to manually submit
dependencies to GitHub to get better dependency graph insights and
dependabot updates :^)

https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/using-the-dependency-submission-api
