### PR TITLE
chore(dependabot): split docker config so /collector skips cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,13 +30,22 @@ updates:
       include: 'scope'
 
   - package-ecosystem: 'docker'
-    directories:
-      - '/'
-      - '/collector'
+    directory: '/'
     schedule:
       interval: 'weekly'
     cooldown:
       default-days: 7
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'
+
+  - package-ecosystem: 'docker'
+    directory: '/collector'
+    schedule:
+      interval: 'weekly'
+    # cooldown is omitted: it crashes the whole docker job when a candidate
+    # tag points to a multi-arch image index (404 on the blob HEAD during
+    # apply_cooldown). See dependabot/dependabot-core#14044.
     commit-message:
       prefix: 'chore'
       include: 'scope'


### PR DESCRIPTION
## Summary
- Splits the `docker` ecosystem block back into two entries (one per directory) so `/collector` can omit `cooldown` while `/` keeps it.
- Works around dependabot/dependabot-core#14044: the cooldown logic crashes the whole docker job when a candidate tag points to a multi-arch OCI image index. The collector's base image (`us-docker.pkg.dev/cloud-ops-agents-artifacts/.../otelcol-google`) is exactly that, so every weekly run was failing — and taking the root `golang` update down with it.

## Why this works
`apply_cooldown` calls `get_tag_publication_details`, which `HEAD`s the config-blob digest. For an image index there's no flat config blob at that digest → 404 → exception bubbles up and aborts the whole job. Removing `cooldown` skips that code path. The root Dockerfile's `golang` is also a multi-arch image, but it only triggers the bug if a *newer* tag is found, so it's safe for now.

Upstream fix PR (dependabot/dependabot-core#14149) is still in draft; revisit once it ships.

## Test plan
- [ ] Wait for the next scheduled dependabot run (or trigger a manual one) and confirm both `/` and `/collector` jobs complete without `DockerRegistry2::NotFound`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)