### PR TITLE
chore: Set a limit on the sql db connection pool

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,6 +76,13 @@ func main() {
 	if err != nil {
 		fail("Failed to initialize PostgresPlayerRepository", "error", err.Error())
 	}
+	if config.IsProduction() {
+		// Current cloud sql database has a connection limit of 25, and 3 reserved for superusers
+		db.DB.SetMaxOpenConns(16)
+	} else {
+		// Fewer connections in staging to prevent interfering with prod
+		db.DB.SetMaxOpenConns(2)
+	}
 	logger.Info("Initialized database connection")
 
 	repositorySchemaName := database.GetSchemaName(!config.IsProduction())


### PR DESCRIPTION
This should prevent
```
pq: remaining connection slots are reserved for roles with privileges of the "pg_use_reserved_connections" role
```
