### PR TITLE
fix mojang invalid username error

### DIFF
--- a/internal/adapters/accountprovider/mojang.go
+++ b/internal/adapters/accountprovider/mojang.go
@@ -143,8 +143,10 @@ func (m *Mojang) getProfile(ctx context.Context, url string) (domain.Account, er
 }
 
 type mojangResponse struct {
-	UUID     string `json:"id"`
-	Username string `json:"name"`
+	UUID         string `json:"id"`
+	Username     string `json:"name"`
+	Error        string `json:"error"`
+	ErrorMessage string `json:"errorMessage"`
 }
 
 func accountFromMojangResponse(statusCode int, data []byte, queriedAt time.Time) (domain.Account, error) {
@@ -164,6 +166,10 @@ func accountFromMojangResponse(statusCode int, data []byte, queriedAt time.Time)
 	var response mojangResponse
 	if err := json.Unmarshal(data, &response); err != nil {
 		return domain.Account{}, fmt.Errorf("failed to parse mojang response: %w", err)
+	}
+
+	if response.Error != "" || response.ErrorMessage != "" {
+		return domain.Account{}, fmt.Errorf("mojang API returned error response (status %d): error=%q errorMessage=%q", statusCode, response.Error, response.ErrorMessage)
 	}
 
 	uuid, err := strutils.NormalizeUUID(response.UUID)

--- a/internal/adapters/accountprovider/mojang_test.go
+++ b/internal/adapters/accountprovider/mojang_test.go
@@ -100,6 +100,25 @@ func TestUUIDFromMojangResponse(t *testing.T) {
 			statusCode: 200,
 			err:        assert.AnError,
 		},
+		{
+			name: "400 with error and errorMessage",
+			response: []byte(`{
+  "path" : "/users/profiles/minecraft/§ko01Y",
+  "error" : "CONSTRAINT_VIOLATION",
+  "errorMessage" : "getProfileName.name: Invalid profile name"
+}`),
+			statusCode: 400,
+			err:        assert.AnError,
+		},
+		{
+			name: "200 with errorMessage only",
+			response: []byte(`{
+  "path" : "/users/profiles/minecraft/whatever",
+  "errorMessage" : "something went wrong"
+}`),
+			statusCode: 200,
+			err:        assert.AnError,
+		},
 	}
 
 	for _, tc := range tests {
@@ -121,6 +140,20 @@ func TestUUIDFromMojangResponse(t *testing.T) {
 			require.True(t, strutils.UUIDIsNormalized(account.UUID))
 		})
 	}
+}
+
+func TestAccountFromMojangResponseSurfacesErrorMessage(t *testing.T) {
+	t.Parallel()
+
+	_, err := accountFromMojangResponse(400, []byte(`{
+  "path" : "/users/profiles/minecraft/§ko01Y",
+  "error" : "CONSTRAINT_VIOLATION",
+  "errorMessage" : "getProfileName.name: Invalid profile name"
+}`), time.Now())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "CONSTRAINT_VIOLATION")
+	require.Contains(t, err.Error(), "Invalid profile name")
+	require.NotContains(t, err.Error(), "failed to normalize UUID")
 }
 
 type mockedClient struct {

--- a/internal/adapters/tagprovider/urchin.go
+++ b/internal/adapters/tagprovider/urchin.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -26,6 +27,14 @@ import (
 )
 
 const getTagsMinOperationTime = 150 * time.Millisecond
+
+// urchinKeyRx matches the `key=<value>` query param so the value can be
+// redacted from error messages before logging or reporting.
+var urchinKeyRx = regexp.MustCompile(`key=[^&"\s]+`)
+
+func scrubURLKey(s string) string {
+	return urchinKeyRx.ReplaceAllString(s, "key=<redacted>")
+}
 
 type HTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
@@ -122,14 +131,14 @@ func (u *urchin) GetTags(ctx context.Context, uuid string, urchinAPIKey *string)
 				// Wrap with temporarily unavailable and set the err from the outside scope
 				// This gets handled outside the limiter call.
 				err = fmt.Errorf(
-					"%w: failed to send request: %w",
+					"%w: failed to send request: %s",
 					domain.ErrTemporarilyUnavailable,
-					err,
+					scrubURLKey(errString),
 				)
 				// Don't report to sentry, as we get a bit of spam here
 				return
 			}
-			err = fmt.Errorf("failed to send request: %w", err)
+			err = fmt.Errorf("failed to send request: %s", scrubURLKey(errString))
 			reporting.Report(ctx, err)
 			return
 		}

