### PR TITLE
ci: Use golangci-lint-action with cached analyzer

### DIFF
--- a/.github/workflows/check-tool-versions.yml
+++ b/.github/workflows/check-tool-versions.yml
@@ -30,8 +30,8 @@ jobs:
 
       - name: Check golangci-lint version matches pre-commit config
         run: |
-          GOMOD_VERSION=$(go tool golangci-lint --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)
-          PRECOMMIT_VERSION=$(grep -A1 'golangci/golangci-lint' .pre-commit-config.yaml | grep 'rev:' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          GOMOD_VERSION=$(go list -m -f '{{.Version}}' github.com/golangci/golangci-lint/v2)
+          PRECOMMIT_VERSION=$(grep -A1 'golangci/golangci-lint' .pre-commit-config.yaml | grep 'rev:' | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+')
           echo "golangci-lint version in go.mod: $GOMOD_VERSION"
           echo "golangci-lint version in .pre-commit-config.yaml: $PRECOMMIT_VERSION"
           if [ "$GOMOD_VERSION" != "$PRECOMMIT_VERSION" ]; then

--- a/.github/workflows/test-and-deploy.yaml
+++ b/.github/workflows/test-and-deploy.yaml
@@ -43,8 +43,10 @@ jobs:
           go mod tidy
           git diff --quiet
 
+      # No `version:` input — the action auto-detects from go.mod's require
+      # directive (same version `go tool golangci-lint` resolves to).
       - name: Lint
-        run: go tool golangci-lint run
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
 
       - name: Verify dependencies
         run: go mod verify


### PR DESCRIPTION
## Summary

- Switch lint step to `golangci/golangci-lint-action@v9.2.0`, which caches `~/.cache/golangci-lint` between runs. Expected savings: ~25–40s off the ~68s lint step (cold ~68s → warm ~30s).
- The action auto-detects the version from `go.mod`'s `github.com/golangci/golangci-lint/v2` require directive (verified in [v9.2.0 `src/version.ts`](https://github.com/golangci/golangci-lint-action/blob/v9.2.0/src/version.ts)), so it installs the same module version `go tool golangci-lint` would compile — no version input needed.
- Simplify `check-tool-versions.yml` to read the version via `go list -m` instead of compiling and running `go tool golangci-lint --version`. Per [Go modules reference — tool directive](https://go.dev/ref/mod), `go tool` uses the same `require`-directive version that `go list -m` reports, so this is the same value without paying the compile cost.

## Test plan

- [ ] Lint job runs on this PR and reports the auto-detected version `v2.11.4` in its logs.
- [ ] Subsequent runs hit the analyzer cache and complete noticeably faster than the cold run.
- [ ] `check-tool-versions` continues to pass (go.mod `v2.11.4` matches `.pre-commit-config.yaml`'s `rev: v2.11.4`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)