### PR TITLE
refactor(domaintest): New interface for PlayerBuilder

### DIFF
--- a/internal/adapters/playerrepository/repository_test.go
+++ b/internal/adapters/playerrepository/repository_test.go
@@ -110,7 +110,7 @@ func TestPostgresPlayerRepository(t *testing.T) {
 			t.Parallel()
 
 			playerUUID := domaintest.NewUUID(t)
-			player := domaintest.NewPlayerBuilder(playerUUID, now).WithGamesPlayed(0).BuildPtr()
+			player := domaintest.NewPlayerBuilder(playerUUID, now).Fours().WithGamesPlayed(0).BuildPtr()
 
 			requireNotStored(t, player)
 			err := p.StorePlayer(ctx, player)
@@ -124,8 +124,8 @@ func TestPostgresPlayerRepository(t *testing.T) {
 			t1 := now
 			t2 := t1.Add(3 * time.Minute)
 
-			player1 := domaintest.NewPlayerBuilder(playerUUID, t1).WithGamesPlayed(1).BuildPtr()
-			player2 := domaintest.NewPlayerBuilder(playerUUID, t2).WithGamesPlayed(2).BuildPtr()
+			player1 := domaintest.NewPlayerBuilder(playerUUID, t1).Fours().WithGamesPlayed(1).BuildPtr()
+			player2 := domaintest.NewPlayerBuilder(playerUUID, t2).Fours().WithGamesPlayed(2).BuildPtr()
 
 			requireNotStored(t, player1)
 			err := p.StorePlayer(ctx, player1)
@@ -138,9 +138,9 @@ func TestPostgresPlayerRepository(t *testing.T) {
 			requireStoredOnce(t, player2)
 
 			// We never stored these combinations
-			player1t2 := domaintest.NewPlayerBuilder(playerUUID, t2).WithGamesPlayed(1).BuildPtr()
+			player1t2 := domaintest.NewPlayerBuilder(playerUUID, t2).Fours().WithGamesPlayed(1).BuildPtr()
 			requireNotStored(t, player1t2)
-			player2t1 := domaintest.NewPlayerBuilder(playerUUID, t1).WithGamesPlayed(2).BuildPtr()
+			player2t1 := domaintest.NewPlayerBuilder(playerUUID, t1).Fours().WithGamesPlayed(2).BuildPtr()
 			requireNotStored(t, player2t1)
 		})
 
@@ -149,7 +149,7 @@ func TestPostgresPlayerRepository(t *testing.T) {
 			playerUUID := domaintest.NewUUID(t)
 			t1 := now
 
-			player1 := domaintest.NewPlayerBuilder(playerUUID, t1).WithGamesPlayed(1).BuildPtr()
+			player1 := domaintest.NewPlayerBuilder(playerUUID, t1).Fours().WithGamesPlayed(1).BuildPtr()
 
 			requireNotStored(t, player1)
 			err := p.StorePlayer(ctx, player1)
@@ -157,7 +157,7 @@ func TestPostgresPlayerRepository(t *testing.T) {
 			requireStoredOnce(t, player1)
 
 			t2 := t1.Add(time.Millisecond)
-			player2 := domaintest.NewPlayerBuilder(playerUUID, t2).WithGamesPlayed(2).BuildPtr()
+			player2 := domaintest.NewPlayerBuilder(playerUUID, t2).Fours().WithGamesPlayed(2).BuildPtr()
 
 			requireNotStored(t, player2)
 			err = p.StorePlayer(ctx, player2)
@@ -170,7 +170,7 @@ func TestPostgresPlayerRepository(t *testing.T) {
 			playerUUID := domaintest.NewUUID(t)
 
 			t1 := now
-			player1 := domaintest.NewPlayerBuilder(playerUUID, t1).WithGamesPlayed(1).BuildPtr()
+			player1 := domaintest.NewPlayerBuilder(playerUUID, t1).Fours().WithGamesPlayed(1).BuildPtr()
 
 			requireNotStored(t, player1)
 			err := p.StorePlayer(ctx, player1)
@@ -179,7 +179,7 @@ func TestPostgresPlayerRepository(t *testing.T) {
 
 			for i := 1; i < 60; i++ {
 				t2 := t1.Add(time.Duration(i) * time.Minute)
-				player2 := domaintest.NewPlayerBuilder(playerUUID, t2).WithGamesPlayed(1).BuildPtr()
+				player2 := domaintest.NewPlayerBuilder(playerUUID, t2).Fours().WithGamesPlayed(1).BuildPtr()
 				requireNotStored(t, player2)
 				err = p.StorePlayer(ctx, player2)
 				require.NoError(t, err)
@@ -192,7 +192,7 @@ func TestPostgresPlayerRepository(t *testing.T) {
 			playerUUID := domaintest.NewUUID(t)
 
 			t1 := now
-			player1 := domaintest.NewPlayerBuilder(playerUUID, t1).WithGamesPlayed(1).BuildPtr()
+			player1 := domaintest.NewPlayerBuilder(playerUUID, t1).Fours().WithGamesPlayed(1).BuildPtr()
 
 			requireNotStored(t, player1)
 			err := p.StorePlayer(ctx, player1)
@@ -201,7 +201,7 @@ func TestPostgresPlayerRepository(t *testing.T) {
 
 			// Consecutive duplicate data is more than an hour old -> store this one
 			t2 := t1.Add(1 * time.Hour)
-			player2 := domaintest.NewPlayerBuilder(playerUUID, t2).WithGamesPlayed(1).BuildPtr()
+			player2 := domaintest.NewPlayerBuilder(playerUUID, t2).Fours().WithGamesPlayed(1).BuildPtr()
 
 			err = p.StorePlayer(ctx, player2)
 			require.NoError(t, err)
@@ -213,7 +213,7 @@ func TestPostgresPlayerRepository(t *testing.T) {
 			playerUUID := domaintest.NewUUID(t)
 
 			t1 := now
-			player1 := domaintest.NewPlayerBuilder(playerUUID, t1).WithGamesPlayed(1).BuildPtr()
+			player1 := domaintest.NewPlayerBuilder(playerUUID, t1).Fours().WithGamesPlayed(1).BuildPtr()
 
 			requireNotStored(t, player1)
 			err := p.StorePlayer(ctx, player1)
@@ -221,7 +221,7 @@ func TestPostgresPlayerRepository(t *testing.T) {
 			requireStoredOnce(t, player1)
 
 			t2 := t1.Add(2 * time.Minute)
-			player2 := domaintest.NewPlayerBuilder(playerUUID, t2).WithGamesPlayed(2).BuildPtr()
+			player2 := domaintest.NewPlayerBuilder(playerUUID, t2).Fours().WithGamesPlayed(2).BuildPtr()
 
 			requireNotStored(t, player2)
 			err = p.StorePlayer(ctx, player2)
@@ -230,7 +230,7 @@ func TestPostgresPlayerRepository(t *testing.T) {
 
 			// Old duplicate data is not consecutive any more -> store it
 			t3 := t2.Add(2 * time.Minute)
-			player3 := domaintest.NewPlayerBuilder(playerUUID, t3).WithGamesPlayed(1).BuildPtr()
+			player3 := domaintest.NewPlayerBuilder(playerUUID, t3).Fours().WithGamesPlayed(1).BuildPtr()
 			requireNotStored(t, player3)
 			err = p.StorePlayer(ctx, player3)
 			require.NoError(t, err)
@@ -268,7 +268,7 @@ func TestPostgresPlayerRepository(t *testing.T) {
 			require.NoError(t, err)
 
 			t2 := t1.Add(2 * time.Minute)
-			player2 := domaintest.NewPlayerBuilder(playerUUID, t2).WithGamesPlayed(1).BuildPtr()
+			player2 := domaintest.NewPlayerBuilder(playerUUID, t2).Fours().WithGamesPlayed(1).BuildPtr()
 			err = p.StorePlayer(ctx, player2)
 			require.NoError(t, err)
 			requireStoredOnce(t, player2)
@@ -279,8 +279,8 @@ func TestPostgresPlayerRepository(t *testing.T) {
 			t1 := now
 			uuid1 := domaintest.NewUUID(t)
 			uuid2 := domaintest.NewUUID(t)
-			player1 := domaintest.NewPlayerBuilder(uuid1, t1).WithGamesPlayed(3).BuildPtr()
-			player2 := domaintest.NewPlayerBuilder(uuid2, t1).WithGamesPlayed(3).BuildPtr()
+			player1 := domaintest.NewPlayerBuilder(uuid1, t1).Fours().WithGamesPlayed(3).BuildPtr()
+			player2 := domaintest.NewPlayerBuilder(uuid2, t1).Fours().WithGamesPlayed(3).BuildPtr()
 
 			requireNotStored(t, player1)
 			err := p.StorePlayer(ctx, player1)
@@ -316,7 +316,7 @@ func TestPostgresPlayerRepository(t *testing.T) {
 				for i := range limit {
 					t1 := now.Add(time.Duration(i) * time.Minute)
 					playerUUID := domaintest.NewUUID(t)
-					player := domaintest.NewPlayerBuilder(playerUUID, t1).WithGamesPlayed(i).BuildPtr()
+					player := domaintest.NewPlayerBuilder(playerUUID, t1).Fours().WithGamesPlayed(i).BuildPtr()
 
 					err := p.StorePlayer(ctx, player)
 					require.NoError(t, err)
@@ -327,7 +327,7 @@ func TestPostgresPlayerRepository(t *testing.T) {
 				t.Parallel()
 				playerUUID := domaintest.NewUUID(t)
 				t1 := now
-				player := domaintest.NewPlayerBuilder(playerUUID, t1).WithGamesPlayed(1).BuildPtr()
+				player := domaintest.NewPlayerBuilder(playerUUID, t1).Fours().WithGamesPlayed(1).BuildPtr()
 
 				for range limit {
 					err := p.StorePlayer(ctx, player)
@@ -342,7 +342,7 @@ func TestPostgresPlayerRepository(t *testing.T) {
 			t.Parallel()
 
 			playerUUID := domaintest.NewUUID(t)
-			player := domaintest.NewPlayerBuilder(playerUUID, now).WithGamesPlayed(11).BuildPtr()
+			player := domaintest.NewPlayerBuilder(playerUUID, now).Fours().WithGamesPlayed(11).BuildPtr()
 
 			requireNotStored(t, player)
 			err := p.StorePlayer(ctx, player)
@@ -402,10 +402,10 @@ func TestPostgresPlayerRepository(t *testing.T) {
 
 			playerUUID := domaintest.NewUUID(t)
 
-			p1 := domaintest.NewPlayerBuilder(playerUUID, now.Add(-2*time.Hour)).WithGamesPlayed(1).BuildPtr()
-			p2 := domaintest.NewPlayerBuilder(playerUUID, now).WithGamesPlayed(2).BuildPtr()
-			p3 := domaintest.NewPlayerBuilder(playerUUID, now.Add(2*time.Minute)).WithGamesPlayed(3).BuildPtr()
-			p4 := domaintest.NewPlayerBuilder(playerUUID, now.Add(2*time.Hour)).WithGamesPlayed(4).BuildPtr()
+			p1 := domaintest.NewPlayerBuilder(playerUUID, now.Add(-2*time.Hour)).Fours().WithGamesPlayed(1).BuildPtr()
+			p2 := domaintest.NewPlayerBuilder(playerUUID, now).Fours().WithGamesPlayed(2).BuildPtr()
+			p3 := domaintest.NewPlayerBuilder(playerUUID, now.Add(2*time.Minute)).Fours().WithGamesPlayed(3).BuildPtr()
+			p4 := domaintest.NewPlayerBuilder(playerUUID, now.Add(2*time.Hour)).Fours().WithGamesPlayed(4).BuildPtr()
 
 			storePlayers(t, p, p1, p2, p3, p4)
 
@@ -541,7 +541,7 @@ func TestPostgresPlayerRepository(t *testing.T) {
 
 			toStore := make([]*domain.PlayerPIT, count)
 			for i := range count {
-				toStore[i] = domaintest.NewPlayerBuilder(playerUUID, now.Add(time.Duration(i)*time.Minute)).WithGamesPlayed(i).BuildPtr()
+				toStore[i] = domaintest.NewPlayerBuilder(playerUUID, now.Add(time.Duration(i)*time.Minute)).Fours().WithGamesPlayed(i).BuildPtr()
 			}
 
 			storePlayers(t, p, toStore...)
@@ -627,7 +627,7 @@ func TestPostgresPlayerRepository(t *testing.T) {
 			for i := range count + 1 {
 				players = append(
 					players,
-					domaintest.NewPlayerBuilder(playerUUID, janFirst21.Add(time.Duration(i)*interval)).WithGamesPlayed(i).BuildPtr(),
+					domaintest.NewPlayerBuilder(playerUUID, janFirst21.Add(time.Duration(i)*interval)).Fours().WithGamesPlayed(i).BuildPtr(),
 				)
 			}
 
@@ -659,31 +659,31 @@ func TestPostgresPlayerRepository(t *testing.T) {
 
 			players := make([]*domain.PlayerPIT, 13)
 			// Before start
-			players[0] = domaintest.NewPlayerBuilder(playerUUID, start.Add(0*time.Hour).Add(-1*time.Minute)).WithGamesPlayed(0).BuildPtr()
+			players[0] = domaintest.NewPlayerBuilder(playerUUID, start.Add(0*time.Hour).Add(-1*time.Minute)).Fours().WithGamesPlayed(0).BuildPtr()
 
 			// First 30 min interval
-			players[1] = domaintest.NewPlayerBuilder(playerUUID, start.Add(0*time.Hour).Add(7*time.Minute)).WithGamesPlayed(1).BuildPtr()
-			players[2] = domaintest.NewPlayerBuilder(playerUUID, start.Add(0*time.Hour).Add(17*time.Minute)).WithGamesPlayed(2).BuildPtr()
+			players[1] = domaintest.NewPlayerBuilder(playerUUID, start.Add(0*time.Hour).Add(7*time.Minute)).Fours().WithGamesPlayed(1).BuildPtr()
+			players[2] = domaintest.NewPlayerBuilder(playerUUID, start.Add(0*time.Hour).Add(17*time.Minute)).Fours().WithGamesPlayed(2).BuildPtr()
 
 			// Second 30 min interval
-			players[3] = domaintest.NewPlayerBuilder(playerUUID, start.Add(0*time.Hour).Add(37*time.Minute)).WithGamesPlayed(3).BuildPtr()
+			players[3] = domaintest.NewPlayerBuilder(playerUUID, start.Add(0*time.Hour).Add(37*time.Minute)).Fours().WithGamesPlayed(3).BuildPtr()
 
 			// Sixth 30 min interval
-			players[4] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(40*time.Minute)).WithGamesPlayed(4).BuildPtr()
-			players[5] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(45*time.Minute)).WithGamesPlayed(5).BuildPtr()
-			players[6] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(50*time.Minute)).WithGamesPlayed(6).BuildPtr()
-			players[7] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(55*time.Minute)).WithGamesPlayed(7).BuildPtr()
+			players[4] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(40*time.Minute)).Fours().WithGamesPlayed(4).BuildPtr()
+			players[5] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(45*time.Minute)).Fours().WithGamesPlayed(5).BuildPtr()
+			players[6] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(50*time.Minute)).Fours().WithGamesPlayed(6).BuildPtr()
+			players[7] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(55*time.Minute)).Fours().WithGamesPlayed(7).BuildPtr()
 
 			// Seventh 30 min interval
-			players[8] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(1*time.Minute)).WithGamesPlayed(8).BuildPtr()
+			players[8] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(1*time.Minute)).Fours().WithGamesPlayed(8).BuildPtr()
 
 			// Eighth 30 min interval
-			players[9] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(47*time.Minute)).WithGamesPlayed(9).BuildPtr()
-			players[10] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(59*time.Minute)).WithGamesPlayed(0).BuildPtr()
+			players[9] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(47*time.Minute)).Fours().WithGamesPlayed(9).BuildPtr()
+			players[10] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(59*time.Minute)).Fours().WithGamesPlayed(0).BuildPtr()
 
 			// After end
-			players[11] = domaintest.NewPlayerBuilder(playerUUID, start.Add(4*time.Hour).Add(1*time.Minute)).WithGamesPlayed(1).BuildPtr()
-			players[12] = domaintest.NewPlayerBuilder(playerUUID, start.Add(4000*time.Hour).Add(1*time.Minute)).WithGamesPlayed(2).BuildPtr()
+			players[11] = domaintest.NewPlayerBuilder(playerUUID, start.Add(4*time.Hour).Add(1*time.Minute)).Fours().WithGamesPlayed(1).BuildPtr()
+			players[12] = domaintest.NewPlayerBuilder(playerUUID, start.Add(4000*time.Hour).Add(1*time.Minute)).Fours().WithGamesPlayed(2).BuildPtr()
 
 			setStoredStats(t, p, players...)
 
@@ -747,7 +747,7 @@ func TestPostgresPlayerRepository(t *testing.T) {
 							t.Parallel()
 							playerUUID := domaintest.NewUUID(t)
 							players := []*domain.PlayerPIT{
-								domaintest.NewPlayerBuilder(playerUUID, queriedAt).WithGamesPlayed(1).BuildPtr(),
+								domaintest.NewPlayerBuilder(playerUUID, queriedAt).Fours().WithGamesPlayed(1).BuildPtr(),
 							}
 
 							storePlayer(t, p, players...)
@@ -783,8 +783,8 @@ func TestPostgresPlayerRepository(t *testing.T) {
 
 						playerUUID := domaintest.NewUUID(t)
 						players := []*domain.PlayerPIT{
-							domaintest.NewPlayerBuilder(playerUUID, start.Add(time.Minute)).WithGamesPlayed(1).BuildPtr(),
-							domaintest.NewPlayerBuilder(playerUUID, end.Add(-1*time.Minute)).WithGamesPlayed(0).BuildPtr(),
+							domaintest.NewPlayerBuilder(playerUUID, start.Add(time.Minute)).Fours().WithGamesPlayed(1).BuildPtr(),
+							domaintest.NewPlayerBuilder(playerUUID, end.Add(-1*time.Minute)).Fours().WithGamesPlayed(0).BuildPtr(),
 						}
 
 						storePlayer(t, p, players...)
@@ -816,8 +816,8 @@ func TestPostgresPlayerRepository(t *testing.T) {
 
 				playerUUID := domaintest.NewUUID(t)
 				players := []*domain.PlayerPIT{
-					domaintest.NewPlayerBuilder(playerUUID, start.Add(time.Minute)).WithGamesPlayed(1).BuildPtr(),
-					domaintest.NewPlayerBuilder(playerUUID, end.Add(-1*time.Minute)).WithGamesPlayed(0).BuildPtr(),
+					domaintest.NewPlayerBuilder(playerUUID, start.Add(time.Minute)).Fours().WithGamesPlayed(1).BuildPtr(),
+					domaintest.NewPlayerBuilder(playerUUID, end.Add(-1*time.Minute)).Fours().WithGamesPlayed(0).BuildPtr(),
 				}
 
 				storePlayer(t, p, players...)

--- a/internal/app/sessions_test.go
+++ b/internal/app/sessions_test.go
@@ -79,40 +79,40 @@ func TestComputeSessions(t *testing.T) {
 
 		players := make([]domain.PlayerPIT, 26)
 		// Ended session before the start
-		players[0] = domaintest.NewPlayerBuilder(playerUUID, start.Add(-8*time.Hour).Add(-1*time.Minute)).WithGamesPlayed(10).WithExperience(1_000).FromDB().Build()
-		players[1] = domaintest.NewPlayerBuilder(playerUUID, start.Add(-8*time.Hour).Add(7*time.Minute)).WithGamesPlayed(11).WithExperience(1_300).FromDB().Build()
-		players[2] = domaintest.NewPlayerBuilder(playerUUID, start.Add(-8*time.Hour).Add(17*time.Minute)).WithGamesPlayed(12).WithExperience(1_600).FromDB().Build()
+		players[0] = domaintest.NewPlayerBuilder(playerUUID, start.Add(-8*time.Hour).Add(-1*time.Minute)).WithExperience(1_000).FromDB().Fours().WithGamesPlayed(10).Build()
+		players[1] = domaintest.NewPlayerBuilder(playerUUID, start.Add(-8*time.Hour).Add(7*time.Minute)).WithExperience(1_300).FromDB().Fours().WithGamesPlayed(11).Build()
+		players[2] = domaintest.NewPlayerBuilder(playerUUID, start.Add(-8*time.Hour).Add(17*time.Minute)).WithExperience(1_600).FromDB().Fours().WithGamesPlayed(12).Build()
 
 		// Session starting just before the start
 		// Some inactivity at the start of the session
-		players[3] = domaintest.NewPlayerBuilder(playerUUID, start.Add(0*time.Hour).Add(-37*time.Minute)).WithGamesPlayed(12).WithExperience(1_600).FromDB().Build()
-		players[4] = domaintest.NewPlayerBuilder(playerUUID, start.Add(0*time.Hour).Add(-27*time.Minute)).WithGamesPlayed(12).WithExperience(1_600).FromDB().Build()
-		players[5] = domaintest.NewPlayerBuilder(playerUUID, start.Add(0*time.Hour).Add(-17*time.Minute)).WithGamesPlayed(12).WithExperience(1_600).FromDB().Build()
-		players[6] = domaintest.NewPlayerBuilder(playerUUID, start.Add(0*time.Hour).Add(-12*time.Minute)).WithGamesPlayed(13).WithExperience(1_900).FromDB().Build()
-		players[7] = domaintest.NewPlayerBuilder(playerUUID, start.Add(0*time.Hour).Add(2*time.Minute)).WithGamesPlayed(14).WithExperience(2_200).FromDB().Build()
+		players[3] = domaintest.NewPlayerBuilder(playerUUID, start.Add(0*time.Hour).Add(-37*time.Minute)).WithExperience(1_600).FromDB().Fours().WithGamesPlayed(12).Build()
+		players[4] = domaintest.NewPlayerBuilder(playerUUID, start.Add(0*time.Hour).Add(-27*time.Minute)).WithExperience(1_600).FromDB().Fours().WithGamesPlayed(12).Build()
+		players[5] = domaintest.NewPlayerBuilder(playerUUID, start.Add(0*time.Hour).Add(-17*time.Minute)).WithExperience(1_600).FromDB().Fours().WithGamesPlayed(12).Build()
+		players[6] = domaintest.NewPlayerBuilder(playerUUID, start.Add(0*time.Hour).Add(-12*time.Minute)).WithExperience(1_900).FromDB().Fours().WithGamesPlayed(13).Build()
+		players[7] = domaintest.NewPlayerBuilder(playerUUID, start.Add(0*time.Hour).Add(2*time.Minute)).WithExperience(2_200).FromDB().Fours().WithGamesPlayed(14).Build()
 		// One hour space between entries
-		players[8] = domaintest.NewPlayerBuilder(playerUUID, start.Add(0*time.Hour).Add(38*time.Minute)).WithGamesPlayed(15).WithExperience(7_200).FromDB().Build()
-		players[9] = domaintest.NewPlayerBuilder(playerUUID, start.Add(1*time.Hour).Add(38*time.Minute)).WithGamesPlayed(16).WithExperience(7_900).FromDB().Build()
+		players[8] = domaintest.NewPlayerBuilder(playerUUID, start.Add(0*time.Hour).Add(38*time.Minute)).WithExperience(7_200).FromDB().Fours().WithGamesPlayed(15).Build()
+		players[9] = domaintest.NewPlayerBuilder(playerUUID, start.Add(1*time.Hour).Add(38*time.Minute)).WithExperience(7_900).FromDB().Fours().WithGamesPlayed(16).Build()
 		// One hour space between stat change, with some inactivity events in between
-		players[10] = domaintest.NewPlayerBuilder(playerUUID, start.Add(1*time.Hour).Add(45*time.Minute)).WithGamesPlayed(17).WithExperience(8_900).FromDB().Build()
-		players[11] = domaintest.NewPlayerBuilder(playerUUID, start.Add(1*time.Hour).Add(55*time.Minute)).WithGamesPlayed(17).WithExperience(8_900).FromDB().Build()
-		players[12] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(5*time.Minute)).WithGamesPlayed(17).WithExperience(8_900).FromDB().Build()
-		players[13] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(15*time.Minute)).WithGamesPlayed(17).WithExperience(8_900).FromDB().Build()
-		players[14] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(25*time.Minute)).WithGamesPlayed(17).WithExperience(8_900).FromDB().Build()
-		players[15] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(35*time.Minute)).WithGamesPlayed(17).WithExperience(8_900).FromDB().Build()
-		players[16] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(45*time.Minute)).WithGamesPlayed(18).WithExperience(9_500).FromDB().Build()
+		players[10] = domaintest.NewPlayerBuilder(playerUUID, start.Add(1*time.Hour).Add(45*time.Minute)).WithExperience(8_900).FromDB().Fours().WithGamesPlayed(17).Build()
+		players[11] = domaintest.NewPlayerBuilder(playerUUID, start.Add(1*time.Hour).Add(55*time.Minute)).WithExperience(8_900).FromDB().Fours().WithGamesPlayed(17).Build()
+		players[12] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(5*time.Minute)).WithExperience(8_900).FromDB().Fours().WithGamesPlayed(17).Build()
+		players[13] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(15*time.Minute)).WithExperience(8_900).FromDB().Fours().WithGamesPlayed(17).Build()
+		players[14] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(25*time.Minute)).WithExperience(8_900).FromDB().Fours().WithGamesPlayed(17).Build()
+		players[15] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(35*time.Minute)).WithExperience(8_900).FromDB().Fours().WithGamesPlayed(17).Build()
+		players[16] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(45*time.Minute)).WithExperience(9_500).FromDB().Fours().WithGamesPlayed(18).Build()
 		// Some inactivity at the end
-		players[17] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(55*time.Minute)).WithGamesPlayed(18).WithExperience(9_500).FromDB().Build()
-		players[18] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(5*time.Minute)).WithGamesPlayed(18).WithExperience(9_500).FromDB().Build()
-		players[19] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(15*time.Minute)).WithGamesPlayed(18).WithExperience(9_500).FromDB().Build()
-		players[20] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(25*time.Minute)).WithGamesPlayed(18).WithExperience(9_500).FromDB().Build()
-		players[21] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(35*time.Minute)).WithGamesPlayed(18).WithExperience(9_500).FromDB().Build()
-		players[22] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(45*time.Minute)).WithGamesPlayed(18).WithExperience(9_500).FromDB().Build()
-		players[23] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(55*time.Minute)).WithGamesPlayed(18).WithExperience(9_500).FromDB().Build()
+		players[17] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(55*time.Minute)).WithExperience(9_500).FromDB().Fours().WithGamesPlayed(18).Build()
+		players[18] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(5*time.Minute)).WithExperience(9_500).FromDB().Fours().WithGamesPlayed(18).Build()
+		players[19] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(15*time.Minute)).WithExperience(9_500).FromDB().Fours().WithGamesPlayed(18).Build()
+		players[20] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(25*time.Minute)).WithExperience(9_500).FromDB().Fours().WithGamesPlayed(18).Build()
+		players[21] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(35*time.Minute)).WithExperience(9_500).FromDB().Fours().WithGamesPlayed(18).Build()
+		players[22] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(45*time.Minute)).WithExperience(9_500).FromDB().Fours().WithGamesPlayed(18).Build()
+		players[23] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(55*time.Minute)).WithExperience(9_500).FromDB().Fours().WithGamesPlayed(18).Build()
 
 		// New activity 71 minutes after the last entry -> new session
