### PR TITLE
refactor: Move prism notices logic into the app package

### DIFF
--- a/internal/app/prism_notices.go
+++ b/internal/app/prism_notices.go
@@ -1,0 +1,141 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/Amund211/flashlight/internal/logging"
+	"github.com/Amund211/flashlight/internal/version"
+)
+
+type Severity string
+
+const (
+	SeverityInfo     Severity = "info"
+	SeverityUpdate   Severity = "update"
+	SeverityWarning  Severity = "warning"
+	SeverityCritical Severity = "critical"
+)
+
+type UpdateSelection int
+
+const (
+	UpdateSelectionNone UpdateSelection = iota
+	UpdateSelectionMinor
+	UpdateSelectionAll
+)
+
+type PrismNotice struct {
+	Message         string
+	URL             string
+	Severity        Severity
+	DurationSeconds *float64
+}
+
+type GetPrismNotices = func(
+	ctx context.Context,
+	userID string,
+	prismVersion string,
+	updateSelection UpdateSelection,
+) []PrismNotice
+
+// latestPrism is the most recent released prism version. Bump this when
+// cutting a new prism release; clients running an older version will be told
+// (via the prism-notices endpoint) that an update is available.
+var latestPrism = version.MustParse("v1.11.0")
+
+// firstPrismVersionWithoutLocalChecker is the first prism release that does
+// not include the in-process GitHub update checker — those clients rely on
+// flashlight to surface update notices. Older clients still poll GitHub
+// themselves, so flashlight must not duplicate the notice for them.
+var firstPrismVersionWithoutLocalChecker = version.MustParse("v1.12.0")
+
+const latestPrismReleaseURL = "https://github.com/Amund211/prism/releases/latest/"
+
+var unicodeReplacementCharacterUsers = []string{
+	"b1b6ead3b357467298c0a186a891940f",
+	"e104fb8b4b8a4a40ba70334e8239c0e1",
+	"b3c71ddfb808414d80e932110dae5716",
+	"9c90ae7b927347a787ddb9c9e85cca16",
+	"a3ec8094a2bb427f81c11faadb33c2ba",
+	"ea2aa5221a614dc1a502f01e33f4ceaa",
+	"47e7859bb33246ef8494fb81a9ac4e01",
+	"426d836cdc7740bd9ff887d1d8a358f3",
+
+	"3eedaf7ed5964d8981835b8f0de2c9d4",
+	"bb683d98dc634a5783be9a4895ab75af",
+	"a55dfa5ddaa7426b87f2a5dbc3ad5254",
+}
+
+func BuildGetPrismNotices(nowFunc func() time.Time) GetPrismNotices {
+	return func(ctx context.Context, userID string, prismVersion string, updateSelection UpdateSelection) []PrismNotice {
+		notices := []PrismNotice{}
+
+		now := nowFunc().UTC()
+
+		notices = append(notices, versionUpdateNotices(ctx, prismVersion, updateSelection)...)
+
+		if slices.Contains(unicodeReplacementCharacterUsers, userID) {
+			// These users sometimes include a unicode replacement character at the end of
+			// usernames sent to the account endpoint, causing issues.
+			// https://prism-overlay.sentry.io/issues/7078120764/?project=4506886744768512
+			duration := 120.0
+			logging.FromContext(ctx).InfoContext(ctx, "Adding critical notice for user with known unicode replacement character issue", "userID", userID)
+			notices = append(notices, PrismNotice{
+				Message:         "We've detected a potential issue with your Prism client.\nPlease click here to create a ticket in the discord server",
+				URL:             "https://discord.gg/NGpRrdh6Fx",
+				Severity:        SeverityWarning,
+				DurationSeconds: &duration,
+			})
+		}
+
+		if now.Month() == time.December || now.Month() == time.January {
+			duration := 60.0
+			year := now.Year()
+			if now.Month() == time.January {
+				year = year - 1
+			}
+			notices = append(notices, PrismNotice{
+				Message:         fmt.Sprintf("Click here to view your Prism Wrapped %d", year),
+				URL:             "https://prismoverlay.com/wrapped",
+				Severity:        SeverityInfo,
+				DurationSeconds: &duration,
+			})
+		}
+
+		return notices
+	}
+}
+
+func versionUpdateNotices(ctx context.Context, prismVersion string, updateSelection UpdateSelection) []PrismNotice {
+	if updateSelection == UpdateSelectionNone {
+		return nil
+	}
+	includePatchUpdates := updateSelection == UpdateSelectionAll
+
+	current, err := version.Parse(prismVersion)
+	if err != nil {
+		logging.FromContext(ctx).WarnContext(ctx, "Failed to parse prism version", "error", err, "prismVersion", prismVersion)
+		return nil
+	}
+
+	if !current.IsAtLeast(firstPrismVersionWithoutLocalChecker) {
+		// This client still has its own GitHub update checker.
+		return nil
+	}
+
+	if !current.UpdateAvailable(latestPrism, !includePatchUpdates) {
+		return nil
+	}
+
+	logging.FromContext(ctx).InfoContext(ctx, "Adding prism update notice", "prismVersion", prismVersion, "latest", latestPrism)
+	duration := 60.0
+	return []PrismNotice{{
+		Message:         "New update available! Click here to download.",
+		URL:             latestPrismReleaseURL,
+		Severity:        SeverityUpdate,
+		DurationSeconds: &duration,
+	}}
+}

