### PR TITLE
chore: Add update severity for prism update notices

### DIFF
--- a/internal/ports/prism_notices.go
+++ b/internal/ports/prism_notices.go
@@ -203,10 +203,12 @@ func versionUpdateNotices(ctx context.Context, prismVersion prismVersionType, in
 	}
 
 	logging.FromContext(ctx).InfoContext(ctx, "Adding prism update notice", "prismVersion", string(prismVersion), "latest", latestPrism)
+	duration := 60.0
 	return []prismNotice{{
-		Message:  "New update available! Click here to download.",
-		URL:      latestPrismReleaseURL,
-		Severity: noticeSeverityUpdate,
+		Message:         "New update available! Click here to download.",
+		URL:             latestPrismReleaseURL,
+		Severity:        noticeSeverityUpdate,
+		DurationSeconds: &duration,
 	}}
 }
 

--- a/internal/ports/prism_notices.go
+++ b/internal/ports/prism_notices.go
@@ -20,6 +20,7 @@ type severity string
 
 const (
 	noticeSeverityInfo     severity = "info"
+	noticeSeverityUpdate   severity = "update"
 	noticeSeverityWarning  severity = "warning"
 	noticeSeverityCritical severity = "critical"
 )
@@ -205,7 +206,7 @@ func versionUpdateNotices(ctx context.Context, prismVersion prismVersionType, in
 	return []prismNotice{{
 		Message:  "New update available! Click here to download.",
 		URL:      latestPrismReleaseURL,
-		Severity: noticeSeverityInfo,
+		Severity: noticeSeverityUpdate,
 	}}
 }
 


### PR DESCRIPTION
## Summary
- Add `update` severity alongside `info`/`warning`/`critical` in `prism-notices`
- Tag the prism version-update notice with `update` so the prism client can render it distinctly from generic info notices

## Test plan
- [x] `go test ./internal/ports/...`