-		players[24] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(56*time.Minute)).WithGamesPlayed(18).WithExperience(9_500).FromDB().Build()
-		players[25] = domaintest.NewPlayerBuilder(playerUUID, start.Add(4*time.Hour).Add(16*time.Minute)).WithGamesPlayed(19).WithExperience(10_800).FromDB().Build()
+		players[24] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(56*time.Minute)).WithExperience(9_500).FromDB().Fours().WithGamesPlayed(18).Build()
+		players[25] = domaintest.NewPlayerBuilder(playerUUID, start.Add(4*time.Hour).Add(16*time.Minute)).WithExperience(10_800).FromDB().Fours().WithGamesPlayed(19).Build()
 
 		sessions := computeSessions(ctx, players, start, start.Add(24*time.Hour))
 
@@ -139,7 +139,7 @@ func TestComputeSessions(t *testing.T) {
 		start := time.Date(2021, time.January, 1, 0, 0, 0, 0, time.FixedZone("UTC", -3600*8))
 
 		players := make([]domain.PlayerPIT, 1)
-		players[0] = domaintest.NewPlayerBuilder(playerUUID, start.Add(6*time.Hour).Add(7*time.Minute)).WithGamesPlayed(11).WithExperience(1_300).FromDB().Build()
+		players[0] = domaintest.NewPlayerBuilder(playerUUID, start.Add(6*time.Hour).Add(7*time.Minute)).WithExperience(1_300).FromDB().Fours().WithGamesPlayed(11).Build()
 
 		sessions := computeSessions(ctx, players, start, start.Add(24*time.Hour))
 
@@ -154,10 +154,10 @@ func TestComputeSessions(t *testing.T) {
 		start := time.Date(2021, time.January, 1, 0, 0, 0, 0, time.FixedZone("UTC", -3600*8))
 
 		players := make([]domain.PlayerPIT, 3)
-		players[0] = domaintest.NewPlayerBuilder(playerUUID, start.Add(6*time.Hour).Add(7*time.Minute)).WithGamesPlayed(9).WithExperience(1_000).FromDB().Build()
+		players[0] = domaintest.NewPlayerBuilder(playerUUID, start.Add(6*time.Hour).Add(7*time.Minute)).WithExperience(1_000).FromDB().Fours().WithGamesPlayed(9).Build()
 
-		players[1] = domaintest.NewPlayerBuilder(playerUUID, start.Add(8*time.Hour).Add(-1*time.Minute)).WithGamesPlayed(10).WithExperience(1_100).FromDB().Build()
-		players[2] = domaintest.NewPlayerBuilder(playerUUID, start.Add(8*time.Hour).Add(7*time.Minute)).WithGamesPlayed(11).WithExperience(1_300).FromDB().Build()
+		players[1] = domaintest.NewPlayerBuilder(playerUUID, start.Add(8*time.Hour).Add(-1*time.Minute)).WithExperience(1_100).FromDB().Fours().WithGamesPlayed(10).Build()
+		players[2] = domaintest.NewPlayerBuilder(playerUUID, start.Add(8*time.Hour).Add(7*time.Minute)).WithExperience(1_300).FromDB().Fours().WithGamesPlayed(11).Build()
 
 		sessions := computeSessions(ctx, players, start, start.Add(24*time.Hour))
 
@@ -179,10 +179,10 @@ func TestComputeSessions(t *testing.T) {
 		start := time.Date(2021, time.January, 1, 0, 0, 0, 0, time.FixedZone("UTC", -3600*8))
 
 		players := make([]domain.PlayerPIT, 3)
-		players[0] = domaintest.NewPlayerBuilder(playerUUID, start.Add(6*time.Hour).Add(-1*time.Minute)).WithGamesPlayed(10).WithExperience(1_000).FromDB().Build()
-		players[1] = domaintest.NewPlayerBuilder(playerUUID, start.Add(6*time.Hour).Add(7*time.Minute)).WithGamesPlayed(11).WithExperience(1_300).FromDB().Build()
+		players[0] = domaintest.NewPlayerBuilder(playerUUID, start.Add(6*time.Hour).Add(-1*time.Minute)).WithExperience(1_000).FromDB().Fours().WithGamesPlayed(10).Build()
+		players[1] = domaintest.NewPlayerBuilder(playerUUID, start.Add(6*time.Hour).Add(7*time.Minute)).WithExperience(1_300).FromDB().Fours().WithGamesPlayed(11).Build()
 
-		players[2] = domaintest.NewPlayerBuilder(playerUUID, start.Add(8*time.Hour).Add(7*time.Minute)).WithGamesPlayed(12).WithExperience(1_600).FromDB().Build()
+		players[2] = domaintest.NewPlayerBuilder(playerUUID, start.Add(8*time.Hour).Add(7*time.Minute)).WithExperience(1_600).FromDB().Fours().WithGamesPlayed(12).Build()
 
 		sessions := computeSessions(ctx, players, start, start.Add(24*time.Hour))
 
@@ -204,12 +204,12 @@ func TestComputeSessions(t *testing.T) {
 		start := time.Date(2021, time.January, 1, 0, 0, 0, 0, time.FixedZone("UTC", -3600*2))
 
 		players := make([]domain.PlayerPIT, 4)
-		players[0] = domaintest.NewPlayerBuilder(playerUUID, start.Add(5*time.Hour).Add(7*time.Minute)).WithGamesPlayed(9).WithExperience(1_000).FromDB().Build()
+		players[0] = domaintest.NewPlayerBuilder(playerUUID, start.Add(5*time.Hour).Add(7*time.Minute)).WithExperience(1_000).FromDB().Fours().WithGamesPlayed(9).Build()
 
-		players[1] = domaintest.NewPlayerBuilder(playerUUID, start.Add(8*time.Hour).Add(-1*time.Minute)).WithGamesPlayed(10).WithExperience(1_000).FromDB().Build()
-		players[2] = domaintest.NewPlayerBuilder(playerUUID, start.Add(8*time.Hour).Add(7*time.Minute)).WithGamesPlayed(11).WithExperience(1_300).FromDB().Build()
+		players[1] = domaintest.NewPlayerBuilder(playerUUID, start.Add(8*time.Hour).Add(-1*time.Minute)).WithExperience(1_000).FromDB().Fours().WithGamesPlayed(10).Build()
+		players[2] = domaintest.NewPlayerBuilder(playerUUID, start.Add(8*time.Hour).Add(7*time.Minute)).WithExperience(1_300).FromDB().Fours().WithGamesPlayed(11).Build()
 
-		players[3] = domaintest.NewPlayerBuilder(playerUUID, start.Add(10*time.Hour).Add(7*time.Minute)).WithGamesPlayed(12).WithExperience(1_600).FromDB().Build()
+		players[3] = domaintest.NewPlayerBuilder(playerUUID, start.Add(10*time.Hour).Add(7*time.Minute)).WithExperience(1_600).FromDB().Fours().WithGamesPlayed(12).Build()
 
 		sessions := computeSessions(ctx, players, start, start.Add(24*time.Hour))
 
@@ -244,19 +244,19 @@ func TestComputeSessions(t *testing.T) {
 		start := time.Date(2021, time.January, 1, 0, 0, 0, 0, time.FixedZone("UTC", -3600*2))
 
 		players := make([]domain.PlayerPIT, 13)
-		players[0] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(30*time.Minute)).WithGamesPlayed(16).WithExperience(9_200).FromDB().Build()
-		players[1] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(35*time.Minute)).WithGamesPlayed(16).WithExperience(9_200).FromDB().Build()
-		players[2] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(45*time.Minute)).WithGamesPlayed(17).WithExperience(9_400).FromDB().Build()
-		players[3] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(55*time.Minute)).WithGamesPlayed(18).WithExperience(9_500).FromDB().Build()
-		players[4] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(5*time.Minute)).WithGamesPlayed(18).WithExperience(9_500).FromDB().Build()
-		players[5] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(15*time.Minute)).WithGamesPlayed(18).WithExperience(9_500).FromDB().Build()
-		players[6] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(25*time.Minute)).WithGamesPlayed(18).WithExperience(9_500).FromDB().Build()
-		players[7] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(35*time.Minute)).WithGamesPlayed(18).WithExperience(9_500).FromDB().Build()
-		players[8] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(45*time.Minute)).WithGamesPlayed(18).WithExperience(9_500).FromDB().Build()
-		players[9] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(55*time.Minute)).WithGamesPlayed(18).WithExperience(9_500).FromDB().Build()
-		players[10] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(56*time.Minute)).WithGamesPlayed(18).WithExperience(9_500).FromDB().Build()
-		players[11] = domaintest.NewPlayerBuilder(playerUUID, start.Add(4*time.Hour).Add(16*time.Minute)).WithGamesPlayed(19).WithExperience(10_800).FromDB().Build()
-		players[12] = domaintest.NewPlayerBuilder(playerUUID, start.Add(4*time.Hour).Add(20*time.Minute)).WithGamesPlayed(19).WithExperience(10_800).FromDB().Build()
+		players[0] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(30*time.Minute)).WithExperience(9_200).FromDB().Fours().WithGamesPlayed(16).Build()
+		players[1] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(35*time.Minute)).WithExperience(9_200).FromDB().Fours().WithGamesPlayed(16).Build()
+		players[2] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(45*time.Minute)).WithExperience(9_400).FromDB().Fours().WithGamesPlayed(17).Build()
+		players[3] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(55*time.Minute)).WithExperience(9_500).FromDB().Fours().WithGamesPlayed(18).Build()
+		players[4] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(5*time.Minute)).WithExperience(9_500).FromDB().Fours().WithGamesPlayed(18).Build()
+		players[5] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(15*time.Minute)).WithExperience(9_500).FromDB().Fours().WithGamesPlayed(18).Build()
+		players[6] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(25*time.Minute)).WithExperience(9_500).FromDB().Fours().WithGamesPlayed(18).Build()
+		players[7] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(35*time.Minute)).WithExperience(9_500).FromDB().Fours().WithGamesPlayed(18).Build()
+		players[8] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(45*time.Minute)).WithExperience(9_500).FromDB().Fours().WithGamesPlayed(18).Build()
+		players[9] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(55*time.Minute)).WithExperience(9_500).FromDB().Fours().WithGamesPlayed(18).Build()
+		players[10] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(56*time.Minute)).WithExperience(9_500).FromDB().Fours().WithGamesPlayed(18).Build()
+		players[11] = domaintest.NewPlayerBuilder(playerUUID, start.Add(4*time.Hour).Add(16*time.Minute)).WithExperience(10_800).FromDB().Fours().WithGamesPlayed(19).Build()
+		players[12] = domaintest.NewPlayerBuilder(playerUUID, start.Add(4*time.Hour).Add(20*time.Minute)).WithExperience(10_800).FromDB().Fours().WithGamesPlayed(19).Build()
 
 		sessions := computeSessions(ctx, players, start, start.Add(24*time.Hour))
 
