### PR TITLE
Limit request body size on sessions and history handlers

### DIFF
--- a/internal/ports/history.go
+++ b/internal/ports/history.go
@@ -2,6 +2,7 @@ package ports
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -70,8 +71,13 @@ func MakeGetHistoryHandler(
 		ctx := r.Context()
 
 		defer r.Body.Close()
-		body, err := io.ReadAll(r.Body)
+		body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 4<<10))
 		if err != nil {
+			var maxBytesErr *http.MaxBytesError
+			if errors.As(err, &maxBytesErr) {
+				http.Error(w, "Request body too large", http.StatusRequestEntityTooLarge)
+				return
+			}
 			reporting.Report(ctx, fmt.Errorf("failed to read request body: %w", err))
 			http.Error(w, "Failed to read request body", http.StatusBadRequest)
 			return

--- a/internal/ports/history_test.go
+++ b/internal/ports/history_test.go
@@ -188,6 +188,30 @@ func TestMakeGetHistoryHandler(t *testing.T) {
 		require.False(t, *called)
 	})
 
+	t.Run("request body exceeds size limit", func(t *testing.T) {
+		t.Parallel()
+
+		getHistoryFunc, called := makeGetHistory(t, uuid, start, end, limit, history, nil)
+		handler := makeGetHistoryHandler(getHistoryFunc)
+
+		// Build a body larger than the 4 KB limit by padding the UUID field.
+		oversized := fmt.Sprintf(
+			`{"uuid":"%s","start":"%s","end":"%s","limit":%d}`,
+			strings.Repeat("a", 5<<10),
+			startStr,
+			endStr,
+			limit,
+		)
+		body := io.NopCloser(strings.NewReader(oversized))
+		req := httptest.NewRequestWithContext(t.Context(), "GET", "/history", body)
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusRequestEntityTooLarge, w.Code)
+		require.False(t, *called)
+	})
+
 	t.Run("invalid limits", func(t *testing.T) {
 		t.Parallel()
 		for _, invalidLimit := range []int{-1, 0, 1, 101, 1001} {

--- a/internal/ports/sessions.go
+++ b/internal/ports/sessions.go
@@ -2,6 +2,7 @@ package ports
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -71,8 +72,13 @@ func MakeGetSessionsHandler(
 		ctx := r.Context()
 
 		defer r.Body.Close()
-		body, err := io.ReadAll(r.Body)
+		body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 4<<10))
 		if err != nil {
+			var maxBytesErr *http.MaxBytesError
+			if errors.As(err, &maxBytesErr) {
+				http.Error(w, "Request body too large", http.StatusRequestEntityTooLarge)
+				return
+			}
 			reporting.Report(ctx, fmt.Errorf("failed to read request body: %w", err))
 			http.Error(w, "Failed to read request body", http.StatusBadRequest)
 			return

--- a/internal/ports/sessions_test.go
+++ b/internal/ports/sessions_test.go
@@ -222,6 +222,29 @@ func TestMakeGetSessionsHandler(t *testing.T) {
 		require.False(t, *called)
 	})
 
+	t.Run("request body exceeds size limit", func(t *testing.T) {
+		t.Parallel()
+
+		getPlayerPITs, called := makeGetPlayerPITs(t, uuid, start, end, stats, nil)
+		handler := makeGetSessionsHandler(getPlayerPITs)
+
+		// Build a body larger than the 4 KB limit by padding the UUID field.
+		oversized := fmt.Sprintf(
+			`{"uuid":"%s","start":"%s","end":"%s"}`,
+			strings.Repeat("a", 5<<10),
+			startStr,
+			endStr,
+		)
+		body := io.NopCloser(strings.NewReader(oversized))
+		req := httptest.NewRequestWithContext(t.Context(), "GET", "/sessions", body)
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusRequestEntityTooLarge, w.Code)
+		require.False(t, *called)
+	})
+
 	t.Run("interval just under 400 days", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## Summary
- Wrap `r.Body` with `http.MaxBytesReader` (4 KiB) on `/sessions` and `/history` so oversized requests are rejected before being buffered into memory.
- Return `413 Request Entity Too Large` on `*http.MaxBytesError` (detected via `errors.As`), keep `400` for other read failures.
- Add tests asserting a 5 KiB body produces a 413 and the downstream data fetcher is not invoked.

## Test plan
- [x] `go test ./internal/ports/ -run "TestMakeGetSessionsHandler|TestMakeGetHistoryHandler"` passes
- [x] New `request_body_exceeds_size_limit` subtests pass for both handlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
