### PR TITLE
chore(docker): Switch base image to distroless static

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,17 +9,11 @@ RUN go mod download
 COPY main.go ./
 COPY internal/ ./internal/
 
-# Disable cgo and use the builtin network stack to get a statically linked binary
-#   https://blog.wollomatic.de/posts/2025-01-28-go-tls-certificates/
-# Use -tags timetzdata to include timezone data in the binary since it isn't installed in the container
-#   https://pkg.go.dev/time#LoadLocation
-#   https://pkg.go.dev/time/tzdata
-RUN CGO_ENABLED=0 GOOS=linux go build -tags=netgo,timetzdata -o /flashlight main.go
+# Statically linked binary; ca-certificates and tzdata come from the distroless base image.
+RUN CGO_ENABLED=0 GOOS=linux go build -o /flashlight main.go
 
-FROM scratch
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:a9329520abc449e3b14d5bc3a6ffae065bdde0f02667fa10880c49b35c109fd1
 
 COPY --from=build /flashlight /flashlight
-
-USER 1001:1001
 
 ENTRYPOINT ["/flashlight"]

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
-	golang.org/x/crypto/x509roots/fallback v0.0.0-20250916063316-ddb4e80c6ad3
 	golang.org/x/time v0.15.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -731,8 +731,6 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliYc=
 golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
-golang.org/x/crypto/x509roots/fallback v0.0.0-20250916063316-ddb4e80c6ad3 h1:tDKyJPWK+Jz1G5l0ECsDbiDrLveZP7k6+i2dUdxz9os=
-golang.org/x/crypto/x509roots/fallback v0.0.0-20250916063316-ddb4e80c6ad3/go.mod h1:MEIPiCnxvQEjA4astfaKItNwEVZA5Ki+3+nyGbJ5N18=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/main.go
+++ b/main.go
@@ -29,8 +29,6 @@ import (
 	"github.com/Amund211/flashlight/internal/ports"
 	"github.com/Amund211/flashlight/internal/reporting"
 	"github.com/Amund211/flashlight/internal/telemetry"
-
-	_ "golang.org/x/crypto/x509roots/fallback" // Add fallback certs (for running in docker scratch image without ca-certificates)
 )
 
 // TODO: Put in config


### PR DESCRIPTION
## Summary
- Replaces scratch base + bundled CA roots + bundled tzdata with `gcr.io/distroless/static-debian12:nonroot`, pinned by digest so Dependabot can propose updates.
- Drops `golang.org/x/crypto/x509roots/fallback`, `-tags=timetzdata`, `-tags=netgo`, and the `USER 1001:1001` line (the `:nonroot` tag sets uid 65532).
- CA certs and tzdata now come from the base image; the binary is otherwise unchanged.

## Why
Centralizes the CA bundle update path on Debian's `ca-certificates` package (refreshed via the distroless image rebuild → Dependabot digest PR) instead of a Go module bump, and lets us drop two build tags plus an import. Image still ~static (no libc).

## Test plan
- [x] `go mod tidy` clean
- [x] `CGO_ENABLED=0 GOOS=linux go build` succeeds
- [x] `docker build` succeeds; final image ~29 MB
- [x] Inside the new image: `time.LoadLocation("Europe/Oslo")` works and `x509.SystemCertPool()` returns 142 roots
- [x] `flashlight` binary starts inside the image (exits cleanly on missing `FLASHLIGHT_ENVIRONMENT`, slog JSON output verified)
- [x] Pre-commit hooks pass (golangci-lint, go-build-mod, go-test-mod, go-mod-tidy)

## Dependabot
No config change — the existing `package-ecosystem: docker, directory: /` entry already covers `/Dockerfile`, so it will track digest updates of `:nonroot`. Heads-up: that entry has `cooldown` enabled, and `:nonroot` is a multi-arch index — same situation `/collector` ran into (dependabot-core#14044). If runs start failing, drop cooldown from the `/` entry too.