@@ -284,11 +284,11 @@ func TestComputeSessions(t *testing.T) {
 
 		players := make([]domain.PlayerPIT, 4)
 		// Session 1
-		players[0] = domaintest.NewPlayerBuilder(playerUUID, start.Add(1*time.Hour).Add(5*time.Minute)).WithGamesPlayed(16).WithExperience(9_200).FromDB().Build()
-		players[1] = domaintest.NewPlayerBuilder(playerUUID, start.Add(1*time.Hour).Add(30*time.Minute)).WithGamesPlayed(17).WithExperience(9_400).FromDB().Build()
+		players[0] = domaintest.NewPlayerBuilder(playerUUID, start.Add(1*time.Hour).Add(5*time.Minute)).WithExperience(9_200).FromDB().Fours().WithGamesPlayed(16).Build()
+		players[1] = domaintest.NewPlayerBuilder(playerUUID, start.Add(1*time.Hour).Add(30*time.Minute)).WithExperience(9_400).FromDB().Fours().WithGamesPlayed(17).Build()
 		// Session 2
-		players[2] = domaintest.NewPlayerBuilder(playerUUID, start.Add(1*time.Hour).Add(45*time.Minute)).WithGamesPlayed(17).WithExperience(9_400).FromDB().Build()
-		players[3] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(31*time.Minute)).WithGamesPlayed(18).WithExperience(10_800).FromDB().Build()
+		players[2] = domaintest.NewPlayerBuilder(playerUUID, start.Add(1*time.Hour).Add(45*time.Minute)).WithExperience(9_400).FromDB().Fours().WithGamesPlayed(17).Build()
+		players[3] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(31*time.Minute)).WithExperience(10_800).FromDB().Fours().WithGamesPlayed(18).Build()
 
 		sessions := computeSessions(ctx, players, start, start.Add(24*time.Hour))
 