--- a/internal/app/prism_notices_test.go
+++ b/internal/app/prism_notices_test.go
@@ -1,0 +1,159 @@
+package app_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Amund211/flashlight/internal/app"
+	"github.com/Amund211/flashlight/internal/domaintest"
+)
+
+func TestBuildGetPrismNotices(t *testing.T) {
+	t.Parallel()
+
+	defaultTime := time.Date(2024, time.June, 1, 0, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name            string
+		userID          string
+		prismVersion    string
+		updateSelection app.UpdateSelection
+		now             time.Time
+		want            []app.PrismNotice
+	}{
+		{
+			name:            "empty inputs",
+			userID:          "",
+			prismVersion:    "",
+			updateSelection: app.UpdateSelectionNone,
+			now:             defaultTime,
+			want:            []app.PrismNotice{},
+		},
+		{
+			name:            "v1.10.1-dev outside wrapped window",
+			userID:          domaintest.NewUUID(t),
+			prismVersion:    "v1.10.1-dev",
+			updateSelection: app.UpdateSelectionNone,
+			now:             defaultTime,
+			want:            []app.PrismNotice{},
+		},
+		{
+			name:            "wrapped notice surfaced at start of December",
+			userID:          domaintest.NewUUID(t),
+			prismVersion:    "v1.11.0",
+			updateSelection: app.UpdateSelectionNone,
+			now:             time.Date(2025, time.December, 1, 0, 0, 0, 0, time.UTC),
+			want: []app.PrismNotice{
+				{
+					Message:         "Click here to view your Prism Wrapped 2025",
+					URL:             "https://prismoverlay.com/wrapped",
+					Severity:        app.SeverityInfo,
+					DurationSeconds: new(60.0),
+				},
+			},
+		},
+		{
+			name:            "wrapped notice surfaced on Christmas Eve",
+			userID:          domaintest.NewUUID(t),
+			prismVersion:    "v1.11.0",
+			updateSelection: app.UpdateSelectionNone,
+			now:             time.Date(2025, time.December, 24, 0, 0, 0, 0, time.UTC),
+			want: []app.PrismNotice{
+				{
+					Message:         "Click here to view your Prism Wrapped 2025",
+					URL:             "https://prismoverlay.com/wrapped",
+					Severity:        app.SeverityInfo,
+					DurationSeconds: new(60.0),
+				},
+			},
+		},
+		{
+			name:            "wrapped notice surfaced on last day of January reports prior year",
+			userID:          domaintest.NewUUID(t),
+			prismVersion:    "v1.11.0",
+			updateSelection: app.UpdateSelectionNone,
+			now:             time.Date(2026, time.January, 31, 23, 59, 59, 0, time.UTC),
+			want: []app.PrismNotice{
+				{
+					Message:         "Click here to view your Prism Wrapped 2025",
+					URL:             "https://prismoverlay.com/wrapped",
+					Severity:        app.SeverityInfo,
+					DurationSeconds: new(60.0),
+				},
+			},
+		},
+		{
+			name:            "wrapped window closed in February",
+			userID:          domaintest.NewUUID(t),
+			prismVersion:    "v1.11.0",
+			updateSelection: app.UpdateSelectionNone,
+			now:             time.Date(2026, time.February, 1, 0, 0, 0, 0, time.UTC),
+			want:            []app.PrismNotice{},
+		},
+		{
+			name:            "known unicode replacement character user gets warning notice",
+			userID:          "b1b6ead3b357467298c0a186a891940f",
+			prismVersion:    "v1.11.0",
+			updateSelection: app.UpdateSelectionNone,
+			now:             defaultTime,
+			want: []app.PrismNotice{
+				{
+					Message:         "We've detected a potential issue with your Prism client.\nPlease click here to create a ticket in the discord server",
+					URL:             "https://discord.gg/NGpRrdh6Fx",
+					Severity:        app.SeverityWarning,
+					DurationSeconds: new(120.0),
+				},
+			},
+		},
+
+		// Version-update-focused cases.
+		{
+			// v1.11.0 sends no preference, so the handler defaults to All.
+			name:            "v1.11.0 still has local checker",
+			userID:          domaintest.NewUUID(t),
+			prismVersion:    "v1.11.0",
+			updateSelection: app.UpdateSelectionAll,
+			now:             defaultTime,
+			want:            []app.PrismNotice{},
+		},
+		{
+			name:            "selection=none with unparseable version",
+			userID:          domaintest.NewUUID(t),
+			prismVersion:    "not-a-version",
+			updateSelection: app.UpdateSelectionNone,
+			now:             defaultTime,
+			want:            []app.PrismNotice{},
+		},
+		{
+			name:            "selection=minor with unparseable version",
+			userID:          domaintest.NewUUID(t),
+			prismVersion:    "not-a-version",
+			updateSelection: app.UpdateSelectionMinor,
+			now:             defaultTime,
+			want:            []app.PrismNotice{},
+		},
+		{
+			name:            "selection=all with unparseable version",
+			userID:          domaintest.NewUUID(t),
+			prismVersion:    "not-a-version",
+			updateSelection: app.UpdateSelectionAll,
+			now:             defaultTime,
+			want:            []app.PrismNotice{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			nowFunc := func() time.Time { return tc.now }
+			getPrismNotices := app.BuildGetPrismNotices(nowFunc)
+
+			got := getPrismNotices(t.Context(), tc.userID, tc.prismVersion, tc.updateSelection)
+
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/ports/prism_notices.go
+++ b/internal/ports/prism_notices.go
@@ -1,20 +1,20 @@
 package ports
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
-	"slices"
-	"time"
 
 	"github.com/Amund211/flashlight/internal/app"
 	"github.com/Amund211/flashlight/internal/logging"
 	"github.com/Amund211/flashlight/internal/ratelimiting"
 	"github.com/Amund211/flashlight/internal/reporting"
-	"github.com/Amund211/flashlight/internal/version"
 )
+
+// Wire-format types for the prism-notices endpoint. The HTTP contract is
+// the handler's responsibility, so the JSON-tagged structs live here and
+// the handler converts from app-layer types before serializing.
 
 type severity string
 
@@ -24,21 +24,6 @@ const (
 	noticeSeverityWarning  severity = "warning"
 	noticeSeverityCritical severity = "critical"
 )
-
-// latestPrism is the most recent released prism version. Bump this when
-// cutting a new prism release; clients running an older version will be told
-// (via the prism-notices endpoint) that an update is available.
-var latestPrism = version.MustParse("v1.11.0")
-
-// firstPrismVersionWithoutLocalChecker is the first prism release that does
-// not include the in-process GitHub update checker — those clients rely on
-// flashlight to surface update notices. Older clients still poll GitHub
-// themselves, so flashlight must not duplicate the notice for them.
-var firstPrismVersionWithoutLocalChecker = version.MustParse("v1.12.0")
-
-// latestPrismReleaseURL is the link clients are sent to when an update notice
-// is shown.
-const latestPrismReleaseURL = "https://github.com/Amund211/prism/releases/latest/"
 
 type prismNotice struct {
 	Message         string   `json:"message"`
@@ -51,10 +36,23 @@ type noticesResponse struct {
 	Notices []prismNotice `json:"notices"`
 }
 
-type userIDType string
-type prismVersionType string
+func severityFromApp(s app.Severity) (severity, error) {
+	switch s {
+	case app.SeverityInfo:
+		return noticeSeverityInfo, nil
+	case app.SeverityUpdate:
+		return noticeSeverityUpdate, nil
+	case app.SeverityWarning:
+		return noticeSeverityWarning, nil
+	case app.SeverityCritical:
+		return noticeSeverityCritical, nil
+	default:
+		return "", fmt.Errorf("unknown app.Severity %q", string(s))
+	}
+}
 
 func MakePrismNoticesHandler(
+	getPrismNotices app.GetPrismNotices,
 	registerUserVisit app.RegisterUserVisit,
 	rootLogger *slog.Logger,
 	sentryMiddleware func(http.HandlerFunc) http.HandlerFunc,
@@ -111,31 +109,51 @@ func MakePrismNoticesHandler(
 			prismVersion = "<missing>"
 		}
 
-		includeVersionUpdates := r.URL.Query().Get("includeVersionUpdates")
+		rawSelection := r.URL.Query().Get("includeVersionUpdates")
 
 		ctx = logging.AddMetaToContext(ctx,
 			slog.String("prismVersion", prismVersion),
-			slog.String("includeVersionUpdates", includeVersionUpdates),
+			slog.String("includeVersionUpdates", rawSelection),
 		)
 		ctx = reporting.AddExtrasToContext(ctx,
 			map[string]string{
 				"prismVersion":          prismVersion,
-				"includeVersionUpdates": includeVersionUpdates,
+				"includeVersionUpdates": rawSelection,
 			},
 		)
 
-		notices, err := noticesForCall(ctx, userIDType(userID), prismVersionType(prismVersion), includeVersionUpdates, time.Now())
-		if err != nil {
-			logging.FromContext(ctx).ErrorContext(ctx, "Failed to get notices for call", "error", err)
-
-			err = fmt.Errorf("failed to get notices for call: %w", err)
-			reporting.Report(ctx, err)
-
-			http.Error(w, "Internal server error", http.StatusInternalServerError)
-			return
+		var updateSelection app.UpdateSelection
+		switch rawSelection {
+		case "none":
+			updateSelection = app.UpdateSelectionNone
+		case "minor":
+			updateSelection = app.UpdateSelectionMinor
+		case "all":
+			updateSelection = app.UpdateSelectionAll
+		default:
+			logging.FromContext(ctx).WarnContext(ctx, "Unrecognized includeVersionUpdates value, defaulting to all", "includeVersionUpdates", rawSelection)
+			updateSelection = app.UpdateSelectionAll
 		}
 
-		responseData, err := json.Marshal(noticesResponse{Notices: notices})
+		appNotices := getPrismNotices(ctx, string(userID), prismVersion, updateSelection)
+		wireNotices := make([]prismNotice, 0, len(appNotices))
+		for _, n := range appNotices {
+			wireSeverity, err := severityFromApp(n.Severity)
+			if err != nil {
+				logging.FromContext(ctx).ErrorContext(ctx, "Failed to convert severity for wire format", "error", err)
+				reporting.Report(ctx, fmt.Errorf("failed to convert severity: %w", err))
+				http.Error(w, "Internal server error", http.StatusInternalServerError)
+				return
+			}
+			wireNotices = append(wireNotices, prismNotice{
+				Message:         n.Message,
+				URL:             n.URL,
+				Severity:        wireSeverity,
+				DurationSeconds: n.DurationSeconds,
+			})
+		}
+
+		responseData, err := json.Marshal(noticesResponse{Notices: wireNotices})
 		if err != nil {
 			logging.FromContext(ctx).ErrorContext(ctx, "Failed to marshal notices", "error", err)
 			reporting.Report(ctx, fmt.Errorf("failed to marshal notices: %w", err))
@@ -152,100 +170,7 @@ func MakePrismNoticesHandler(
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
 		}
-
 	}
 
 	return middleware(handler)
-}
-
-var unicodeReplacementCharacterUsers = []string{
-	"b1b6ead3b357467298c0a186a891940f",
-	"e104fb8b4b8a4a40ba70334e8239c0e1",
-	"b3c71ddfb808414d80e932110dae5716",
-	"9c90ae7b927347a787ddb9c9e85cca16",
-	"a3ec8094a2bb427f81c11faadb33c2ba",
-	"ea2aa5221a614dc1a502f01e33f4ceaa",
-	"47e7859bb33246ef8494fb81a9ac4e01",
-	"426d836cdc7740bd9ff887d1d8a358f3",
-
-	"3eedaf7ed5964d8981835b8f0de2c9d4",
-	"bb683d98dc634a5783be9a4895ab75af",
-	"a55dfa5ddaa7426b87f2a5dbc3ad5254",
-}
-
-func versionUpdateNotices(ctx context.Context, prismVersion prismVersionType, includeVersionUpdates string) []prismNotice {
-	var includePatchUpdates bool
-	switch includeVersionUpdates {
-	case "none":
-		return nil
-	case "minor":
-		includePatchUpdates = false
-	case "all":
-		includePatchUpdates = true
-	default:
-		logging.FromContext(ctx).WarnContext(ctx, "Unrecognized includeVersionUpdates value, defaulting to all", "includeVersionUpdates", includeVersionUpdates)
-		includePatchUpdates = true
-	}
-
-	current, err := version.Parse(string(prismVersion))
-	if err != nil {
-		logging.FromContext(ctx).WarnContext(ctx, "Failed to parse prism version", "error", err, "prismVersion", string(prismVersion))
-		return nil
-	}
-
-	if !current.IsAtLeast(firstPrismVersionWithoutLocalChecker) {
-		// This client still has its own GitHub update checker.
-		return nil
-	}
-
-	if !current.UpdateAvailable(latestPrism, !includePatchUpdates) {
-		return nil
-	}
-
-	logging.FromContext(ctx).InfoContext(ctx, "Adding prism update notice", "prismVersion", string(prismVersion), "latest", latestPrism)
-	duration := 60.0
-	return []prismNotice{{
-		Message:         "New update available! Click here to download.",
-		URL:             latestPrismReleaseURL,
-		Severity:        noticeSeverityUpdate,
-		DurationSeconds: &duration,
-	}}
-}
-
-func noticesForCall(ctx context.Context, userID userIDType, prismVersion prismVersionType, includeVersionUpdates string, now time.Time) ([]prismNotice, error) {
-	notices := []prismNotice{}
-
-	now = now.UTC()
-
-	notices = append(notices, versionUpdateNotices(ctx, prismVersion, includeVersionUpdates)...)
-
-	if slices.Contains(unicodeReplacementCharacterUsers, string(userID)) {
-		// These users sometimes include a unicode replacement character at the end of
-		// usernames sent to the account endpoint, causing issues.
-		// https://prism-overlay.sentry.io/issues/7078120764/?project=4506886744768512
-		duration := 120.0
-		logging.FromContext(ctx).InfoContext(ctx, "Adding critical notice for user with known unicode replacement character issue", "userID", userID)
-		notices = append(notices, prismNotice{
-			Message:         "We've detected a potential issue with your Prism client.\nPlease click here to create a ticket in the discord server",
-			URL:             "https://discord.gg/NGpRrdh6Fx",
-			Severity:        noticeSeverityWarning,
-			DurationSeconds: &duration,
-		})
-	}
-
-	if now.Month() == time.December || now.Month() == time.January {
-		duration := 60.0
-		year := now.Year()
-		if now.Month() == time.January {
-			year = year - 1
-		}
-		notices = append(notices, prismNotice{
-			Message:         fmt.Sprintf("Click here to view your Prism Wrapped %d", year),
-			URL:             "https://prismoverlay.com/wrapped",
-			Severity:        noticeSeverityInfo,
-			DurationSeconds: &duration,
-		})
-	}
-
-	return notices, nil
 }

--- a/internal/ports/prism_notices_test.go
+++ b/internal/ports/prism_notices_test.go
@@ -7,145 +7,281 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"testing/synctest"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/Amund211/flashlight/internal/app"
 	"github.com/Amund211/flashlight/internal/domain"
 	"github.com/Amund211/flashlight/internal/domaintest"
 	"github.com/Amund211/flashlight/internal/ports"
 )
 
-func TestPrismNoticesHandler(t *testing.T) {
-	t.Parallel()
+var noopPrismNoticesMiddleware = func(h http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		h(w, r)
+	}
+}
 
-	defaultTime := time.Date(2024, time.June, 1, 0, 0, 0, 0, time.UTC)
+var stubPrismNoticesRegisterUserVisit = func(ctx context.Context, userID string, ipHash string, userAgent string) (domain.User, error) {
+	return domain.User{}, nil
+}
+
+var prismNoticesTestLogger = slog.New(slog.NewTextHandler(io.Discard, nil))
+
+func makePrismNoticesHandler(t *testing.T, getPrismNotices app.GetPrismNotices) http.HandlerFunc {
+	t.Helper()
+	return ports.MakePrismNoticesHandler(
+		getPrismNotices,
+		stubPrismNoticesRegisterUserVisit,
+		prismNoticesTestLogger,
+		noopPrismNoticesMiddleware,
+		emptyBlocklistConfig,
+	)
+}
+
+func TestPrismNoticesHandlerPassesArgsToApp(t *testing.T) {
+	t.Parallel()
 
 	cases := []struct {
 		name                  string
 		userID                string
-		prismVersion          string
+		prismVersionHeader    string
 		includeVersionUpdates string
-		time                  time.Time
-		responseJSON          string
+		wantPrismVersion      string
+		wantSelection         app.UpdateSelection
 	}{
 		{
-			name:         "empty headers",
-			userID:       "",
-			prismVersion: "",
-			responseJSON: `{"notices":[]}`,
-			time:         defaultTime,
+			name:                  "selection=none",
+			userID:                domaintest.NewUUID(t),
+			prismVersionHeader:    "v1.12.0",
+			includeVersionUpdates: "none",
+			wantPrismVersion:      "v1.12.0",
+			wantSelection:         app.UpdateSelectionNone,
 		},
 		{
-			name:         "v1.10.1-dev outside wrapped window",
-			userID:       domaintest.NewUUID(t),
-			prismVersion: "v1.10.1-dev",
-			responseJSON: `{"notices":[]}`,
-			time:         defaultTime,
+			name:                  "selection=minor",
+			userID:                domaintest.NewUUID(t),
+			prismVersionHeader:    "v1.12.0",
+			includeVersionUpdates: "minor",
+			wantPrismVersion:      "v1.12.0",
+			wantSelection:         app.UpdateSelectionMinor,
 		},
 		{
-			name:         "v1.11.0 outside wrapped window",
-			userID:       domaintest.NewUUID(t),
-			prismVersion: "v1.11.0",
-			responseJSON: `{"notices":[]}`,
-			time:         defaultTime,
+			name:                  "selection=all",
+			userID:                domaintest.NewUUID(t),
+			prismVersionHeader:    "v1.12.0",
+			includeVersionUpdates: "all",
+			wantPrismVersion:      "v1.12.0",
+			wantSelection:         app.UpdateSelectionAll,
 		},
 		{
-			name:         "wrapped notice surfaced at start of December",
-			userID:       domaintest.NewUUID(t),
-			prismVersion: "v1.11.0",
-			responseJSON: `{"notices":[
-				{
-					"message":"Click here to view your Prism Wrapped 2025",
-					"url":"https://prismoverlay.com/wrapped",
-					"severity":"info",
-					"duration_seconds":60
-				}
-			]}`,
-			time: time.Date(2025, time.December, 1, 0, 0, 0, 0, time.UTC),
-		},
-		{
-			name:         "wrapped notice surfaced on Christmas Eve",
-			userID:       domaintest.NewUUID(t),
-			prismVersion: "v1.11.0",
-			responseJSON: `{"notices":[
-				{
-					"message":"Click here to view your Prism Wrapped 2025",
-					"url":"https://prismoverlay.com/wrapped",
-					"severity":"info",
-					"duration_seconds":60
-				}
-			]}`,
-			time: time.Date(2025, time.December, 24, 0, 0, 0, 0, time.UTC),
-		},
-		{
-			name:         "wrapped notice surfaced on last day of January",
-			userID:       domaintest.NewUUID(t),
-			prismVersion: "v1.11.0",
-			responseJSON: `{"notices":[
-				{
-					"message":"Click here to view your Prism Wrapped 2025",
-					"url":"https://prismoverlay.com/wrapped",
-					"severity":"info",
-					"duration_seconds":60
-				}
-			]}`,
-			time: time.Date(2026, time.January, 31, 23, 59, 59, 0, time.UTC),
-		},
-		{
-			name:         "wrapped window closed in February",
-			userID:       domaintest.NewUUID(t),
-			prismVersion: "v1.11.0",
-			responseJSON: `{"notices":[]}`,
-			time:         time.Date(2026, time.February, 1, 0, 0, 0, 0, time.UTC),
-		},
-		{
-			name:         "v1.11.0 (still has local checker)",
-			userID:       domaintest.NewUUID(t),
-			prismVersion: "v1.11.0",
-			// v1.11.0 does not send the includeVersionUpdates query param
+			name:                  "missing query param defaults to all",
+			userID:                domaintest.NewUUID(t),
+			prismVersionHeader:    "v1.12.0",
 			includeVersionUpdates: "",
-			responseJSON:          `{"notices":[]}`,
-			time:                  defaultTime,
+			wantPrismVersion:      "v1.12.0",
+			wantSelection:         app.UpdateSelectionAll,
+		},
+		{
+			name:                  "unrecognized query param defaults to all",
+			userID:                domaintest.NewUUID(t),
+			prismVersionHeader:    "v1.12.0",
+			includeVersionUpdates: "bogus",
+			wantPrismVersion:      "v1.12.0",
+			wantSelection:         app.UpdateSelectionAll,
+		},
+		{
+			name:                  "missing prism version header is replaced with <missing>",
+			userID:                domaintest.NewUUID(t),
+			prismVersionHeader:    "",
+			includeVersionUpdates: "all",
+			wantPrismVersion:      "<missing>",
+			wantSelection:         app.UpdateSelectionAll,
 		},
 	}
-
-	testLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	noopMiddleware := func(h http.HandlerFunc) http.HandlerFunc {
-		return func(w http.ResponseWriter, r *http.Request) {
-			h(w, r)
-		}
-	}
-
-	// NOTE: Need to make the handler outside, since we create TTL caches inside the handler.
-	stubRegisterUserVisit := func(ctx context.Context, userID string, ipHash string, userAgent string) (domain.User, error) {
-		return domain.User{}, nil
-	}
-	handler := ports.MakePrismNoticesHandler(stubRegisterUserVisit, testLogger, noopMiddleware, emptyBlocklistConfig)
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			synctest.Test(t, func(t *testing.T) {
-				time.Sleep(time.Until(tc.time))
 
-				url := "/v1/prism-notices"
-				if tc.includeVersionUpdates != "" {
-					url += "?includeVersionUpdates=" + tc.includeVersionUpdates
-				}
-				req := httptest.NewRequestWithContext(t.Context(), "GET", url, nil)
-				req.Header.Set("X-User-Id", tc.userID)
-				req.Header.Set("X-Prism-Version", tc.prismVersion)
+			called := false
+			getPrismNotices := func(ctx context.Context, userID, prismVersion string, selection app.UpdateSelection) []app.PrismNotice {
+				require.False(t, called, "getPrismNotices should be called exactly once")
+				called = true
+				require.Equal(t, tc.userID, userID)
+				require.Equal(t, tc.wantPrismVersion, prismVersion)
+				require.Equal(t, tc.wantSelection, selection)
+				return []app.PrismNotice{}
+			}
+			handler := makePrismNoticesHandler(t, getPrismNotices)
 
-				w := httptest.NewRecorder()
+			url := "/v1/prism-notices"
+			if tc.includeVersionUpdates != "" {
+				url += "?includeVersionUpdates=" + tc.includeVersionUpdates
+			}
+			req := httptest.NewRequestWithContext(t.Context(), "GET", url, nil)
+			req.Header.Set("X-User-Id", tc.userID)
+			if tc.prismVersionHeader != "" {
+				req.Header.Set("X-Prism-Version", tc.prismVersionHeader)
+			}
 
-				handler.ServeHTTP(w, req)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
 
-				require.Equal(t, http.StatusOK, w.Code)
-				require.JSONEq(t, tc.responseJSON, w.Body.String())
-				require.Equal(t, "application/json", w.Result().Header.Get("Content-Type"))
-			})
+			require.Equal(t, http.StatusOK, w.Code)
+			require.True(t, called)
 		})
 	}
+}
+
+func TestPrismNoticesHandlerSerializesAppNotices(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		notices []app.PrismNotice
+		want    string
+	}{
+		{
+			name:    "empty slice serializes to empty notices array",
+			notices: []app.PrismNotice{},
+			want:    `{"notices":[]}`,
+		},
+		{
+			name: "single info notice with url and duration",
+			notices: []app.PrismNotice{
+				{
+					Message:         "Click here to view your Prism Wrapped 2025",
+					URL:             "https://prismoverlay.com/wrapped",
+					Severity:        app.SeverityInfo,
+					DurationSeconds: new(60.0),
+				},
+			},
+			want: `{"notices":[
+				{
+					"message":"Click here to view your Prism Wrapped 2025",
+					"url":"https://prismoverlay.com/wrapped",
+					"severity":"info",
+					"duration_seconds":60
+				}
+			]}`,
+		},
+		{
+			name: "update notice",
+			notices: []app.PrismNotice{
+				{
+					Message:         "New update available! Click here to download.",
+					URL:             "https://github.com/Amund211/prism/releases/latest/",
+					Severity:        app.SeverityUpdate,
+					DurationSeconds: new(60.0),
+				},
+			},
+			want: `{"notices":[
+				{
+					"message":"New update available! Click here to download.",
+					"url":"https://github.com/Amund211/prism/releases/latest/",
+					"severity":"update",
+					"duration_seconds":60
+				}
+			]}`,
+		},
+		{
+			name: "warning notice with url and duration",
+			notices: []app.PrismNotice{
+				{
+					Message:         "We've detected a potential issue with your Prism client.\nPlease click here to create a ticket in the discord server",
+					URL:             "https://discord.gg/NGpRrdh6Fx",
+					Severity:        app.SeverityWarning,
+					DurationSeconds: new(120.0),
+				},
+			},
+			want: `{"notices":[
+				{
+					"message":"We've detected a potential issue with your Prism client.\nPlease click here to create a ticket in the discord server",
+					"url":"https://discord.gg/NGpRrdh6Fx",
+					"severity":"warning",
+					"duration_seconds":120
+				}
+			]}`,
+		},
+		{
+			name: "critical notice without optional fields",
+			notices: []app.PrismNotice{
+				{
+					Message:  "Something critical happened",
+					Severity: app.SeverityCritical,
+				},
+			},
+			want: `{"notices":[
+				{
+					"message":"Something critical happened",
+					"severity":"critical"
+				}
+			]}`,
+		},
+		{
+			name: "multiple notices preserve order",
+			notices: []app.PrismNotice{
+				{
+					Message:         "first",
+					Severity:        app.SeverityUpdate,
+					DurationSeconds: new(60.0),
+				},
+				{
+					Message:  "second",
+					Severity: app.SeverityInfo,
+				},
+			},
+			want: `{"notices":[
+				{
+					"message":"first",
+					"severity":"update",
+					"duration_seconds":60
+				},
+				{
+					"message":"second",
+					"severity":"info"
+				}
+			]}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			getPrismNotices := func(ctx context.Context, userID, prismVersion string, selection app.UpdateSelection) []app.PrismNotice {
+				return tc.notices
+			}
+			handler := makePrismNoticesHandler(t, getPrismNotices)
+
+			req := httptest.NewRequestWithContext(t.Context(), "GET", "/v1/prism-notices", nil)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			require.Equal(t, http.StatusOK, w.Code)
+			require.JSONEq(t, tc.want, w.Body.String())
+			require.Equal(t, "application/json", w.Result().Header.Get("Content-Type"))
+		})
+	}
+}
+
+func TestPrismNoticesHandlerReturns500OnUnknownSeverity(t *testing.T) {
+	t.Parallel()
+
+	getPrismNotices := func(ctx context.Context, userID, prismVersion string, selection app.UpdateSelection) []app.PrismNotice {
+		return []app.PrismNotice{
+			{
+				Message:  "notice with bogus severity",
+				Severity: app.Severity("not-a-real-severity"),
+			},
+		}
+	}
+	handler := makePrismNoticesHandler(t, getPrismNotices)
+
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v1/prism-notices", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
 }

--- a/main.go
+++ b/main.go
@@ -196,6 +196,8 @@ func main() {
 
 	registerUserVisit := app.BuildRegisterUserVisit(userRepo)
 
+	getPrismNotices := app.BuildGetPrismNotices(time.Now)
+
 	mux := http.NewServeMux()
 
 	handleFunc := func(pattern string, handlerFunc http.HandlerFunc) {
@@ -206,6 +208,7 @@ func main() {
 	handleFunc(
 		"GET /v1/prism-notices",
 		ports.MakePrismNoticesHandler(
+			getPrismNotices,
 			registerUserVisit,
 			logger.With("port", "prism-notices"),
 			sentryMiddleware,


### PR DESCRIPTION
Factor the prism-notices business logic out of the ports handler and
into a BuildGetPrismNotices builder in the app package. The handler
now translates the raw includeVersionUpdates query string into a typed
app.UpdateSelection, calls the app function, and converts the
returned []app.PrismNotice into its own JSON-tagged wire-format struct
before serializing — keeping the app types wire-agnostic.

Tests split accordingly: the app tests assert on []app.PrismNotice
using an injected nowFunc (no synctest/time.Sleep), and the handler
tests stub the app function to verify argument mapping and JSON
serialization separately.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
