### PR TITLE
chore: Bump go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Amund211/flashlight
 
-go 1.24.6
+go 1.25
 
 require (
 	github.com/getsentry/sentry-go v0.35.3


### PR DESCRIPTION
Already using 1.25 in the dockerfile where we build it.