@@ -315,17 +315,17 @@ func TestComputeSessions(t *testing.T) {
 		start := time.Date(2021, time.January, 1, 0, 0, 0, 0, time.FixedZone("UTC", -3600*2))
 
 		players := make([]domain.PlayerPIT, 8)
-		players[0] = domaintest.NewPlayerBuilder(playerUUID, start.Add(-25*time.Hour).Add(5*time.Minute)).WithGamesPlayed(16).WithExperience(9_200).FromDB().Build()
-		players[1] = domaintest.NewPlayerBuilder(playerUUID, start.Add(-25*time.Hour).Add(30*time.Minute)).WithGamesPlayed(17).WithExperience(9_400).FromDB().Build()
+		players[0] = domaintest.NewPlayerBuilder(playerUUID, start.Add(-25*time.Hour).Add(5*time.Minute)).WithExperience(9_200).FromDB().Fours().WithGamesPlayed(16).Build()
+		players[1] = domaintest.NewPlayerBuilder(playerUUID, start.Add(-25*time.Hour).Add(30*time.Minute)).WithExperience(9_400).FromDB().Fours().WithGamesPlayed(17).Build()
 
-		players[2] = domaintest.NewPlayerBuilder(playerUUID, start.Add(-16*time.Hour).Add(5*time.Minute)).WithGamesPlayed(17).WithExperience(9_400).FromDB().Build()
-		players[3] = domaintest.NewPlayerBuilder(playerUUID, start.Add(-16*time.Hour).Add(30*time.Minute)).WithGamesPlayed(18).WithExperience(9_900).FromDB().Build()
+		players[2] = domaintest.NewPlayerBuilder(playerUUID, start.Add(-16*time.Hour).Add(5*time.Minute)).WithExperience(9_400).FromDB().Fours().WithGamesPlayed(17).Build()
+		players[3] = domaintest.NewPlayerBuilder(playerUUID, start.Add(-16*time.Hour).Add(30*time.Minute)).WithExperience(9_900).FromDB().Fours().WithGamesPlayed(18).Build()
 
-		players[4] = domaintest.NewPlayerBuilder(playerUUID, start.Add(25*time.Hour).Add(5*time.Minute)).WithGamesPlayed(18).WithExperience(9_900).FromDB().Build()
-		players[5] = domaintest.NewPlayerBuilder(playerUUID, start.Add(25*time.Hour).Add(30*time.Minute)).WithGamesPlayed(19).WithExperience(10_900).FromDB().Build()
+		players[4] = domaintest.NewPlayerBuilder(playerUUID, start.Add(25*time.Hour).Add(5*time.Minute)).WithExperience(9_900).FromDB().Fours().WithGamesPlayed(18).Build()
+		players[5] = domaintest.NewPlayerBuilder(playerUUID, start.Add(25*time.Hour).Add(30*time.Minute)).WithExperience(10_900).FromDB().Fours().WithGamesPlayed(19).Build()
 
-		players[6] = domaintest.NewPlayerBuilder(playerUUID, start.Add(45*time.Hour).Add(5*time.Minute)).WithGamesPlayed(19).WithExperience(10_900).FromDB().Build()
-		players[7] = domaintest.NewPlayerBuilder(playerUUID, start.Add(45*time.Hour).Add(30*time.Minute)).WithGamesPlayed(20).WithExperience(11_900).FromDB().Build()
+		players[6] = domaintest.NewPlayerBuilder(playerUUID, start.Add(45*time.Hour).Add(5*time.Minute)).WithExperience(10_900).FromDB().Fours().WithGamesPlayed(19).Build()
+		players[7] = domaintest.NewPlayerBuilder(playerUUID, start.Add(45*time.Hour).Add(30*time.Minute)).WithExperience(11_900).FromDB().Fours().WithGamesPlayed(20).Build()
 
 		sessions := computeSessions(ctx, players, start, start.Add(24*time.Hour))
 
@@ -342,11 +342,11 @@ func TestComputeSessions(t *testing.T) {
 
 		players := make([]domain.PlayerPIT, 4)
 		// Session 1
-		players[0] = domaintest.NewPlayerBuilder(playerUUID, start.Add(1*time.Hour).Add(5*time.Minute)).WithGamesPlayed(16).WithExperience(9_200).FromDB().Build()
-		players[1] = domaintest.NewPlayerBuilder(playerUUID, start.Add(1*time.Hour).Add(30*time.Minute)).WithGamesPlayed(16).WithExperience(9_400).FromDB().Build()
+		players[0] = domaintest.NewPlayerBuilder(playerUUID, start.Add(1*time.Hour).Add(5*time.Minute)).WithExperience(9_200).FromDB().Fours().WithGamesPlayed(16).Build()
+		players[1] = domaintest.NewPlayerBuilder(playerUUID, start.Add(1*time.Hour).Add(30*time.Minute)).WithExperience(9_400).FromDB().Fours().WithGamesPlayed(16).Build()
 		// Session 2
-		players[2] = domaintest.NewPlayerBuilder(playerUUID, start.Add(1*time.Hour).Add(45*time.Minute)).WithGamesPlayed(16).WithExperience(9_400).FromDB().Build()
-		players[3] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(31*time.Minute)).WithGamesPlayed(16).WithExperience(10_800).FromDB().Build()
+		players[2] = domaintest.NewPlayerBuilder(playerUUID, start.Add(1*time.Hour).Add(45*time.Minute)).WithExperience(9_400).FromDB().Fours().WithGamesPlayed(16).Build()
+		players[3] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(31*time.Minute)).WithExperience(10_800).FromDB().Fours().WithGamesPlayed(16).Build()
 
 		sessions := computeSessions(ctx, players, start, start.Add(24*time.Hour))
 
@@ -374,11 +374,11 @@ func TestComputeSessions(t *testing.T) {
 
 		players := make([]domain.PlayerPIT, 4)
 		// Session 1
-		players[0] = domaintest.NewPlayerBuilder(playerUUID, start.Add(1*time.Hour).Add(5*time.Minute)).WithGamesPlayed(16).WithExperience(9_200).FromDB().Build()
-		players[1] = domaintest.NewPlayerBuilder(playerUUID, start.Add(1*time.Hour).Add(30*time.Minute)).WithGamesPlayed(17).WithExperience(9_200).FromDB().Build()
+		players[0] = domaintest.NewPlayerBuilder(playerUUID, start.Add(1*time.Hour).Add(5*time.Minute)).WithExperience(9_200).FromDB().Fours().WithGamesPlayed(16).Build()
+		players[1] = domaintest.NewPlayerBuilder(playerUUID, start.Add(1*time.Hour).Add(30*time.Minute)).WithExperience(9_200).FromDB().Fours().WithGamesPlayed(17).Build()
 		// Session 2
-		players[2] = domaintest.NewPlayerBuilder(playerUUID, start.Add(1*time.Hour).Add(45*time.Minute)).WithGamesPlayed(17).WithExperience(9_200).FromDB().Build()
-		players[3] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(31*time.Minute)).WithGamesPlayed(18).WithExperience(9_200).FromDB().Build()
+		players[2] = domaintest.NewPlayerBuilder(playerUUID, start.Add(1*time.Hour).Add(45*time.Minute)).WithExperience(9_200).FromDB().Fours().WithGamesPlayed(17).Build()
+		players[3] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(31*time.Minute)).WithExperience(9_200).FromDB().Fours().WithGamesPlayed(18).Build()
 
 		sessions := computeSessions(ctx, players, start, start.Add(24*time.Hour))
 
@@ -410,22 +410,22 @@ func TestComputeSessions(t *testing.T) {
 		// turning into multiple calculated sessions.
 		players := make([]domain.PlayerPIT, 10)
 
-		players[0] = domaintest.NewPlayerBuilder(playerUUID, start.Add(1*time.Hour).Add(5*time.Minute)).WithGamesPlayed(16).WithExperience(9_200).FromDB().Build()
-		players[1] = domaintest.NewPlayerBuilder(playerUUID, start.Add(1*time.Hour).Add(30*time.Minute)).WithGamesPlayed(17).WithExperience(9_200).FromDB().Build()
+		players[0] = domaintest.NewPlayerBuilder(playerUUID, start.Add(1*time.Hour).Add(5*time.Minute)).WithExperience(9_200).FromDB().Fours().WithGamesPlayed(16).Build()
+		players[1] = domaintest.NewPlayerBuilder(playerUUID, start.Add(1*time.Hour).Add(30*time.Minute)).WithExperience(9_200).FromDB().Fours().WithGamesPlayed(17).Build()
 
-		players[2] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(45*time.Minute)).WithGamesPlayed(20).WithExperience(15_200).FromDB().Build()
+		players[2] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(45*time.Minute)).WithExperience(15_200).FromDB().Fours().WithGamesPlayed(20).Build()
 
-		players[3] = domaintest.NewPlayerBuilder(playerUUID, start.Add(5*time.Hour).Add(45*time.Minute)).WithGamesPlayed(23).WithExperience(17_200).FromDB().Build()
+		players[3] = domaintest.NewPlayerBuilder(playerUUID, start.Add(5*time.Hour).Add(45*time.Minute)).WithExperience(17_200).FromDB().Fours().WithGamesPlayed(23).Build()
 
