### PR TITLE
chore(dependabot): collapse docker entries and switch daily to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,7 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
     cooldown:
       default-days: 7
     commit-message:
@@ -34,7 +34,7 @@ updates:
       - '/'
       - '/collector'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
     cooldown:
       default-days: 7
     commit-message:
@@ -44,7 +44,7 @@ updates:
   - package-ecosystem: 'gomod'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
     cooldown:
       default-days: 7
     commit-message:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,17 +30,9 @@ updates:
       include: 'scope'
 
   - package-ecosystem: 'docker'
-    directory: '/'
-    schedule:
-      interval: 'daily'
-    cooldown:
-      default-days: 7
-    commit-message:
-      prefix: 'chore'
-      include: 'scope'
-
-  - package-ecosystem: 'docker'
-    directory: '/collector'
+    directories:
+      - '/'
+      - '/collector'
     schedule:
       interval: 'daily'
     cooldown:


### PR DESCRIPTION
## Summary
- Collapse the two duplicate `docker` ecosystem entries (`/` and `/collector`) into one block using the plural `directories:` key.
- Switch `github-actions`, `docker`, and `gomod` from `daily` to `weekly` to match GitHub's recommended cadence; the existing 7-day `cooldown.default-days` makes daily runs mostly redundant anyway.

## Test plan
- [ ] Confirm Dependabot accepts the file (no validation error on next run / PR view of dependabot.yml in the GitHub UI).
- [ ] Verify the next scheduled run picks up both Dockerfiles via the consolidated entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)