--- a/internal/adapters/tagprovider/urchin.go
+++ b/internal/adapters/tagprovider/urchin.go
@@ -1,6 +1,7 @@
 package tagprovider
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -283,6 +284,15 @@ func tagsFromUrchinResponse(ctx context.Context, statusCode int, data []byte, us
 
 	var response urchinResponse
 	if err := json.Unmarshal(data, &response); err != nil {
+		if bytes.HasPrefix(data, []byte(`"Invalid source(s)`)) {
+			// Urchin returns a bare JSON string `"Invalid source(s) ..."` in some
+			// cases. Treat as transient instead of reporting a noisy
+			// "cannot unmarshal string into ...urchinResponse" parse error to Sentry.
+			return domain.Tags{}, urchinTagCollection{}, fmt.Errorf(
+				"%w: urchin API returned 'Invalid source(s)' response",
+				domain.ErrTemporarilyUnavailable,
+			)
+		}
 		return domain.Tags{}, urchinTagCollection{}, fmt.Errorf("failed to parse urchin response: %w", err)
 	}
 

--- a/internal/adapters/tagprovider/urchin.go
+++ b/internal/adapters/tagprovider/urchin.go
@@ -116,7 +116,8 @@ func (u *urchin) GetTags(ctx context.Context, uuid string, urchinAPIKey *string)
 		resp, err = u.httpClient.Do(req) // nolint:bodyclose // Closed via deferred Close inside this closure
 		if err != nil {
 			errString := err.Error()
-			if strings.HasSuffix(errString, "read: connection reset by peer") ||
+			if errors.Is(err, context.DeadlineExceeded) ||
+				strings.HasSuffix(errString, "read: connection reset by peer") ||
 				strings.HasSuffix(errString, "context deadline exceeded (Client.Timeout exceeded while awaiting headers)") {
 				// Wrap with temporarily unavailable and set the err from the outside scope
 				// This gets handled outside the limiter call.

--- a/internal/adapters/tagprovider/urchin_internal_test.go
+++ b/internal/adapters/tagprovider/urchin_internal_test.go
@@ -9,6 +9,39 @@ import (
 	"github.com/Amund211/flashlight/internal/domain"
 )
 
+func TestScrubURLKey(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "key in url query",
+			in:   `failed to send request: Get "https://urchin.ws/player/01234567-89ab-cdef-0123-456789abcdef?sources=MANUAL&key=super-secret-key": context deadline exceeded`,
+			want: `failed to send request: Get "https://urchin.ws/player/01234567-89ab-cdef-0123-456789abcdef?sources=MANUAL&key=<redacted>": context deadline exceeded`,
+		},
+		{
+			name: "no key",
+			in:   `failed to send request: Get "https://urchin.ws/player/01234567-89ab-cdef-0123-456789abcdef?sources=MANUAL": context deadline exceeded`,
+			want: `failed to send request: Get "https://urchin.ws/player/01234567-89ab-cdef-0123-456789abcdef?sources=MANUAL": context deadline exceeded`,
+		},
+		{
+			name: "key as only query param",
+			in:   `something key=hunter2 something else`,
+			want: `something key=<redacted> something else`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, c.want, scrubURLKey(c.in))
+		})
+	}
+}
+
 func TestTagsFromUrchinResponse(t *testing.T) {
 	t.Parallel()
 

--- a/internal/adapters/tagprovider/urchin_test.go
+++ b/internal/adapters/tagprovider/urchin_test.go
@@ -2,10 +2,12 @@ package tagprovider_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"reflect"
 	"testing"
 	"time"
@@ -239,6 +241,26 @@ func TestUrchinTagsProvider(t *testing.T) {
 					// NOTE: Error type is probably completely incorrect, but the text content
 					//       (like from .Error()) should be correct
 					err: errors.New(`Get "https://urchin.ws/player/01234567-89ab-cdef-0123-456789abcdef?sources=MANUAL": context deadline exceeded (Client.Timeout exceeded while awaiting headers)`),
+				}
+				urchinAPI, err := tagprovider.NewUrchin(httpClient, nowFunc, time.After)
+				require.NoError(t, err)
+
+				_, err = urchinAPI.GetTags(t.Context(), uuid, nil)
+				require.ErrorIs(t, err, domain.ErrTemporarilyUnavailable)
+			})
+			t.Run("context deadline exceeded", func(t *testing.T) {
+				t.Parallel()
+				// Newer net/http surfaces a context-deadline timeout without the
+				// "Client.Timeout exceeded while awaiting headers" suffix; the wrapped
+				// error is detectable via errors.Is(err, context.DeadlineExceeded).
+				httpClient := &mockedHTTPClient{
+					t:           t,
+					expectedURL: urlForUUID(uuid),
+					err: &url.Error{
+						Op:  "Get",
+						URL: urlForUUID(uuid),
+						Err: context.DeadlineExceeded,
+					},
 				}
 				urchinAPI, err := tagprovider.NewUrchin(httpClient, nowFunc, time.After)
 				require.NoError(t, err)

--- a/internal/adapters/tagprovider/urchin_test.go
+++ b/internal/adapters/tagprovider/urchin_test.go
@@ -279,6 +279,26 @@ func TestUrchinTagsProvider(t *testing.T) {
 
 			_, err = urchinAPI.GetTags(t.Context(), uuid, nil)
 			require.Error(t, err)
+			require.NotErrorIs(t, err, domain.ErrTemporarilyUnavailable)
+		})
+
+		t.Run("invalid sources response", func(t *testing.T) {
+			t.Parallel()
+			// Urchin sometimes returns `"Invalid source(s) ..."` as a bare JSON string,
+			// which would otherwise surface in Sentry as a noisy
+			// "cannot unmarshal string into ...urchinResponse" parse error.
+			httpClient := &mockedHTTPClient{
+				t:           t,
+				expectedURL: urlForUUID(uuid),
+				statusCode:  200,
+				body:        `"Invalid source(s) provided: {{sources}} must be one of: PARTY_INVITES, MANUAL, CHAT, GAME, CHAT_MENTIONS, PARTY, ME"`,
+				err:         nil,
+			}
+			urchinAPI, err := tagprovider.NewUrchin(httpClient, nowFunc, time.After)
+			require.NoError(t, err)
+
+			_, err = urchinAPI.GetTags(t.Context(), uuid, nil)
+			require.ErrorIs(t, err, domain.ErrTemporarilyUnavailable)
 		})
 
 		t.Run("Invalid api key response", func(t *testing.T) {

--- a/internal/ports/get_account_by_username.go
+++ b/internal/ports/get_account_by_username.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/Amund211/flashlight/internal/app"
 	"github.com/Amund211/flashlight/internal/domain"
@@ -100,6 +101,12 @@ func MakeGetAccountByUsernameHandler(
 		if usernameLength == 0 || usernameLength > 100 {
 			username = "<invalid>"
 			handleError(ctx, "invalid username length", http.StatusBadRequest)
+			return
+		}
+
+		if strings.ContainsAny(username, "§�") {
+			logging.FromContext(ctx).WarnContext(ctx, "Rejecting username with disallowed character")
+			handleError(ctx, "invalid username", http.StatusBadRequest)
 			return
 		}
 

--- a/internal/ports/get_account_by_username_test.go
+++ b/internal/ports/get_account_by_username_test.go
@@ -191,6 +191,54 @@ func TestMakeGetAccountByUsernameHandler(t *testing.T) {
 		require.Equal(t, "application/json", w.Result().Header.Get("Content-Type"))
 	})
 
+	t.Run("rejects username with section sign", func(t *testing.T) {
+		t.Parallel()
+
+		getAccountByUsername, called := makeGetAccountByUsername(t, "", domain.Account{}, nil)
+		handler := makeGetAccountByUsernameHandler(getAccountByUsername)
+
+		req := makeRequest("§ko01Y")
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		body := w.Body.String()
+		parsed := parseResponse(t, body)
+		require.NotNil(t, parsed.Success)
+		require.False(t, *parsed.Success)
+		require.Nil(t, parsed.UUID)
+		require.NotNil(t, parsed.Cause)
+		require.Contains(t, *parsed.Cause, "invalid username")
+
+		require.False(t, *called)
+		require.Equal(t, "application/json", w.Result().Header.Get("Content-Type"))
+	})
+
+	t.Run("rejects username with unicode replacement char", func(t *testing.T) {
+		t.Parallel()
+
+		getAccountByUsername, called := makeGetAccountByUsername(t, "", domain.Account{}, nil)
+		handler := makeGetAccountByUsernameHandler(getAccountByUsername)
+
+		req := makeRequest("foo�bar")
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		body := w.Body.String()
+		parsed := parseResponse(t, body)
+		require.NotNil(t, parsed.Success)
+		require.False(t, *parsed.Success)
+		require.Nil(t, parsed.UUID)
+		require.NotNil(t, parsed.Cause)
+		require.Contains(t, *parsed.Cause, "invalid username")
+
+		require.False(t, *called)
+		require.Equal(t, "application/json", w.Result().Header.Get("Content-Type"))
+	})
+
 	t.Run("returns cors headers", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
- **fix(mojang): Surface error responses before normalizing UUID**
- **fix(ports): Reject usernames with section sign or replacement char**
- **fix(urchin): Treat "Invalid source(s)" string response as transient**
- **fix(urchin): Treat context deadline as transient send error**
- **fix(urchin): Redact key= query param from send-error messages**