-		players[4] = domaintest.NewPlayerBuilder(playerUUID, start.Add(7*time.Hour).Add(45*time.Minute)).WithGamesPlayed(27).WithExperience(19_200).FromDB().Build()
-		players[5] = domaintest.NewPlayerBuilder(playerUUID, start.Add(7*time.Hour).Add(55*time.Minute)).WithGamesPlayed(28).WithExperience(19_800).FromDB().Build()
+		players[4] = domaintest.NewPlayerBuilder(playerUUID, start.Add(7*time.Hour).Add(45*time.Minute)).WithExperience(19_200).FromDB().Fours().WithGamesPlayed(27).Build()
+		players[5] = domaintest.NewPlayerBuilder(playerUUID, start.Add(7*time.Hour).Add(55*time.Minute)).WithExperience(19_800).FromDB().Fours().WithGamesPlayed(28).Build()
 
-		players[6] = domaintest.NewPlayerBuilder(playerUUID, start.Add(9*time.Hour).Add(15*time.Minute)).WithGamesPlayed(30).WithExperience(20_800).FromDB().Build()
-		players[7] = domaintest.NewPlayerBuilder(playerUUID, start.Add(9*time.Hour).Add(55*time.Minute)).WithGamesPlayed(33).WithExperience(23_800).FromDB().Build()
+		players[6] = domaintest.NewPlayerBuilder(playerUUID, start.Add(9*time.Hour).Add(15*time.Minute)).WithExperience(20_800).FromDB().Fours().WithGamesPlayed(30).Build()
+		players[7] = domaintest.NewPlayerBuilder(playerUUID, start.Add(9*time.Hour).Add(55*time.Minute)).WithExperience(23_800).FromDB().Fours().WithGamesPlayed(33).Build()
 
-		players[8] = domaintest.NewPlayerBuilder(playerUUID, start.Add(11*time.Hour).Add(15*time.Minute)).WithGamesPlayed(35).WithExperience(28_800).FromDB().Build()
+		players[8] = domaintest.NewPlayerBuilder(playerUUID, start.Add(11*time.Hour).Add(15*time.Minute)).WithExperience(28_800).FromDB().Fours().WithGamesPlayed(35).Build()
 
-		players[9] = domaintest.NewPlayerBuilder(playerUUID, start.Add(17*time.Hour).Add(15*time.Minute)).WithGamesPlayed(44).WithExperience(38_800).FromDB().Build()
+		players[9] = domaintest.NewPlayerBuilder(playerUUID, start.Add(17*time.Hour).Add(15*time.Minute)).WithExperience(38_800).FromDB().Fours().WithGamesPlayed(44).Build()
 
 		sessions := computeSessions(ctx, players, start, start.Add(24*time.Hour))
 
@@ -457,9 +457,9 @@ func TestComputeSessions(t *testing.T) {
 		start := time.Date(2025, time.December, 9, 14, 13, 34, 987_654_321, time.FixedZone("UTC", 3600*0))
 
 		players := make([]domain.PlayerPIT, 3)
-		players[0] = domaintest.NewPlayerBuilder(playerUUID, start.Add(23*time.Hour).Add(5*time.Minute)).WithGamesPlayed(16).WithExperience(9_200).FromDB().Build()
-		players[1] = domaintest.NewPlayerBuilder(playerUUID, start.Add(23*time.Hour).Add(40*time.Minute)).WithGamesPlayed(17).WithExperience(9_500).FromDB().Build()
-		players[2] = domaintest.NewPlayerBuilder(playerUUID, start.Add(24*time.Hour).Add(05*time.Minute)).WithGamesPlayed(18).WithExperience(9_900).FromDB().Build()
+		players[0] = domaintest.NewPlayerBuilder(playerUUID, start.Add(23*time.Hour).Add(5*time.Minute)).WithExperience(9_200).FromDB().Fours().WithGamesPlayed(16).Build()
+		players[1] = domaintest.NewPlayerBuilder(playerUUID, start.Add(23*time.Hour).Add(40*time.Minute)).WithExperience(9_500).FromDB().Fours().WithGamesPlayed(17).Build()
+		players[2] = domaintest.NewPlayerBuilder(playerUUID, start.Add(24*time.Hour).Add(05*time.Minute)).WithExperience(9_900).FromDB().Fours().WithGamesPlayed(18).Build()
 
 		sessions := computeSessions(ctx, players, start, start.Add(24*time.Hour))
 
@@ -481,12 +481,12 @@ func TestComputeSessions(t *testing.T) {
 		start := time.Date(2025, time.February, 7, 4, 13, 34, 987_654_321, time.FixedZone("UTC", 3600*-10))
 
 		players := make([]domain.PlayerPIT, 6)
-		players[0] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(5*time.Minute)).WithGamesPlayed(15).WithExperience(9_200).FromDB().Build()
-		players[1] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(40*time.Minute)).WithGamesPlayed(16).WithExperience(9_500).FromDB().Build()
-		players[2] = domaintest.NewPlayerBuilder(playerUUID, start.Add(4*time.Hour).Add(05*time.Minute)).WithGamesPlayed(17).WithExperience(9_900).FromDB().Build()
-		players[3] = domaintest.NewPlayerBuilder(playerUUID, start.Add(4*time.Hour).Add(45*time.Minute)).WithGamesPlayed(20).WithExperience(10_900).FromDB().Build()
-		players[4] = domaintest.NewPlayerBuilder(playerUUID, start.Add(4*time.Hour).Add(55*time.Minute)).WithGamesPlayed(21).WithExperience(11_900).FromDB().Build()
-		players[5] = domaintest.NewPlayerBuilder(playerUUID, start.Add(5*time.Hour).Add(15*time.Minute)).WithGamesPlayed(22).WithExperience(12_900).FromDB().Build()
+		players[0] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(5*time.Minute)).WithExperience(9_200).FromDB().Fours().WithGamesPlayed(15).Build()
+		players[1] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(40*time.Minute)).WithExperience(9_500).FromDB().Fours().WithGamesPlayed(16).Build()
+		players[2] = domaintest.NewPlayerBuilder(playerUUID, start.Add(4*time.Hour).Add(05*time.Minute)).WithExperience(9_900).FromDB().Fours().WithGamesPlayed(17).Build()
+		players[3] = domaintest.NewPlayerBuilder(playerUUID, start.Add(4*time.Hour).Add(45*time.Minute)).WithExperience(10_900).FromDB().Fours().WithGamesPlayed(20).Build()
+		players[4] = domaintest.NewPlayerBuilder(playerUUID, start.Add(4*time.Hour).Add(55*time.Minute)).WithExperience(11_900).FromDB().Fours().WithGamesPlayed(21).Build()
+		players[5] = domaintest.NewPlayerBuilder(playerUUID, start.Add(5*time.Hour).Add(15*time.Minute)).WithExperience(12_900).FromDB().Fours().WithGamesPlayed(22).Build()
 
 		sessions := computeSessions(ctx, players, start, start.Add(24*time.Hour))
 
@@ -508,12 +508,12 @@ func TestComputeSessions(t *testing.T) {
 		start := time.Date(2025, time.December, 1, 7, 13, 34, 987_654_321, time.FixedZone("UTC", 3600*7))
 
 		players := make([]domain.PlayerPIT, 6)
-		players[0] = domaintest.NewPlayerBuilder(playerUUID, start.Add(1*time.Hour).Add(5*time.Minute)).WithGamesPlayed(16).WithExperience(9_200).FromDB().Build()
-		players[1] = domaintest.NewPlayerBuilder(playerUUID, start.Add(1*time.Hour).Add(40*time.Minute)).WithGamesPlayed(16).WithExperience(9_500).FromDB().Build()
-		players[2] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(05*time.Minute)).WithGamesPlayed(16).WithExperience(9_600).FromDB().Build()
-		players[3] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(45*time.Minute)).WithGamesPlayed(17).WithExperience(10_900).FromDB().Build()
-		players[4] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(55*time.Minute)).WithGamesPlayed(17).WithExperience(10_900).FromDB().Build()
-		players[5] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(15*time.Minute)).WithGamesPlayed(17).WithExperience(11_900).FromDB().Build()
+		players[0] = domaintest.NewPlayerBuilder(playerUUID, start.Add(1*time.Hour).Add(5*time.Minute)).WithExperience(9_200).FromDB().Fours().WithGamesPlayed(16).Build()
+		players[1] = domaintest.NewPlayerBuilder(playerUUID, start.Add(1*time.Hour).Add(40*time.Minute)).WithExperience(9_500).FromDB().Fours().WithGamesPlayed(16).Build()
+		players[2] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(05*time.Minute)).WithExperience(9_600).FromDB().Fours().WithGamesPlayed(16).Build()
+		players[3] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(45*time.Minute)).WithExperience(10_900).FromDB().Fours().WithGamesPlayed(17).Build()
+		players[4] = domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour).Add(55*time.Minute)).WithExperience(10_900).FromDB().Fours().WithGamesPlayed(17).Build()
+		players[5] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(15*time.Minute)).WithExperience(11_900).FromDB().Fours().WithGamesPlayed(17).Build()
 
 		sessions := computeSessions(ctx, players, start, start.Add(24*time.Hour))
 
@@ -535,12 +535,12 @@ func TestComputeSessions(t *testing.T) {
 		start := time.Date(2025, time.February, 7, 4, 13, 34, 987_654_321, time.FixedZone("UTC", 3600*-10))
 
 		players := make([]domain.PlayerPIT, 6)
-		players[0] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(5*time.Minute)).WithGamesPlayed(16).WithExperience(9_200).FromDB().Build()
-		players[1] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(40*time.Minute)).WithGamesPlayed(17).WithExperience(9_500).FromDB().Build()
-		players[2] = domaintest.NewPlayerBuilder(playerUUID, start.Add(4*time.Hour).Add(05*time.Minute)).WithGamesPlayed(18).WithExperience(9_900).FromDB().Build()
-		players[3] = domaintest.NewPlayerBuilder(playerUUID, start.Add(4*time.Hour).Add(45*time.Minute)).WithGamesPlayed(20).WithExperience(10_900).FromDB().Build()
-		players[4] = domaintest.NewPlayerBuilder(playerUUID, start.Add(4*time.Hour).Add(55*time.Minute)).WithGamesPlayed(21).WithExperience(11_900).FromDB().Build()
-		players[5] = domaintest.NewPlayerBuilder(playerUUID, start.Add(5*time.Hour).Add(15*time.Minute)).WithGamesPlayed(22).WithExperience(12_900).FromDB().Build()
+		players[0] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(5*time.Minute)).WithExperience(9_200).FromDB().Fours().WithGamesPlayed(16).Build()
+		players[1] = domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour).Add(40*time.Minute)).WithExperience(9_500).FromDB().Fours().WithGamesPlayed(17).Build()
+		players[2] = domaintest.NewPlayerBuilder(playerUUID, start.Add(4*time.Hour).Add(05*time.Minute)).WithExperience(9_900).FromDB().Fours().WithGamesPlayed(18).Build()
+		players[3] = domaintest.NewPlayerBuilder(playerUUID, start.Add(4*time.Hour).Add(45*time.Minute)).WithExperience(10_900).FromDB().Fours().WithGamesPlayed(20).Build()
+		players[4] = domaintest.NewPlayerBuilder(playerUUID, start.Add(4*time.Hour).Add(55*time.Minute)).WithExperience(11_900).FromDB().Fours().WithGamesPlayed(21).Build()
+		players[5] = domaintest.NewPlayerBuilder(playerUUID, start.Add(5*time.Hour).Add(15*time.Minute)).WithExperience(12_900).FromDB().Fours().WithGamesPlayed(22).Build()
 
 		sessions := computeSessions(ctx, players, start, start.Add(24*time.Hour))
 
