### PR TITLE
ci: auto-sync pre-commit golangci-lint rev to go.mod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
     commit-message:
       prefix: 'chore'
       include: 'scope'
+    ignore:
+      # golangci-lint is driven by the gomod ecosystem (go.mod is the source of
+      # truth) and synced into .pre-commit-config.yaml by the check-tool-versions
+      # workflow, so don't let pre-commit bump it independently.
+      - dependency-name: 'golangci/golangci-lint'
     groups:
       # Group minor+patch updates together
       # Leave major updates and security updates to their own PRs
@@ -64,11 +69,6 @@ updates:
       # Leave major updates and security updates to their own PRs
       minor-updates:
         applies-to: 'version-updates'
-        exclude-patterns:
-          # Keep this dependency out of the bundle:
-          # - version must stay in sync with .pre-commit-config.yaml
-          # - updates can require manual fixes for newly introduced rules
-          - 'github.com/golangci/golangci-lint/v2'
         update-types:
           - 'patch'
           - 'minor'

--- a/.github/workflows/check-tool-versions.yml
+++ b/.github/workflows/check-tool-versions.yml
@@ -22,20 +22,96 @@ on:
 jobs:
   check-versions:
     runs-on: ubuntu-latest
+    outputs:
+      out_of_sync: ${{ steps.compare.outputs.out_of_sync }}
+      golangcilint_version: ${{ steps.compare.outputs.golangcilint_version }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
 
-      - name: Check golangci-lint version matches pre-commit config
+      - name: Compare golangci-lint versions
+        id: compare
         run: |
-          GOMOD_VERSION=$(go list -m -f '{{.Version}}' github.com/golangci/golangci-lint/v2)
-          PRECOMMIT_VERSION=$(grep -A1 'golangci/golangci-lint' .pre-commit-config.yaml | grep 'rev:' | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+')
-          echo "golangci-lint version in go.mod: $GOMOD_VERSION"
-          echo "golangci-lint version in .pre-commit-config.yaml: $PRECOMMIT_VERSION"
-          if [ "$GOMOD_VERSION" != "$PRECOMMIT_VERSION" ]; then
-              echo "Error: golangci-lint versions do not match!"
-              exit 1
+          GOLANGCILINT_GOMOD=$(go list -m -f '{{.Version}}' github.com/golangci/golangci-lint/v2)
+          GOLANGCILINT_PRECOMMIT=$(grep -A1 'golangci/golangci-lint' .pre-commit-config.yaml | grep 'rev:' | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+')
+
+          echo "golangci-lint — go.mod: $GOLANGCILINT_GOMOD, pre-commit: $GOLANGCILINT_PRECOMMIT"
+
+          OUT_OF_SYNC=false
+          if [ "$GOLANGCILINT_GOMOD" = "$GOLANGCILINT_PRECOMMIT" ]; then
+            echo "golangci-lint versions match ✓"
+          else
+            echo "golangci-lint versions do not match ✗"
+            OUT_OF_SYNC=true
           fi
-          echo "golangci-lint versions match ✓"
+
+          # Always exit 0 here so these outputs are recorded even when the job
+          # fails below; the sync-versions job reads them.
+          echo "golangcilint_version=$GOLANGCILINT_GOMOD" >> "$GITHUB_OUTPUT"
+          echo "out_of_sync=$OUT_OF_SYNC" >> "$GITHUB_OUTPUT"
+
+      - name: Fail if out of sync
+        if: steps.compare.outputs.out_of_sync == 'true'
+        run: |
+          echo "::error::golangci-lint version in .pre-commit-config.yaml does not match go.mod."
+          echo "The 'sync-versions' job will push a fix to this PR and CI will re-run automatically."
+          exit 1
+
+  sync-versions:
+    needs: check-versions
+    # `!cancelled()` is required because the check-versions job ends in failure
+    # when out of sync, which would otherwise skip this job (while still
+    # respecting cancellation, unlike always()).
+    # Skip PRs from forks: the deploy key/secrets aren't available there and
+    # we can't push to a fork's branch anyway.
+    if: >-
+      ${{
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.fork == false &&
+        !cancelled() &&
+        needs.check-versions.outputs.out_of_sync == 'true'
+      }}
+    runs-on: ubuntu-latest
+    # Avoid concurrent pushes to the same PR branch racing each other.
+    concurrency:
+      group: sync-versions-${{ github.head_ref }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # `ref` must be the PR branch, not the detached merge ref that
+          # pull_request checks out by default.
+          ref: ${{ github.head_ref }}
+          # Use a deploy key so the push triggers CI on the new commit (a
+          # GITHUB_TOKEN push would not).
+          ssh-key: ${{ secrets.REPO_WRITE_DEPLOY_KEY }}
+
+      - name: Sync pre-commit rev to go.mod
+        env:
+          GOLANGCILINT_VERSION: ${{ needs.check-versions.outputs.golangcilint_version }}
+        run: |
+          # Replace the `rev:` line within the golangci-lint repo block only.
+          sed -i "\|repo: https://github.com/golangci/golangci-lint|,/rev:/ s|rev: .*|rev: ${GOLANGCILINT_VERSION}|" .pre-commit-config.yaml
+
+      - name: Validate pre-commit config
+        run: |
+          pipx install pre-commit
+          # Schema-check the rewritten config...
+          pre-commit validate-config
+          # ...then clone + build every hook environment at its pinned rev
+          # (without running them) to catch a bad rev before committing.
+          pre-commit install-hooks
+
+      - name: Commit & push fix
+        run: |
+          if git diff --quiet; then
+            echo "Nothing to change — already in sync."
+            exit 0
+          fi
+          git config user.name  "Prism Overlay CI[bot]"
+          git config user.email "ci@prismoverlay.com"
+          git add .pre-commit-config.yaml
+          git commit -m "chore(pre-commit): sync golangci-lint rev to go.mod"
+          git push


### PR DESCRIPTION
## What

Make the golangci-lint version in `.pre-commit-config.yaml` follow `go.mod` automatically, instead of just failing CI when they drift.

### `check-tool-versions.yml` — split into two jobs
- **`check-versions`** (all PRs + push to main): compares the go.mod and pre-commit golangci-lint versions, exports `out_of_sync` / `golangcilint_version` outputs, and fails red on mismatch (same gate as before).
- **`sync-versions`** (new, separate job): runs on any PR when `out_of_sync == 'true'` — no `dependabot[bot]` actor gate. Rewrites the pre-commit `rev` to match go.mod and pushes via a **deploy key** so CI re-runs on the new commit (a `GITHUB_TOKEN` push would not). The re-run finds things in sync, so the job skips itself — no loop.

### `dependabot.yml`
- `ignore` golangci-lint in the **pre-commit** ecosystem — gomod is now the single source of truth.
- Drop the now-unnecessary golangci-lint `exclude-patterns` entry from the gomod group.

## Required manual setup before this works
1. Generate a key: `ssh-keygen -t ed25519 -f deploy_key -N "" -C "repo-write-deploy-key"`
2. Add the **public** key as a repo **deploy key with write access** (Settings → Deploy keys).
3. Store the **private** key as `REPO_WRITE_DEPLOY_KEY` in **both** Actions secrets and **Dependabot** secrets (the golangci-lint bump PR is Dependabot-triggered and only sees Dependabot secrets).
4. *(Recommended)* Protect `main` with a ruleset (require PRs, empty bypass list) so the deploy key can't push to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
