### PR TITLE
chore: add workflow to check golangci-lint version consistency

### DIFF
--- a/.github/workflows/check-tool-versions.yml
+++ b/.github/workflows/check-tool-versions.yml
@@ -1,0 +1,41 @@
+name: Check tool versions
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - go.mod
+      - go.sum
+      - .pre-commit-config.yaml
+      - .github/workflows/check-tool-versions.yml
+  push:
+    branches:
+      - main
+    paths:
+      - go.mod
+      - go.sum
+      - .pre-commit-config.yaml
+      - .github/workflows/check-tool-versions.yml
+
+jobs:
+  check-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Check golangci-lint version matches pre-commit config
+        run: |
+          GOMOD_VERSION=$(go tool golangci-lint --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)
+          PRECOMMIT_VERSION=$(grep -A1 'golangci/golangci-lint' .pre-commit-config.yaml | grep 'rev:' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          echo "golangci-lint version in go.mod: $GOMOD_VERSION"
+          echo "golangci-lint version in .pre-commit-config.yaml: $PRECOMMIT_VERSION"
+          if [ "$GOMOD_VERSION" != "$PRECOMMIT_VERSION" ]; then
+              echo "Error: golangci-lint versions do not match!"
+              exit 1
+          fi
+          echo "golangci-lint versions match ✓"


### PR DESCRIPTION
## Summary
- Adds a CI workflow that fails when the `golangci-lint` version in `go.mod` (resolved via the `tool` directive) drifts from the rev pinned in `.pre-commit-config.yaml`.
- Mirrors the existing `check-tool-versions` workflows in prism (black/isort/flake8) and rainbow (oxlint/oxfmt).
- Triggers on changes to `go.mod`, `go.sum`, `.pre-commit-config.yaml`, or the workflow itself.

## Test plan
- [ ] Workflow runs green on this PR (versions currently match at `2.11.4`).
- [ ] Bump only the pre-commit rev in a scratch commit and confirm the job fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)