@@ -562,27 +562,19 @@ func TestComputeSessions(t *testing.T) {
 
 		// 11:50, 10 games played
 		statA := domaintest.NewPlayerBuilder(playerUUID, refTime).
-			WithGamesPlayed(10).
-			WithExperience(1_000).
-			FromDB().
+			WithExperience(1_000).FromDB().Fours().WithGamesPlayed(10).
 			Build()
 		// 12:00, +1 game
 		statB := domaintest.NewPlayerBuilder(playerUUID, refTime.Add(10*time.Minute)).
-			WithGamesPlayed(11).
-			WithExperience(1_300).
-			FromDB().
+			WithExperience(1_300).FromDB().Fours().WithGamesPlayed(11).
 			Build()
 		// 12:10, identical to statB so it doesn't extend the session
 		statC := domaintest.NewPlayerBuilder(playerUUID, refTime.Add(20*time.Minute)).
-			WithGamesPlayed(11).
-			WithExperience(1_300).
-			FromDB().
+			WithExperience(1_300).FromDB().Fours().WithGamesPlayed(11).
 			Build()
 		// 13:05, +1 game — starts a new session
 		statD := domaintest.NewPlayerBuilder(playerUUID, refTime.Add(75*time.Minute)).
-			WithGamesPlayed(12).
-			WithExperience(1_700).
-			FromDB().
+			WithExperience(1_700).FromDB().Fours().WithGamesPlayed(12).
 			Build()
 
 		intervalStart := refTime.Add(-12 * time.Hour)
@@ -689,14 +681,10 @@ func TestComputeSessions(t *testing.T) {
 
 			stats := []domain.PlayerPIT{
 				domaintest.NewPlayerBuilder(playerUUID, start).
-					WithGamesPlayed(10).
-					WithExperience(1_000).
-					FromDB().
+					WithExperience(1_000).FromDB().Fours().WithGamesPlayed(10).
 					Build(),
 				domaintest.NewPlayerBuilder(playerUUID, start.Add(10*time.Minute)).
-					WithGamesPlayed(11).
-					WithExperience(1_300).
-					FromDB().
+					WithExperience(1_300).FromDB().Fours().WithGamesPlayed(11).
 					Build(),
 			}
 			// now lands strictly between session.Start and session.End
@@ -718,14 +706,10 @@ func TestComputeSessions(t *testing.T) {
 
 			stats := []domain.PlayerPIT{
 				domaintest.NewPlayerBuilder(playerUUID, start).
-					WithGamesPlayed(10).
-					WithExperience(1_000).
-					FromDB().
+					WithExperience(1_000).FromDB().Fours().WithGamesPlayed(10).
 					Build(),
 				domaintest.NewPlayerBuilder(playerUUID, start.Add(10*time.Minute)).
-					WithGamesPlayed(11).
-					WithExperience(1_300).
-					FromDB().
+					WithExperience(1_300).FromDB().Fours().WithGamesPlayed(11).
 					Build(),
 			}
 			// now is before the session starts

--- a/internal/domaintest/player.go
+++ b/internal/domaintest/player.go
@@ -11,22 +11,18 @@ import (
 )
 
 type playerBuilder struct {
-	player *domain.PlayerPIT
+	player                       *domain.PlayerPIT
+	solo, doubles, threes, fours *statsBuilder
+	overallWinstreak             *int
 }
 
-// Utility method for setting only the GamesPlayed field in Overall stats
-func (pb *playerBuilder) WithGamesPlayed(gamesPlayed int) *playerBuilder {
-	pb.player.Overall.GamesPlayed = gamesPlayed
-	return pb
-}
+func (pb *playerBuilder) Solo() *statsBuilder    { return pb.solo }
+func (pb *playerBuilder) Doubles() *statsBuilder { return pb.doubles }
+func (pb *playerBuilder) Threes() *statsBuilder  { return pb.threes }
+func (pb *playerBuilder) Fours() *statsBuilder   { return pb.fours }
 
 func (pb *playerBuilder) WithExperience(exp int64) *playerBuilder {
 	pb.player.Experience = exp
-	return pb
-}
-
-func (pb *playerBuilder) WithOverallStats(stats domain.GamemodeStatsPIT) *playerBuilder {
-	pb.player.Overall = stats
 	return pb
 }
 
@@ -44,8 +40,45 @@ func (pb *playerBuilder) FromDB() *playerBuilder {
 	return pb.WithDBID(&dbID)
 }
 
+func (pb *playerBuilder) WithOverallWinstreak(winstreak int) *playerBuilder {
+	pb.overallWinstreak = &winstreak
+	return pb
+}
+
 func (pb *playerBuilder) Build() domain.PlayerPIT {
-	return *pb.player
+	player := *pb.player
+
+	winstreakAPIEnabled := pb.solo.stats.Winstreak != nil ||
+		pb.doubles.stats.Winstreak != nil ||
+		pb.threes.stats.Winstreak != nil ||
+		pb.fours.stats.Winstreak != nil ||
+		pb.overallWinstreak != nil
+
+	if winstreakAPIEnabled {
+		// Winstreak API enablement is all or nothing.
+		// If one gamemode had a winstreak, but another didn't, that gamemode
+		// actually had winstreak 0.
+		if player.Solo.Winstreak == nil {
+			player.Solo.Winstreak = new(0)
+		}
+		if player.Doubles.Winstreak == nil {
+			player.Doubles.Winstreak = new(0)
+		}
+		if player.Threes.Winstreak == nil {
+			player.Threes.Winstreak = new(0)
+		}
+		if player.Fours.Winstreak == nil {
+			player.Fours.Winstreak = new(0)
+		}
+	}
+
+	player.Overall = computeOverallStats(player.Solo, player.Doubles, player.Threes, player.Fours)
+
+	if pb.overallWinstreak != nil {
+		player.Overall.Winstreak = pb.overallWinstreak
+	}
+
+	return player
 }
 
 func (pb *playerBuilder) BuildPtr() *domain.PlayerPIT {
@@ -54,19 +87,58 @@ func (pb *playerBuilder) BuildPtr() *domain.PlayerPIT {
 	return &player
 }
 
+func computeOverallStats(modes ...domain.GamemodeStatsPIT) domain.GamemodeStatsPIT {
+	var overall domain.GamemodeStatsPIT
+
+	for _, m := range modes {
+		overall.GamesPlayed += m.GamesPlayed
+		overall.Wins += m.Wins
+		overall.Losses += m.Losses
+		overall.BedsBroken += m.BedsBroken
+		overall.BedsLost += m.BedsLost
+		overall.FinalKills += m.FinalKills
+		overall.FinalDeaths += m.FinalDeaths
+		overall.Kills += m.Kills
+		overall.Deaths += m.Deaths
+		if m.Winstreak != nil {
+			// Overall winstreak is not uniquely determined by gamemode winstreaks
+			// The set of possible values are
+			//     [min(gamemode winstreaks), sum(gamemode winstreaks)]
+			// Doing min here.
+			if overall.Winstreak == nil || *m.Winstreak < *overall.Winstreak {
+				overall.Winstreak = m.Winstreak
+			}
+		}
+	}
+
+	return overall
+}
+
 func NewPlayerBuilder(uuid string, queriedAt time.Time) *playerBuilder {
 	player := &domain.PlayerPIT{
 		QueriedAt:  queriedAt,
 		UUID:       uuid,
 		Experience: 500,
 	}
-	return &playerBuilder{
-		player: player,
-	}
+	pb := &playerBuilder{player: player}
+	pb.solo = &statsBuilder{stats: &player.Solo, parent: pb}
+	pb.doubles = &statsBuilder{stats: &player.Doubles, parent: pb}
+	pb.threes = &statsBuilder{stats: &player.Threes, parent: pb}
+	pb.fours = &statsBuilder{stats: &player.Fours, parent: pb}
+	return pb
 }
 
+// statsBuilder mutates a single gamemode's stats on its parent
+// playerBuilder. Build/BuildPtr delegate to the parent so chains like
+// NewPlayerBuilder(...).Fours().WithGamesPlayed(10).Build() work inline.
 type statsBuilder struct {
-	stats *domain.GamemodeStatsPIT
+	stats  *domain.GamemodeStatsPIT
+	parent *playerBuilder
+}
+
+func (sb *statsBuilder) WithWinstreak(winstreak int) *statsBuilder {
+	sb.stats.Winstreak = &winstreak
+	return sb
 }
 
 func (sb *statsBuilder) WithGamesPlayed(gamesPlayed int) *statsBuilder {
@@ -81,6 +153,16 @@ func (sb *statsBuilder) WithWins(wins int) *statsBuilder {
 
 func (sb *statsBuilder) WithLosses(losses int) *statsBuilder {
 	sb.stats.Losses = losses
+	return sb
+}
+
+func (sb *statsBuilder) WithBedsBroken(bedsBroken int) *statsBuilder {
+	sb.stats.BedsBroken = bedsBroken
+	return sb
+}
+
+func (sb *statsBuilder) WithBedsLost(bedsLost int) *statsBuilder {
+	sb.stats.BedsLost = bedsLost
 	return sb
 }
 
@@ -104,15 +186,15 @@ func (sb *statsBuilder) WithDeaths(deaths int) *statsBuilder {
 	return sb
 }
 
-func (sb *statsBuilder) Build() domain.GamemodeStatsPIT {
-	return *sb.stats
-}
+// Navigation to other gamemodes on the parent player, so chains like
+// Fours().WithGamesPlayed(10).Threes().WithFinalKills(5).Build() flow inline.
+func (sb *statsBuilder) Solo() *statsBuilder    { return sb.parent.solo }
+func (sb *statsBuilder) Doubles() *statsBuilder { return sb.parent.doubles }
+func (sb *statsBuilder) Threes() *statsBuilder  { return sb.parent.threes }
+func (sb *statsBuilder) Fours() *statsBuilder   { return sb.parent.fours }
 
-func NewStatsBuilder() *statsBuilder {
-	return &statsBuilder{
-		stats: &domain.GamemodeStatsPIT{},
-	}
-}
+func (sb *statsBuilder) Build() domain.PlayerPIT     { return sb.parent.Build() }
+func (sb *statsBuilder) BuildPtr() *domain.PlayerPIT { return sb.parent.BuildPtr() }
 
 func RequireEqualStats(t *testing.T, expected, actual domain.GamemodeStatsPIT) {
 	t.Helper()

--- a/internal/ports/history_test.go
+++ b/internal/ports/history_test.go
@@ -70,9 +70,7 @@ func TestMakeGetHistoryHandler(t *testing.T) {
 	history := []domain.PlayerPIT{
 		domaintest.NewPlayerBuilder(uuid, start).
 			WithExperience(500).
-			WithOverallStats(
-				domaintest.NewStatsBuilder().WithFinalKills(10).Build(),
-			).Build(),
+			Fours().WithFinalKills(10).Build(),
 	}
 	historyJSON, err := ports.HistoryToRainbowHistoryData(history)
 	require.NoError(t, err)

--- a/internal/ports/sessions_test.go
+++ b/internal/ports/sessions_test.go
@@ -72,16 +72,12 @@ func TestMakeGetSessionsHandler(t *testing.T) {
 	stats := []domain.PlayerPIT{
 		domaintest.NewPlayerBuilder(uuid, start).
 			WithExperience(500).
-			WithGamesPlayed(10).
-			WithOverallStats(
-				domaintest.NewStatsBuilder().WithGamesPlayed(10).WithFinalKills(10).Build(),
-			).FromDB().Build(),
+			FromDB().
+			Fours().WithGamesPlayed(10).WithFinalKills(10).Build(),
 		domaintest.NewPlayerBuilder(uuid, end).
 			WithExperience(1000).
-			WithGamesPlayed(11).
-			WithOverallStats(
-				domaintest.NewStatsBuilder().WithGamesPlayed(11).WithFinalKills(11).Build(),
-			).FromDB().Build(),
+			FromDB().
+			Fours().WithGamesPlayed(11).WithFinalKills(11).Build(),
 	}
 
 	// Expected sessions computed from stats

--- a/internal/ports/wrapped_internal_test.go
+++ b/internal/ports/wrapped_internal_test.go
@@ -87,39 +87,39 @@ func TestComputeSessionsPerMonth(t *testing.T) {
 			sessions: []domain.Session{
 				{
 					Start: domaintest.NewPlayerBuilder(playerUUID, time.Date(2022, time.December, 31, 10, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(0).Build()).Build(),
+						Fours().WithGamesPlayed(0).Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 11, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(1).Build()).Build(),
+						Fours().WithGamesPlayed(1).Build(),
 				},
 				{
 					Start: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 15, 10, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(0).Build()).Build(),
+						Fours().WithGamesPlayed(0).Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 15, 11, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(1).Build()).Build(),
+						Fours().WithGamesPlayed(1).Build(),
 				},
 				{
 					Start: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 20, 10, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(1).Build()).Build(),
+						Fours().WithGamesPlayed(1).Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 20, 11, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(2).Build()).Build(),
+						Fours().WithGamesPlayed(2).Build(),
 				},
 				{
 					Start: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.March, 10, 10, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(2).Build()).Build(),
+						Fours().WithGamesPlayed(2).Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.March, 10, 11, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(3).Build()).Build(),
+						Fours().WithGamesPlayed(3).Build(),
 				},
 				{
 					Start: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.December, 25, 10, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(3).Build()).Build(),
+						Fours().WithGamesPlayed(3).Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.December, 25, 11, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(4).Build()).Build(),
+						Fours().WithGamesPlayed(4).Build(),
 				},
 				{
 					Start: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.December, 31, 10, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(0).Build()).Build(),
+						Fours().WithGamesPlayed(0).Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, time.Date(2024, time.January, 1, 11, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(1).Build()).Build(),
+						Fours().WithGamesPlayed(1).Build(),
 				},
 			},
 			want: sessionsPerMonth{
@@ -155,15 +155,15 @@ func TestComputeFlawlessSessions(t *testing.T) {
 			sessions: []domain.Session{
 				{
 					Start: domaintest.NewPlayerBuilder(playerUUID, start).
-						WithOverallStats(domaintest.NewStatsBuilder().WithLosses(0).WithFinalDeaths(0).Build()).Build(),
+						Fours().WithLosses(0).WithFinalDeaths(0).Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, start.Add(time.Hour)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithLosses(1).WithFinalDeaths(0).Build()).Build(),
+						Fours().WithLosses(1).WithFinalDeaths(0).Build(),
 				},
 				{
 					Start: domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithLosses(1).WithFinalDeaths(0).Build()).Build(),
+						Fours().WithLosses(1).WithFinalDeaths(0).Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithLosses(1).WithFinalDeaths(1).Build()).Build(),
+						Fours().WithLosses(1).WithFinalDeaths(1).Build(),
 				},
 			},
 			want: flawlessSessionStats{
@@ -176,15 +176,15 @@ func TestComputeFlawlessSessions(t *testing.T) {
 			sessions: []domain.Session{
 				{
 					Start: domaintest.NewPlayerBuilder(playerUUID, start).
-						WithOverallStats(domaintest.NewStatsBuilder().WithLosses(0).WithFinalDeaths(0).WithWins(0).Build()).Build(),
+						Fours().WithLosses(0).WithFinalDeaths(0).WithWins(0).Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, start.Add(time.Hour)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithLosses(0).WithFinalDeaths(0).WithWins(5).Build()).Build(),
+						Fours().WithLosses(0).WithFinalDeaths(0).WithWins(5).Build(),
 				},
 				{
 					Start: domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithLosses(0).WithFinalDeaths(0).WithWins(5).Build()).Build(),
+						Fours().WithLosses(0).WithFinalDeaths(0).WithWins(5).Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithLosses(0).WithFinalDeaths(0).WithWins(10).Build()).Build(),
+						Fours().WithLosses(0).WithFinalDeaths(0).WithWins(10).Build(),
 				},
 			},
 			want: flawlessSessionStats{
@@ -197,27 +197,27 @@ func TestComputeFlawlessSessions(t *testing.T) {
 			sessions: []domain.Session{
 				{
 					Start: domaintest.NewPlayerBuilder(playerUUID, start).
-						WithOverallStats(domaintest.NewStatsBuilder().WithLosses(0).WithFinalDeaths(0).WithWins(0).Build()).Build(),
+						Fours().WithLosses(0).WithFinalDeaths(0).WithWins(0).Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, start.Add(time.Hour)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithLosses(0).WithFinalDeaths(0).WithWins(2).Build()).Build(),
+						Fours().WithLosses(0).WithFinalDeaths(0).WithWins(2).Build(),
 				},
 				{
 					Start: domaintest.NewPlayerBuilder(playerUUID, start.Add(2*time.Hour)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithLosses(0).WithFinalDeaths(0).WithWins(2).Build()).Build(),
+						Fours().WithLosses(0).WithFinalDeaths(0).WithWins(2).Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, start.Add(3*time.Hour)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithLosses(1).WithFinalDeaths(0).WithWins(2).Build()).Build(),
+						Fours().WithLosses(1).WithFinalDeaths(0).WithWins(2).Build(),
 				},
 				{
 					Start: domaintest.NewPlayerBuilder(playerUUID, start.Add(4*time.Hour)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithLosses(1).WithFinalDeaths(0).WithWins(2).Build()).Build(),
+						Fours().WithLosses(1).WithFinalDeaths(0).WithWins(2).Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, start.Add(5*time.Hour)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithLosses(1).WithFinalDeaths(0).WithWins(5).Build()).Build(),
+						Fours().WithLosses(1).WithFinalDeaths(0).WithWins(5).Build(),
 				},
 				{
 					Start: domaintest.NewPlayerBuilder(playerUUID, start.Add(6*time.Hour)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithLosses(1).WithFinalDeaths(0).WithWins(5).Build()).Build(),
+						Fours().WithLosses(1).WithFinalDeaths(0).WithWins(5).Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, start.Add(7*time.Hour)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithLosses(1).WithFinalDeaths(1).WithWins(5).Build()).Build(),
+						Fours().WithLosses(1).WithFinalDeaths(1).WithWins(5).Build(),
 				},
 			},
 			want: flawlessSessionStats{
@@ -250,9 +250,9 @@ func TestComputeAverages(t *testing.T) {
 			sessions: []domain.Session{
 				{
 					Start: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 10, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(0).WithWins(0).WithFinalKills(0).Build()).Build(),
+						Fours().WithGamesPlayed(0).WithWins(0).WithFinalKills(0).Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 12, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(10).WithWins(5).WithFinalKills(20).Build()).Build(),
+						Fours().WithGamesPlayed(10).WithWins(5).WithFinalKills(20).Build(),
 				},
 			},
 			want: &averageStats{
@@ -267,15 +267,15 @@ func TestComputeAverages(t *testing.T) {
 			sessions: []domain.Session{
 				{
 					Start: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 10, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(0).WithWins(0).WithFinalKills(0).Build()).Build(),
+						Fours().WithGamesPlayed(0).WithWins(0).WithFinalKills(0).Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 12, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(10).WithWins(5).WithFinalKills(20).Build()).Build(),
+						Fours().WithGamesPlayed(10).WithWins(5).WithFinalKills(20).Build(),
 				},
 				{
 					Start: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 2, 14, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(10).WithWins(5).WithFinalKills(20).Build()).Build(),
+						Fours().WithGamesPlayed(10).WithWins(5).WithFinalKills(20).Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 2, 18, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(30).WithWins(15).WithFinalKills(60).Build()).Build(),
+						Fours().WithGamesPlayed(30).WithWins(15).WithFinalKills(60).Build(),
 				},
 			},
 			want: &averageStats{
@@ -392,16 +392,16 @@ func TestComputeCoverage(t *testing.T) {
 			name: "100% coverage",
 			boundaryStats: &yearBoundaryStats{
 				Start: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 0, 0, 0, 0, time.UTC)).
-					WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(0).Build()).BuildPtr(),
+					Fours().WithGamesPlayed(0).BuildPtr(),
 				End: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.December, 31, 23, 59, 59, 0, time.UTC)).
-					WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(100).Build()).BuildPtr(),
+					Fours().WithGamesPlayed(100).BuildPtr(),
 			},
 			sessions: []domain.Session{
 				{
 					Start: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.June, 1, 10, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(0).Build()).Build(),
+						Fours().WithGamesPlayed(0).Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.June, 1, 12, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(100).Build()).Build(),
+						Fours().WithGamesPlayed(100).Build(),
 				},
 			},
 			totalHours:             2.0,
@@ -412,16 +412,16 @@ func TestComputeCoverage(t *testing.T) {
 			name: "50% coverage",
 			boundaryStats: &yearBoundaryStats{
 				Start: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 0, 0, 0, 0, time.UTC)).
-					WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(0).Build()).BuildPtr(),
+					Fours().WithGamesPlayed(0).BuildPtr(),
 				End: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.December, 31, 23, 59, 59, 0, time.UTC)).
-					WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(100).Build()).BuildPtr(),
+					Fours().WithGamesPlayed(100).BuildPtr(),
 			},
 			sessions: []domain.Session{
 				{
 					Start: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.June, 1, 10, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(0).Build()).Build(),
+						Fours().WithGamesPlayed(0).Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.June, 1, 12, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(50).Build()).Build(),
+						Fours().WithGamesPlayed(50).Build(),
 				},
 			},
 			totalHours:             2.0,
@@ -432,16 +432,16 @@ func TestComputeCoverage(t *testing.T) {
 			name: "0% coverage",
 			boundaryStats: &yearBoundaryStats{
 				Start: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 0, 0, 0, 0, time.UTC)).
-					WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(0).Build()).BuildPtr(),
+					Fours().WithGamesPlayed(0).BuildPtr(),
 				End: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.December, 31, 23, 59, 59, 0, time.UTC)).
-					WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(100).Build()).BuildPtr(),
+					Fours().WithGamesPlayed(100).BuildPtr(),
 			},
 			sessions: []domain.Session{
 				{
 					Start: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.June, 1, 10, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(0).Build()).Build(),
+						Fours().WithGamesPlayed(0).Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.June, 1, 12, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(0).Build()).Build(),
+						Fours().WithGamesPlayed(0).Build(),
 				},
 			},
 			totalHours:             2.0,
@@ -452,16 +452,16 @@ func TestComputeCoverage(t *testing.T) {
 			name: "coverage over 100%",
 			boundaryStats: &yearBoundaryStats{
 				Start: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 0, 0, 0, 0, time.UTC)).
-					WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(0).Build()).BuildPtr(),
+					Fours().WithGamesPlayed(0).BuildPtr(),
 				End: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.December, 31, 23, 59, 59, 0, time.UTC)).
-					WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(50).Build()).BuildPtr(),
+					Fours().WithGamesPlayed(50).BuildPtr(),
 			},
 			sessions: []domain.Session{
 				{
 					Start: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.June, 1, 10, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(0).Build()).Build(),
+						Fours().WithGamesPlayed(0).Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.June, 1, 12, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(100).Build()).Build(),
+						Fours().WithGamesPlayed(100).Build(),
 				},
 			},
 			totalHours:             2.0,
@@ -474,9 +474,9 @@ func TestComputeCoverage(t *testing.T) {
 			sessions: []domain.Session{
 				{
 					Start: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.June, 1, 10, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(0).Build()).Build(),
+						Fours().WithGamesPlayed(0).Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.June, 1, 12, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(100).Build()).Build(),
+						Fours().WithGamesPlayed(100).Build(),
 				},
 			},
 			totalHours:             2.0,
@@ -517,12 +517,12 @@ func TestComputeBestSessions(t *testing.T) {
 				{
 					Start: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 10, 0, 0, 0, time.UTC)).
 						FromDB().
-						WithOverallStats(domaintest.NewStatsBuilder().
-							WithKills(0).WithFinalKills(0).WithWins(0).WithFinalDeaths(0).Build()).Build(),
+						Fours().
+						WithKills(0).WithFinalKills(0).WithWins(0).WithFinalDeaths(0).Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 12, 0, 0, 0, time.UTC)).
 						FromDB().
-						WithOverallStats(domaintest.NewStatsBuilder().
-							WithKills(50).WithFinalKills(20).WithWins(5).WithFinalDeaths(2).Build()).Build(),
+						Fours().
+						WithKills(50).WithFinalKills(20).WithWins(5).WithFinalDeaths(2).Build(),
 				},
 			},
 			wantHighestFKDR:   20.0 / 2.0,
@@ -539,12 +539,12 @@ func TestComputeBestSessions(t *testing.T) {
 				{
 					Start: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 10, 0, 0, 0, time.UTC)).
 						FromDB().
-						WithOverallStats(domaintest.NewStatsBuilder().
-							WithKills(0).WithFinalKills(0).WithWins(0).WithFinalDeaths(0).Build()).Build(),
+						Fours().
+						WithKills(0).WithFinalKills(0).WithWins(0).WithFinalDeaths(0).Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 12, 0, 0, 0, time.UTC)).
 						FromDB().
-						WithOverallStats(domaintest.NewStatsBuilder().
-							WithKills(50).WithFinalKills(15).WithWins(5).WithFinalDeaths(0).Build()).Build(),
+						Fours().
+						WithKills(50).WithFinalKills(15).WithWins(5).WithFinalDeaths(0).Build(),
 				},
 			},
 			wantHighestFKDR:   15.0, // 15 final kills with 0 deaths
@@ -562,23 +562,23 @@ func TestComputeBestSessions(t *testing.T) {
 				{
 					Start: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 10, 0, 0, 0, time.UTC)).
 						FromDB().
-						WithOverallStats(domaintest.NewStatsBuilder().
-							WithKills(0).WithFinalKills(0).WithWins(0).WithFinalDeaths(0).Build()).Build(),
+						Fours().
+						WithKills(0).WithFinalKills(0).WithWins(0).WithFinalDeaths(0).Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 11, 0, 0, 0, time.UTC)).
 						FromDB().
-						WithOverallStats(domaintest.NewStatsBuilder().
-							WithKills(100).WithFinalKills(10).WithWins(2).WithFinalDeaths(1).Build()).Build(),
+						Fours().
+						WithKills(100).WithFinalKills(10).WithWins(2).WithFinalDeaths(1).Build(),
 				},
 				// Session 2: 8 hours (longest), FKDR=40 (40/1, highest), 50 kills, 40 finals (most), 20 wins (most)
 				{
 					Start: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 2, 10, 0, 0, 0, time.UTC)).
 						FromDB().
-						WithOverallStats(domaintest.NewStatsBuilder().
-							WithKills(100).WithFinalKills(10).WithWins(2).WithFinalDeaths(1).Build()).Build(),
+						Fours().
+						WithKills(100).WithFinalKills(10).WithWins(2).WithFinalDeaths(1).Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 2, 18, 0, 0, 0, time.UTC)).
 						FromDB().
-						WithOverallStats(domaintest.NewStatsBuilder().
-							WithKills(150).WithFinalKills(50).WithWins(22).WithFinalDeaths(2).Build()).Build(),
+						Fours().
+						WithKills(150).WithFinalKills(50).WithWins(22).WithFinalDeaths(2).Build(),
 				},
 			},
 			wantHighestFKDR:   40.0,             // Session 2: 40/1
@@ -641,11 +641,11 @@ func TestComputeWinstreaks(t *testing.T) {
 			name: "winstreak of 5 then loss",
 			playerPITs: []domain.PlayerPIT{
 				domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 10, 0, 0, 0, time.UTC)).
-					WithOverallStats(domaintest.NewStatsBuilder().WithWins(100).WithLosses(0).Build()).Build(),
+					Fours().WithWins(100).WithLosses(0).Build(),
 				domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 11, 0, 0, 0, time.UTC)).
-					WithOverallStats(domaintest.NewStatsBuilder().WithWins(105).WithLosses(0).Build()).Build(),
+					Fours().WithWins(105).WithLosses(0).Build(),
 				domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 12, 0, 0, 0, time.UTC)).
-					WithOverallStats(domaintest.NewStatsBuilder().WithWins(105).WithLosses(1).Build()).Build(),
+					Fours().WithWins(105).WithLosses(1).Build(),
 			},
 			wantOverallHigh: 5,
 		},
@@ -653,15 +653,15 @@ func TestComputeWinstreaks(t *testing.T) {
 			name: "ongoing winstreak excluded",
 			playerPITs: []domain.PlayerPIT{
 				domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 10, 0, 0, 0, time.UTC)).
-					WithOverallStats(domaintest.NewStatsBuilder().WithWins(0).WithLosses(0).Build()).Build(),
+					Fours().WithWins(0).WithLosses(0).Build(),
 				domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 11, 0, 0, 0, time.UTC)).
-					WithOverallStats(domaintest.NewStatsBuilder().WithWins(6).WithLosses(0).Build()).Build(),
+					Fours().WithWins(6).WithLosses(0).Build(),
 				domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 12, 0, 0, 0, time.UTC)).
-					WithOverallStats(domaintest.NewStatsBuilder().WithWins(6).WithLosses(1).Build()).Build(),
+					Fours().WithWins(6).WithLosses(1).Build(),
 				domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.February, 1, 10, 0, 0, 0, time.UTC)).
-					WithOverallStats(domaintest.NewStatsBuilder().WithWins(6).WithLosses(0).Build()).Build(),
+					Fours().WithWins(6).WithLosses(0).Build(),
 				domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.February, 1, 11, 0, 0, 0, time.UTC)).
-					WithOverallStats(domaintest.NewStatsBuilder().WithWins(100).WithLosses(0).Build()).Build(),
+					Fours().WithWins(100).WithLosses(0).Build(),
 			},
 			wantOverallHigh: 6,
 		},
@@ -669,12 +669,12 @@ func TestComputeWinstreaks(t *testing.T) {
 			name: "concurrent wins and losses - extra wins don't count",
 			playerPITs: []domain.PlayerPIT{
 				domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 10, 0, 0, 0, time.UTC)).
-					WithOverallStats(domaintest.NewStatsBuilder().WithWins(0).WithLosses(0).Build()).Build(),
+					Fours().WithWins(0).WithLosses(0).Build(),
 				domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 11, 0, 0, 0, time.UTC)).
-					WithOverallStats(domaintest.NewStatsBuilder().WithWins(5).WithLosses(0).Build()).Build(),
+					Fours().WithWins(5).WithLosses(0).Build(),
 				// Both wins and losses increased - we don't know the order
 				domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 12, 0, 0, 0, time.UTC)).
-					WithOverallStats(domaintest.NewStatsBuilder().WithWins(8).WithLosses(1).Build()).Build(),
+					Fours().WithWins(8).WithLosses(1).Build(),
 			},
 			wantOverallHigh: 5, // The extra 3 wins don't count toward the streak
 		},
@@ -711,11 +711,11 @@ func TestComputeFinalKillStreaks(t *testing.T) {
 			name: "final kill streak of 8 then death",
 			playerPITs: []domain.PlayerPIT{
 				domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 10, 0, 0, 0, time.UTC)).
-					WithOverallStats(domaintest.NewStatsBuilder().WithFinalKills(100).WithFinalDeaths(0).Build()).Build(),
+					Fours().WithFinalKills(100).WithFinalDeaths(0).Build(),
 				domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 11, 0, 0, 0, time.UTC)).
-					WithOverallStats(domaintest.NewStatsBuilder().WithFinalKills(108).WithFinalDeaths(0).Build()).Build(),
+					Fours().WithFinalKills(108).WithFinalDeaths(0).Build(),
 				domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 12, 0, 0, 0, time.UTC)).
-					WithOverallStats(domaintest.NewStatsBuilder().WithFinalKills(108).WithFinalDeaths(1).Build()).Build(),
+					Fours().WithFinalKills(108).WithFinalDeaths(1).Build(),
 			},
 			wantOverallHigh: 8,
 		},
@@ -723,15 +723,15 @@ func TestComputeFinalKillStreaks(t *testing.T) {
 			name: "ongoing streak excluded",
 			playerPITs: []domain.PlayerPIT{
 				domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 10, 0, 0, 0, time.UTC)).
-					WithOverallStats(domaintest.NewStatsBuilder().WithFinalKills(0).WithFinalDeaths(0).Build()).Build(),
+					Fours().WithFinalKills(0).WithFinalDeaths(0).Build(),
 				domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 11, 0, 0, 0, time.UTC)).
-					WithOverallStats(domaintest.NewStatsBuilder().WithFinalKills(9).WithFinalDeaths(0).Build()).Build(),
+					Fours().WithFinalKills(9).WithFinalDeaths(0).Build(),
 				domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 12, 0, 0, 0, time.UTC)).
-					WithOverallStats(domaintest.NewStatsBuilder().WithFinalKills(9).WithFinalDeaths(1).Build()).Build(),
+					Fours().WithFinalKills(9).WithFinalDeaths(1).Build(),
 				domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.February, 1, 10, 0, 0, 0, time.UTC)).
-					WithOverallStats(domaintest.NewStatsBuilder().WithFinalKills(9).WithFinalDeaths(0).Build()).Build(),
+					Fours().WithFinalKills(9).WithFinalDeaths(0).Build(),
 				domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.February, 1, 11, 0, 0, 0, time.UTC)).
-					WithOverallStats(domaintest.NewStatsBuilder().WithFinalKills(100).WithFinalDeaths(0).Build()).Build(),
+					Fours().WithFinalKills(100).WithFinalDeaths(0).Build(),
 			},
 			wantOverallHigh: 9,
 		},
@@ -739,12 +739,12 @@ func TestComputeFinalKillStreaks(t *testing.T) {
 			name: "concurrent final kills and deaths - extra kills don't count",
 			playerPITs: []domain.PlayerPIT{
 				domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 10, 0, 0, 0, time.UTC)).
-					WithOverallStats(domaintest.NewStatsBuilder().WithFinalKills(0).WithFinalDeaths(0).Build()).Build(),
+					Fours().WithFinalKills(0).WithFinalDeaths(0).Build(),
 				domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 11, 0, 0, 0, time.UTC)).
-					WithOverallStats(domaintest.NewStatsBuilder().WithFinalKills(8).WithFinalDeaths(0).Build()).Build(),
+					Fours().WithFinalKills(8).WithFinalDeaths(0).Build(),
 				// Both final kills and deaths increased - we don't know the order
 				domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 12, 0, 0, 0, time.UTC)).
-					WithOverallStats(domaintest.NewStatsBuilder().WithFinalKills(12).WithFinalDeaths(1).Build()).Build(),
+					Fours().WithFinalKills(12).WithFinalDeaths(1).Build(),
 			},
 			wantOverallHigh: 8, // The extra 4 kills don't count toward the streak
 		},
@@ -804,10 +804,10 @@ func TestComputePlaytimeDistribution(t *testing.T) {
 			sessions: []domain.Session{
 				{
 					Start: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 10, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(0).Build()).
+						Fours().WithGamesPlayed(0).
 						Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 10, 30, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(1).Build()).
+						Fours().WithGamesPlayed(1).
 						Build(),
 				},
 			},
@@ -831,10 +831,10 @@ func TestComputePlaytimeDistribution(t *testing.T) {
 			sessions: []domain.Session{
 				{
 					Start: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 2, 14, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(0).Build()).
+						Fours().WithGamesPlayed(0).
 						Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 2, 16, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(1).Build()).
+						Fours().WithGamesPlayed(1).
 						Build(),
 				},
 			},
@@ -861,10 +861,10 @@ func TestComputePlaytimeDistribution(t *testing.T) {
 			sessions: []domain.Session{
 				{
 					Start: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 3, 9, 30, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(0).Build()).
+						Fours().WithGamesPlayed(0).
 						Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 3, 11, 45, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(1).Build()).
+						Fours().WithGamesPlayed(1).
 						Build(),
 				},
 			},
@@ -893,19 +893,19 @@ func TestComputePlaytimeDistribution(t *testing.T) {
 				{
 					// Sunday session
 					Start: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 10, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(0).Build()).
+						Fours().WithGamesPlayed(0).
 						Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 12, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(1).Build()).
+						Fours().WithGamesPlayed(1).
 						Build(),
 				},
 				{
 					// Monday session at the same hour
 					Start: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 2, 10, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(1).Build()).
+						Fours().WithGamesPlayed(1).
 						Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 2, 11, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(2).Build()).
+						Fours().WithGamesPlayed(2).
 						Build(),
 				},
 			},
@@ -937,10 +937,10 @@ func TestComputePlaytimeDistribution(t *testing.T) {
 			sessions: []domain.Session{
 				{
 					Start: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 1, 23, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(0).Build()).
+						Fours().WithGamesPlayed(0).
 						Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 2, 1, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(1).Build()).
+						Fours().WithGamesPlayed(1).
 						Build(),
 				},
 			},
@@ -972,19 +972,19 @@ func TestComputePlaytimeDistribution(t *testing.T) {
 				{
 					// Summer time (CEST, UTC+2)
 					Start: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.June, 15, 12, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(0).Build()).
+						Fours().WithGamesPlayed(0).
 						Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.June, 15, 14, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(1).Build()).
+						Fours().WithGamesPlayed(1).
 						Build(),
 				},
 				{
 					// Winter time (CET, UTC+1)
 					Start: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.December, 15, 8, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(0).Build()).
+						Fours().WithGamesPlayed(0).
 						Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.December, 15, 9, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(1).Build()).
+						Fours().WithGamesPlayed(1).
 						Build(),
 				},
 			},
@@ -1018,10 +1018,10 @@ func TestComputePlaytimeDistribution(t *testing.T) {
 			sessions: []domain.Session{
 				{
 					Start: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 10, 6, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(0).Build()).
+						Fours().WithGamesPlayed(0).
 						Build(),
 					End: domaintest.NewPlayerBuilder(playerUUID, time.Date(2023, time.January, 10, 8, 0, 0, 0, time.UTC)).
-						WithOverallStats(domaintest.NewStatsBuilder().WithGamesPlayed(1).Build()).
+						Fours().WithGamesPlayed(1).
 						Build(),
 				},
 			},


### PR DESCRIPTION
The playerBuilder previously let tests set Overall stats directly via
WithOverallStats, which could drift from the per-gamemode stats. Drop
that escape hatch in favour of per-gamemode setters and derive Overall
as the sum of Solo/Doubles/Threes/Fours during Build.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
