### PR TITLE
feat: Add anonymous-tier auth sessions

### DIFF
--- a/internal/adapters/authsessionrepository/converters_whitebox_test.go
+++ b/internal/adapters/authsessionrepository/converters_whitebox_test.go
@@ -1,0 +1,55 @@
+package authsessionrepository
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Amund211/flashlight/internal/domain"
+)
+
+func TestIdentityTypeFromDB(t *testing.T) {
+	t.Parallel()
+
+	t.Run("anonymous round-trips", func(t *testing.T) {
+		t.Parallel()
+		got, err := identityTypeFromDB("anonymous")
+		require.NoError(t, err)
+		require.Equal(t, domain.AuthSessionIdentityAnonymous, got)
+	})
+
+	t.Run("unknown string returns error", func(t *testing.T) {
+		t.Parallel()
+		_, err := identityTypeFromDB("microsoft")
+		require.Error(t, err)
+	})
+
+	t.Run("empty string returns error", func(t *testing.T) {
+		t.Parallel()
+		_, err := identityTypeFromDB("")
+		require.Error(t, err)
+	})
+}
+
+func TestIdentityTypeToDB(t *testing.T) {
+	t.Parallel()
+
+	t.Run("anonymous round-trips", func(t *testing.T) {
+		t.Parallel()
+		got, err := identityTypeToDB(domain.AuthSessionIdentityAnonymous)
+		require.NoError(t, err)
+		require.Equal(t, "anonymous", got)
+	})
+
+	t.Run("unknown domain value returns error", func(t *testing.T) {
+		t.Parallel()
+		_, err := identityTypeToDB(domain.AuthSessionIdentityType("bogus"))
+		require.Error(t, err)
+	})
+
+	t.Run("empty domain value returns error", func(t *testing.T) {
+		t.Parallel()
+		_, err := identityTypeToDB("")
+		require.Error(t, err)
+	})
+}

--- a/internal/adapters/authsessionrepository/postgres.go
+++ b/internal/adapters/authsessionrepository/postgres.go
@@ -1,0 +1,360 @@
+package authsessionrepository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/lib/pq"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/Amund211/flashlight/internal/domain"
+	"github.com/Amund211/flashlight/internal/reporting"
+)
+
+type Postgres struct {
+	db     *sqlx.DB
+	schema string
+	tracer trace.Tracer
+}
+
+func NewPostgres(db *sqlx.DB, schema string) *Postgres {
+	return &Postgres{
+		db:     db,
+		schema: schema,
+		tracer: otel.Tracer("flashlight/authsessionrepository/postgres"),
+	}
+}
+
+type dbAuthSession struct {
+	ID             string       `db:"id"`
+	IdentityType   string       `db:"identity_type"`
+	IdentityKey    string       `db:"identity_key"`
+	IPHash         string       `db:"ip_hash"`
+	CreatedAt      time.Time    `db:"created_at"`
+	ExpiresAt      time.Time    `db:"expires_at"`
+	RefreshUntil   time.Time    `db:"refresh_until"`
+	LifetimeEndsAt time.Time    `db:"lifetime_ends_at"`
+	LastUsedAt     time.Time    `db:"last_used_at"`
+	RevokedAt      sql.NullTime `db:"revoked_at"`
+}
+
+// dbIdentityType is the on-disk representation of an identity type.
+type dbIdentityType string
+
+const dbIdentityTypeAnonymous dbIdentityType = "anonymous"
+
+// Revoked-reason values written to the revoked_reason column. These
+// are DB-only audit data — not surfaced on the domain model and not
+// returned to clients — so they live here next to the SQL that writes
+// them.
+const (
+	revokedReasonReplaced       = "replaced"
+	revokedReasonExpired        = "expired"
+	revokedReasonEvictedByIPCap = "evicted_by_ip_cap"
+)
+
+func identityTypeFromDB(s string) (domain.AuthSessionIdentityType, error) {
+	switch dbIdentityType(s) {
+	case dbIdentityTypeAnonymous:
+		return domain.AuthSessionIdentityAnonymous, nil
+	default:
+		return "", fmt.Errorf("unknown identity_type in db: %q", s)
+	}
+}
+
+func identityTypeToDB(t domain.AuthSessionIdentityType) (string, error) {
+	switch t {
+	case domain.AuthSessionIdentityAnonymous:
+		return string(dbIdentityTypeAnonymous), nil
+	default:
+		return "", fmt.Errorf("unknown identity type: %q", string(t))
+	}
+}
+
+func (r dbAuthSession) toDomain() (domain.AuthSession, error) {
+	identityType, err := identityTypeFromDB(r.IdentityType)
+	if err != nil {
+		return domain.AuthSession{}, fmt.Errorf("failed to decode identity type from db: %w", err)
+	}
+	var revokedAt *time.Time
+	if r.RevokedAt.Valid {
+		t := r.RevokedAt.Time
+		revokedAt = &t
+	}
+	return domain.AuthSession{
+		ID:             r.ID,
+		IdentityType:   identityType,
+		IdentityKey:    r.IdentityKey,
+		IPHash:         r.IPHash,
+		CreatedAt:      r.CreatedAt,
+		ExpiresAt:      r.ExpiresAt,
+		RefreshUntil:   r.RefreshUntil,
+		LifetimeEndsAt: r.LifetimeEndsAt,
+		LastUsedAt:     r.LastUsedAt,
+		RevokedAt:      revokedAt,
+	}, nil
+}
+
+// Create inserts a complete session into the table. The caller is
+// responsible for filling in every field, including a unique ID and a
+// last_used_at value (typically set to created_at on initial issue).
+//
+// Single-active-per-identity is enforced by soft-revoking any existing
+// active row for the same (identity_type, identity_key) in the same
+// transaction. The reason recorded on the old row is:
+//   - "replaced" if it was still within its refresh window
+//   - "expired"  if it had already aged past it
+//
+// revoked_at follows the reason: "replaced" rows get the current time
+// (the session was actively killed now), "expired" rows get their own
+// expires_at (the session was provably unused after that point — any
+// later validate would have failed and any later refresh would have
+// moved expires_at forward, so a row that aged out to refresh_until
+// without being refreshed cannot have been used past expires_at).
+// Note: rows that never get touched by Create/EnforceActiveIPCap can
+// still sit with revoked_at IS NULL past their refresh_until — for
+// those, the row's expires_at / lifetime_ends_at are the truth.
+func (p *Postgres) Create(ctx context.Context, sess domain.AuthSession) error {
+	ctx, span := p.tracer.Start(ctx, "Postgres.Create")
+	defer span.End()
+
+	identityTypeDB, err := identityTypeToDB(sess.IdentityType)
+	if err != nil {
+		err := fmt.Errorf("failed to encode identity type for create: %w", err)
+		reporting.Report(ctx, err)
+		return err
+	}
+
+	tx, err := p.db.BeginTxx(ctx, nil)
+	if err != nil {
+		err := fmt.Errorf("failed to begin tx for create: %w", err)
+		reporting.Report(ctx, err)
+		return err
+	}
+	defer tx.Rollback()
+
+	// Soft-revoke any existing active row for this identity. Both the
+	// reason and the revoked_at timestamp depend on whether the row
+	// was still within its refresh window: an actively-killed row gets
+	// the current time, an already-aged-out row gets its own
+	// expires_at (the last point at which the session was provably
+	// usable).
+	_, err = tx.ExecContext(
+		ctx,
+		fmt.Sprintf(`UPDATE %s.auth_sessions
+		SET revoked_at = CASE WHEN refresh_until > $1 THEN $1 ELSE expires_at END,
+		    revoked_reason = CASE WHEN refresh_until > $1 THEN $2 ELSE $3 END
+		WHERE identity_type = $4 AND identity_key = $5 AND revoked_at IS NULL`,
+			pq.QuoteIdentifier(p.schema)),
+		sess.CreatedAt,
+		revokedReasonReplaced,
+		revokedReasonExpired,
+		identityTypeDB,
+		sess.IdentityKey,
+	)
+	if err != nil {
+		err := fmt.Errorf("failed to revoke existing active session: %w", err)
+		reporting.Report(ctx, err)
+		return err
+	}
+
+	_, err = tx.ExecContext(
+		ctx,
+		fmt.Sprintf(`INSERT INTO %s.auth_sessions
+		(id, identity_type, identity_key, ip_hash, created_at, expires_at, refresh_until, lifetime_ends_at, last_used_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+			pq.QuoteIdentifier(p.schema)),
+		sess.ID,
+		identityTypeDB,
+		sess.IdentityKey,
+		sess.IPHash,
+		sess.CreatedAt,
+		sess.ExpiresAt,
+		sess.RefreshUntil,
+		sess.LifetimeEndsAt,
+		sess.LastUsedAt,
+	)
+	if err != nil {
+		err := fmt.Errorf("failed to insert auth session: %w", err)
+		reporting.Report(ctx, err)
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		err := fmt.Errorf("failed to commit create: %w", err)
+		reporting.Report(ctx, err)
+		return err
+	}
+	return nil
+}
+
+// Update loads the row by id, calls update on it, and writes the
+// result back inside a single transaction. update sees the live row
+// and returns the desired new state. The row is SELECT-FOR-UPDATE
+// locked between load and write so concurrent updates don't trample
+// each other.
+//
+// Only the mutable fields (ip_hash, expires_at, refresh_until,
+// last_used_at) are written back; everything else (id, identity, time
+// of creation, revocation state) is immutable from this method's
+// perspective.
+//
+// Returns ErrAuthSessionNotFound if the id doesn't exist,
+// ErrAuthSessionRevoked if the row exists but has been revoked,
+// update's error if it returns one (the row is not modified), or any
+// tx/DB error.
+func (p *Postgres) Update(
+	ctx context.Context,
+	id string,
+	update func(domain.AuthSession) (domain.AuthSession, error),
+) (domain.AuthSession, error) {
+	ctx, span := p.tracer.Start(ctx, "Postgres.Update")
+	defer span.End()
+
+	if id == "" {
+		return domain.AuthSession{}, domain.ErrAuthSessionNotFound
+	}
+
+	tx, err := p.db.BeginTxx(ctx, nil)
+	if err != nil {
+		err := fmt.Errorf("failed to begin tx: %w", err)
+		reporting.Report(ctx, err)
+		return domain.AuthSession{}, err
+	}
+	defer tx.Rollback()
+
+	var row dbAuthSession
+	err = tx.QueryRowxContext(
+		ctx,
+		fmt.Sprintf(`SELECT id, identity_type, identity_key, ip_hash,
+			created_at, expires_at, refresh_until, lifetime_ends_at, last_used_at, revoked_at
+			FROM %s.auth_sessions WHERE id = $1 FOR UPDATE`,
+			pq.QuoteIdentifier(p.schema)),
+		id,
+	).StructScan(&row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return domain.AuthSession{}, domain.ErrAuthSessionNotFound
+	}
+	if err != nil {
+		err := fmt.Errorf("failed to load auth session for update: %w", err)
+		reporting.Report(ctx, err)
+		return domain.AuthSession{}, err
+	}
+
+	current, err := row.toDomain()
+	if err != nil {
+		err := fmt.Errorf("failed to decode loaded auth session: %w", err)
+		reporting.Report(ctx, err)
+		return domain.AuthSession{}, err
+	}
+
+	if current.RevokedAt != nil {
+		return domain.AuthSession{}, domain.ErrAuthSessionRevoked
+	}
+
+	updated, err := update(current)
+	if err != nil {
+		return domain.AuthSession{}, fmt.Errorf("auth session update callback: %w", err)
+	}
+
+	_, err = tx.ExecContext(
+		ctx,
+		fmt.Sprintf(`UPDATE %s.auth_sessions
+		SET ip_hash = $1, expires_at = $2, refresh_until = $3, last_used_at = $4
+		WHERE id = $5`,
+			pq.QuoteIdentifier(p.schema)),
+		updated.IPHash,
+		updated.ExpiresAt,
+		updated.RefreshUntil,
+		updated.LastUsedAt,
+		id,
+	)
+	if err != nil {
+		err := fmt.Errorf("failed to update auth session: %w", err)
+		reporting.Report(ctx, err)
+		return domain.AuthSession{}, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		err := fmt.Errorf("failed to commit auth session update: %w", err)
+		reporting.Report(ctx, err)
+		return domain.AuthSession{}, err
+	}
+
+	return updated, nil
+}
+
+// EnforceActiveIPCap soft-revokes sessions for a given
+// (identity_type, ip_hash). Two things happen in a single UPDATE:
+//   - any not-yet-revoked rows past their refresh_until get
+//     revoked_reason = 'expired' and revoked_at = expires_at (the
+//     session was provably unused after that point).
+//   - if the number of still-active rows (revoked_at IS NULL AND
+//     refresh_until > now) exceeds maxActive-1, the oldest excess
+//     gets revoked_reason = 'evicted_by_ip_cap' and revoked_at = now
+//     (the session is being actively killed now to make room).
+//
+// CASE expressions pick reason and timestamp at write time from each
+// row's own refresh_until so each touched row gets the accurate "why"
+// and "when." Idempotent: if there's nothing to revoke, this is a
+// no-op.
+func (p *Postgres) EnforceActiveIPCap(
+	ctx context.Context,
+	identityType domain.AuthSessionIdentityType,
+	ipHash string,
+	maxActive int,
+	now time.Time,
+) error {
+	ctx, span := p.tracer.Start(ctx, "Postgres.EnforceActiveIPCap")
+	defer span.End()
+
+	if maxActive <= 0 {
+		return nil
+	}
+
+	identityTypeDB, err := identityTypeToDB(identityType)
+	if err != nil {
+		err := fmt.Errorf("failed to encode identity type for ip cap: %w", err)
+		reporting.Report(ctx, err)
+		return err
+	}
+
+	_, err = p.db.ExecContext(
+		ctx,
+		fmt.Sprintf(`WITH targets AS (
+			SELECT id FROM %s.auth_sessions
+			WHERE identity_type = $1 AND ip_hash = $2
+			  AND revoked_at IS NULL AND refresh_until <= $3
+			UNION ALL
+			(SELECT id FROM %s.auth_sessions
+			 WHERE identity_type = $1 AND ip_hash = $2
+			   AND revoked_at IS NULL AND refresh_until > $3
+			 ORDER BY created_at DESC
+			 OFFSET $4)
+		)
+		UPDATE %s.auth_sessions
+		SET revoked_at = CASE WHEN refresh_until > $3 THEN $3 ELSE expires_at END,
+		    revoked_reason = CASE WHEN refresh_until > $3 THEN $5 ELSE $6 END
+		WHERE id IN (SELECT id FROM targets)`,
+			pq.QuoteIdentifier(p.schema),
+			pq.QuoteIdentifier(p.schema),
+			pq.QuoteIdentifier(p.schema)),
+		identityTypeDB,
+		ipHash,
+		now,
+		maxActive-1,
+		revokedReasonEvictedByIPCap,
+		revokedReasonExpired,
+	)
+	if err != nil {
+		err := fmt.Errorf("failed to enforce active ip cap: %w", err)
+		reporting.Report(ctx, err)
+		return err
+	}
+	return nil
+}

--- a/internal/adapters/authsessionrepository/postgres_whitebox_test.go
+++ b/internal/adapters/authsessionrepository/postgres_whitebox_test.go
@@ -1,0 +1,450 @@
+package authsessionrepository
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Amund211/flashlight/internal/adapters/database"
+	"github.com/Amund211/flashlight/internal/domain"
+)
+
+func newPostgres(t *testing.T, db *sqlx.DB, schemaSuffix string) (*Postgres, string) {
+	require.NotEmpty(t, schemaSuffix)
+	schema := fmt.Sprintf("auth_sessions_repo_test_%s", schemaSuffix)
+
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	db.MustExec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", pq.QuoteIdentifier(schema)))
+
+	migrator := database.NewDatabaseMigrator(db, logger)
+	err := migrator.Migrate(t.Context(), schema)
+	require.NoError(t, err)
+
+	return NewPostgres(db, schema), schema
+}
+
+// testAuthSessionRow is a test-local projection that also pulls
+// revoked_reason out of the DB so we can assert on the audit field.
+// Production code doesn't expose it on the domain type, but tests
+// want to verify it.
+type testAuthSessionRow struct {
+	ID             string         `db:"id"`
+	IdentityType   string         `db:"identity_type"`
+	IdentityKey    string         `db:"identity_key"`
+	IPHash         string         `db:"ip_hash"`
+	CreatedAt      time.Time      `db:"created_at"`
+	ExpiresAt      time.Time      `db:"expires_at"`
+	RefreshUntil   time.Time      `db:"refresh_until"`
+	LifetimeEndsAt time.Time      `db:"lifetime_ends_at"`
+	LastUsedAt     time.Time      `db:"last_used_at"`
+	RevokedAt      sql.NullTime   `db:"revoked_at"`
+	RevokedReason  sql.NullString `db:"revoked_reason"`
+}
+
+func selectRow(t *testing.T, db *sqlx.DB, schema string, id string) *testAuthSessionRow {
+	t.Helper()
+	ctx := t.Context()
+
+	txx, err := db.Beginx()
+	require.NoError(t, err)
+	defer txx.Rollback()
+
+	_, err = txx.ExecContext(ctx, fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schema)))
+	require.NoError(t, err)
+
+	var row testAuthSessionRow
+	err = txx.QueryRowxContext(
+		ctx,
+		`SELECT id, identity_type, identity_key, ip_hash, created_at, expires_at,
+			refresh_until, lifetime_ends_at, last_used_at, revoked_at, revoked_reason
+			FROM auth_sessions WHERE id = $1`,
+		id,
+	).StructScan(&row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	require.NoError(t, err)
+	return &row
+}
+
+func TestPostgresAuthSession(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping db tests in short mode.")
+	}
+	t.Parallel()
+
+	now := time.Date(2026, 5, 30, 10, 0, 0, 0, time.UTC)
+
+	mkSession := func(id, key string) domain.AuthSession {
+		return domain.AuthSession{
+			ID:             id,
+			IdentityType:   domain.AuthSessionIdentityAnonymous,
+			IdentityKey:    key,
+			IPHash:         "iphash-1",
+			CreatedAt:      now,
+			ExpiresAt:      now.Add(1 * time.Hour),
+			RefreshUntil:   now.Add(2 * time.Hour),
+			LifetimeEndsAt: now.Add(24 * time.Hour),
+			LastUsedAt:     now,
+		}
+	}
+
+	t.Run("Create persists the session with revoked_at NULL", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+
+		db, err := database.NewPostgresDatabase(database.LocalConnectionString)
+		require.NoError(t, err)
+		defer db.Close()
+		p, schema := newPostgres(t, db, "create")
+
+		sess := mkSession("flsess_create-1", "user-A")
+		require.NoError(t, p.Create(ctx, sess))
+
+		row := selectRow(t, db, schema, "flsess_create-1")
+		require.NotNil(t, row)
+		require.False(t, row.RevokedAt.Valid, "fresh row should have NULL revoked_at")
+		require.False(t, row.RevokedReason.Valid)
+		require.True(t, row.LifetimeEndsAt.Equal(sess.LifetimeEndsAt),
+			"lifetime_ends_at should be persisted from the caller-supplied value")
+	})
+
+	t.Run("Create soft-revokes an active replacement as 'replaced'", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+
+		db, err := database.NewPostgresDatabase(database.LocalConnectionString)
+		require.NoError(t, err)
+		defer db.Close()
+		p, schema := newPostgres(t, db, "create_replaces_active")
+
+		old := mkSession("flsess_old", "user-X")
+		require.NoError(t, p.Create(ctx, old))
+
+		// New session created while the old one is still fresh.
+		fresh := mkSession("flsess_new", "user-X")
+		fresh.CreatedAt = now.Add(10 * time.Minute)
+		require.NoError(t, p.Create(ctx, fresh))
+
+		oldRow := selectRow(t, db, schema, "flsess_old")
+		require.NotNil(t, oldRow, "old row should still exist for audit")
+		require.True(t, oldRow.RevokedAt.Valid)
+		require.True(t, oldRow.RevokedReason.Valid)
+		require.Equal(t, revokedReasonReplaced, oldRow.RevokedReason.String)
+		require.True(t, oldRow.RevokedAt.Time.Equal(fresh.CreatedAt),
+			"replaced reaps actively kill the session at the new session's CreatedAt, "+
+				"so revoked_at == that timestamp (not refresh_until)")
+
+		newRow := selectRow(t, db, schema, "flsess_new")
+		require.NotNil(t, newRow)
+		require.False(t, newRow.RevokedAt.Valid)
+	})
+
+	t.Run("Create soft-revokes an aged-out replacement as 'expired'", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+
+		db, err := database.NewPostgresDatabase(database.LocalConnectionString)
+		require.NoError(t, err)
+		defer db.Close()
+		p, schema := newPostgres(t, db, "create_replaces_expired")
+
+		// Old session: expires in 20min, refresh window ends 30min in.
+		old := mkSession("flsess_old", "user-Y")
+		old.CreatedAt = now
+		old.ExpiresAt = now.Add(20 * time.Minute)
+		old.RefreshUntil = now.Add(30 * time.Minute)
+		require.NoError(t, p.Create(ctx, old))
+
+		// New session created an hour later — past the old refresh window.
+		fresh := mkSession("flsess_new", "user-Y")
+		fresh.CreatedAt = now.Add(1 * time.Hour)
+		fresh.ExpiresAt = fresh.CreatedAt.Add(1 * time.Hour)
+		fresh.RefreshUntil = fresh.CreatedAt.Add(2 * time.Hour)
+		require.NoError(t, p.Create(ctx, fresh))
+
+		oldRow := selectRow(t, db, schema, "flsess_old")
+		require.NotNil(t, oldRow)
+		require.True(t, oldRow.RevokedAt.Valid)
+		require.Equal(t, revokedReasonExpired, oldRow.RevokedReason.String)
+		require.True(t, oldRow.RevokedAt.Time.Equal(oldRow.ExpiresAt),
+			"expired reaps stamp revoked_at = expires_at — the last point the "+
+				"session was provably usable; anything past that is dead time")
+	})
+
+	t.Run("Update applies fn and persists the result", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		db, err := database.NewPostgresDatabase(database.LocalConnectionString)
+		require.NoError(t, err)
+		defer db.Close()
+		p, schema := newPostgres(t, db, "update_apply")
+
+		original := mkSession("flsess_u", "user-U")
+		require.NoError(t, p.Create(ctx, original))
+
+		bumped := now.Add(30 * time.Minute)
+		// Try to mutate lifetime_ends_at via the callback to verify
+		// Update doesn't write it.
+		tamperedLifetime := original.LifetimeEndsAt.Add(48 * time.Hour)
+		updated, err := p.Update(ctx, "flsess_u", func(s domain.AuthSession) (domain.AuthSession, error) {
+			s.ExpiresAt = bumped.Add(1 * time.Hour)
+			s.RefreshUntil = bumped.Add(2 * time.Hour)
+			s.IPHash = "iphash-new"
+			s.LastUsedAt = bumped
+			s.LifetimeEndsAt = tamperedLifetime
+			return s, nil
+		})
+		require.NoError(t, err)
+		require.WithinDuration(t, bumped.Add(1*time.Hour), updated.ExpiresAt, time.Millisecond)
+		require.Equal(t, "iphash-new", updated.IPHash)
+
+		row := selectRow(t, db, schema, "flsess_u")
+		require.NotNil(t, row)
+		require.Equal(t, "iphash-new", row.IPHash)
+		require.True(t, row.LifetimeEndsAt.Equal(original.LifetimeEndsAt),
+			"Update must not write lifetime_ends_at, even if the callback returns a different value")
+	})
+
+	t.Run("Update propagates fn errors without writing", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		db, err := database.NewPostgresDatabase(database.LocalConnectionString)
+		require.NoError(t, err)
+		defer db.Close()
+		p, schema := newPostgres(t, db, "update_fn_err")
+
+		require.NoError(t, p.Create(ctx, mkSession("flsess_e", "user-E")))
+
+		_, err = p.Update(ctx, "flsess_e", func(s domain.AuthSession) (domain.AuthSession, error) {
+			return domain.AuthSession{}, domain.ErrAuthSessionRefreshExpired
+		})
+		require.ErrorIs(t, err, domain.ErrAuthSessionRefreshExpired)
+
+		row := selectRow(t, db, schema, "flsess_e")
+		require.NotNil(t, row, "session should still exist")
+		require.Equal(t, "iphash-1", row.IPHash, "row should not have been modified")
+	})
+
+	t.Run("Update on missing id returns NotFound", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		db, err := database.NewPostgresDatabase(database.LocalConnectionString)
+		require.NoError(t, err)
+		defer db.Close()
+		p, _ := newPostgres(t, db, "update_missing")
+
+		_, err = p.Update(ctx, "flsess_no-such", func(s domain.AuthSession) (domain.AuthSession, error) {
+			t.Fatal("fn should not be called for missing id")
+			return s, nil
+		})
+		require.ErrorIs(t, err, domain.ErrAuthSessionNotFound)
+	})
+
+	t.Run("Update on revoked id returns ErrAuthSessionRevoked", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		db, err := database.NewPostgresDatabase(database.LocalConnectionString)
+		require.NoError(t, err)
+		defer db.Close()
+		p, schema := newPostgres(t, db, "update_revoked")
+
+		require.NoError(t, p.Create(ctx, mkSession("flsess_old", "user-R")))
+		// Trigger soft-revoke via Create-replaces.
+		later := mkSession("flsess_new", "user-R")
+		later.CreatedAt = now.Add(5 * time.Minute)
+		require.NoError(t, p.Create(ctx, later))
+
+		_, err = p.Update(ctx, "flsess_old", func(s domain.AuthSession) (domain.AuthSession, error) {
+			t.Fatal("update callback should not run on a revoked session")
+			return s, nil
+		})
+		require.ErrorIs(t, err, domain.ErrAuthSessionRevoked)
+
+		// Old row's revoked state should be untouched by the failed Update.
+		row := selectRow(t, db, schema, "flsess_old")
+		require.NotNil(t, row)
+		require.Equal(t, revokedReasonReplaced, row.RevokedReason.String)
+	})
+
+	t.Run("EnforceActiveIPCap soft-revokes excess oldest with 'evicted_by_ip_cap'", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		db, err := database.NewPostgresDatabase(database.LocalConnectionString)
+		require.NoError(t, err)
+		defer db.Close()
+		p, schema := newPostgres(t, db, "evict_excess")
+
+		mk := func(id, key string, createdAt time.Time) domain.AuthSession {
+			s := mkSession(id, key)
+			s.IPHash = "ip-z"
+			s.CreatedAt = createdAt
+			s.LastUsedAt = createdAt
+			s.ExpiresAt = createdAt.Add(1 * time.Hour)
+			s.RefreshUntil = createdAt.Add(2 * time.Hour)
+			return s
+		}
+		require.NoError(t, p.Create(ctx, mk("flsess_old", "u-old", now)))
+		require.NoError(t, p.Create(ctx, mk("flsess_mid", "u-mid", now.Add(1*time.Minute))))
+		require.NoError(t, p.Create(ctx, mk("flsess_new", "u-new", now.Add(2*time.Minute))))
+
+		// cap=2 means keep at most 1 active so a new insert lands within cap.
+		callNow := now.Add(3 * time.Minute)
+		require.NoError(t, p.EnforceActiveIPCap(ctx, domain.AuthSessionIdentityAnonymous, "ip-z", 2, callNow))
+
+		oldRow := selectRow(t, db, schema, "flsess_old")
+		require.NotNil(t, oldRow, "evicted rows should still exist for audit")
+		require.True(t, oldRow.RevokedAt.Valid)
+		require.Equal(t, revokedReasonEvictedByIPCap, oldRow.RevokedReason.String)
+		require.True(t, oldRow.RevokedAt.Time.Equal(callNow),
+			"actively-evicted rows are killed now, so revoked_at == call's now")
+
+		midRow := selectRow(t, db, schema, "flsess_mid")
+		require.NotNil(t, midRow)
+		require.True(t, midRow.RevokedAt.Valid)
+		require.Equal(t, revokedReasonEvictedByIPCap, midRow.RevokedReason.String)
+		require.True(t, midRow.RevokedAt.Time.Equal(callNow))
+
+		newRow := selectRow(t, db, schema, "flsess_new")
+		require.NotNil(t, newRow)
+		require.False(t, newRow.RevokedAt.Valid, "newest should remain active")
+	})
+
+	t.Run("EnforceActiveIPCap marks expired sessions as 'expired'", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		db, err := database.NewPostgresDatabase(database.LocalConnectionString)
+		require.NoError(t, err)
+		defer db.Close()
+		p, schema := newPostgres(t, db, "evict_marks_expired")
+
+		mk := func(id, key string, refreshUntil time.Time) domain.AuthSession {
+			s := mkSession(id, key)
+			s.IPHash = "ip-y"
+			// Keep expires_at strictly before refresh_until so the row
+			// shape is realistic for both expired and active cases.
+			s.ExpiresAt = refreshUntil.Add(-30 * time.Minute)
+			s.RefreshUntil = refreshUntil
+			return s
+		}
+		require.NoError(t, p.Create(ctx, mk("flsess_expired", "u-e", now.Add(-1*time.Hour))))
+		require.NoError(t, p.Create(ctx, mk("flsess_active", "u-a", now.Add(1*time.Hour))))
+
+		require.NoError(t, p.EnforceActiveIPCap(ctx, domain.AuthSessionIdentityAnonymous, "ip-y", 2, now))
+
+		expiredRow := selectRow(t, db, schema, "flsess_expired")
+		require.NotNil(t, expiredRow)
+		require.True(t, expiredRow.RevokedAt.Valid,
+			"aged-out session should now be revoked")
+		require.Equal(t, revokedReasonExpired, expiredRow.RevokedReason.String)
+		require.True(t, expiredRow.RevokedAt.Time.Equal(expiredRow.ExpiresAt),
+			"expired reaps stamp revoked_at = expires_at, not the call's now")
+
+		activeRow := selectRow(t, db, schema, "flsess_active")
+		require.NotNil(t, activeRow)
+		require.False(t, activeRow.RevokedAt.Valid,
+			"still-active session under cap should be untouched")
+	})
+
+	t.Run("EnforceActiveIPCap mixes 'evicted_by_ip_cap' and 'expired' in one call", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		db, err := database.NewPostgresDatabase(database.LocalConnectionString)
+		require.NoError(t, err)
+		defer db.Close()
+		p, schema := newPostgres(t, db, "evict_mixed_reasons")
+
+		mk := func(id, key string, createdAt, refreshUntil time.Time) domain.AuthSession {
+			s := mkSession(id, key)
+			s.IPHash = "ip-m"
+			s.CreatedAt = createdAt
+			s.LastUsedAt = createdAt
+			s.ExpiresAt = refreshUntil.Add(-30 * time.Minute)
+			s.RefreshUntil = refreshUntil
+			return s
+		}
+		// Two active sessions and one expired one, same IP.
+		require.NoError(t, p.Create(ctx, mk("flsess_active_old", "u-1", now, now.Add(2*time.Hour))))
+		require.NoError(t, p.Create(ctx, mk("flsess_active_new", "u-2", now.Add(1*time.Minute), now.Add(2*time.Hour))))
+		require.NoError(t, p.Create(ctx, mk("flsess_aged", "u-3", now.Add(-3*time.Hour), now.Add(-1*time.Hour))))
+
+		// cap=2 → keep at most 1 active so the over-cap active gets
+		// 'evicted_by_ip_cap' and the aged one gets 'expired'.
+		callNow := now.Add(2 * time.Minute)
+		require.NoError(t, p.EnforceActiveIPCap(ctx, domain.AuthSessionIdentityAnonymous, "ip-m", 2, callNow))
+
+		oldActive := selectRow(t, db, schema, "flsess_active_old")
+		require.NotNil(t, oldActive)
+		require.True(t, oldActive.RevokedAt.Valid)
+		require.Equal(t, revokedReasonEvictedByIPCap, oldActive.RevokedReason.String,
+			"still-active over-cap session should be 'evicted_by_ip_cap'")
+		require.True(t, oldActive.RevokedAt.Time.Equal(callNow),
+			"evicted-while-active rows are killed now, so revoked_at == call's now")
+
+		aged := selectRow(t, db, schema, "flsess_aged")
+		require.NotNil(t, aged)
+		require.True(t, aged.RevokedAt.Valid)
+		require.Equal(t, revokedReasonExpired, aged.RevokedReason.String,
+			"aged-out session should be 'expired'")
+		require.True(t, aged.RevokedAt.Time.Equal(aged.ExpiresAt),
+			"expired-and-reaped rows stamp revoked_at = expires_at, even when reaped alongside an active eviction")
+
+		newActive := selectRow(t, db, schema, "flsess_active_new")
+		require.NotNil(t, newActive)
+		require.False(t, newActive.RevokedAt.Valid,
+			"newest active under cap should be untouched")
+	})
+
+	t.Run("EnforceActiveIPCap ignores already-revoked sessions", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		db, err := database.NewPostgresDatabase(database.LocalConnectionString)
+		require.NoError(t, err)
+		defer db.Close()
+		p, schema := newPostgres(t, db, "evict_skips_revoked")
+
+		// Three sessions for the same ip+identity_key; Create chain
+		// will soft-revoke earlier ones as 'replaced'.
+		mk := func(id string, createdAt time.Time) domain.AuthSession {
+			s := mkSession(id, "u-r")
+			s.IPHash = "ip-r"
+			s.CreatedAt = createdAt
+			s.LastUsedAt = createdAt
+			s.ExpiresAt = createdAt.Add(1 * time.Hour)
+			s.RefreshUntil = createdAt.Add(2 * time.Hour)
+			return s
+		}
+		require.NoError(t, p.Create(ctx, mk("flsess_v1", now)))
+		require.NoError(t, p.Create(ctx, mk("flsess_v2", now.Add(1*time.Minute))))
+		require.NoError(t, p.Create(ctx, mk("flsess_v3", now.Add(2*time.Minute))))
+
+		// At this point: v1 and v2 are revoked ('replaced'), v3 active.
+		// cap=4 → no eviction needed; check that already-revoked rows
+		// aren't disturbed.
+		require.NoError(t, p.EnforceActiveIPCap(ctx, domain.AuthSessionIdentityAnonymous, "ip-r", 4, now.Add(3*time.Minute)))
+
+		v1 := selectRow(t, db, schema, "flsess_v1")
+		require.NotNil(t, v1)
+		require.Equal(t, revokedReasonReplaced, v1.RevokedReason.String,
+			"reason should remain 'replaced', not overwritten by EnforceActiveIPCap")
+	})
+
+	t.Run("EnforceActiveIPCap no-op when under cap", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		db, err := database.NewPostgresDatabase(database.LocalConnectionString)
+		require.NoError(t, err)
+		defer db.Close()
+		p, _ := newPostgres(t, db, "evict_under_cap")
+
+		require.NoError(t, p.EnforceActiveIPCap(ctx, domain.AuthSessionIdentityAnonymous, "no-ip", 4, now))
+	})
+}

--- a/internal/adapters/database/migrations/8_create_auth_sessions_table.down.sql
+++ b/internal/adapters/database/migrations/8_create_auth_sessions_table.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS auth_sessions_active_identity;
+DROP INDEX IF EXISTS auth_sessions_ip_hash;
+DROP TABLE IF EXISTS auth_sessions;

--- a/internal/adapters/database/migrations/8_create_auth_sessions_table.up.sql
+++ b/internal/adapters/database/migrations/8_create_auth_sessions_table.up.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS auth_sessions (
+    id              TEXT PRIMARY KEY,
+    identity_type   TEXT NOT NULL,
+    identity_key    TEXT NOT NULL,
+    ip_hash         TEXT NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL,
+    expires_at      TIMESTAMPTZ NOT NULL,
+    refresh_until   TIMESTAMPTZ NOT NULL,
+    lifetime_ends_at TIMESTAMPTZ NOT NULL,
+    last_used_at    TIMESTAMPTZ NOT NULL,
+    revoked_at      TIMESTAMPTZ,
+    revoked_reason  TEXT
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS auth_sessions_active_identity
+    ON auth_sessions (identity_type, identity_key)
+    WHERE revoked_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS auth_sessions_ip_hash
+    ON auth_sessions (ip_hash);

--- a/internal/app/auth_anonymous_login.go
+++ b/internal/app/auth_anonymous_login.go
@@ -1,0 +1,67 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Amund211/flashlight/internal/domain"
+)
+
+// anonymousLoginRepository is the subset of the auth-session
+// repository that BuildAnonymousLogin depends on.
+type anonymousLoginRepository interface {
+	Create(ctx context.Context, sess domain.AuthSession) error
+	EnforceActiveIPCap(ctx context.Context, identityType domain.AuthSessionIdentityType, ipHash string, maxActive int, now time.Time) error
+}
+
+// authAnonymousIPCap is the max number of concurrently-active
+// anonymous sessions per ip_hash. When exceeded, the oldest active
+// sessions are evicted before issuing a new one.
+const authAnonymousIPCap = 4
+
+// AnonymousLogin issues a new anonymous-tier session for (userID,
+// ipHash). It enforces the per-IP anonymous session cap by deleting
+// the oldest active sessions for the ip until there's room, then
+// inserts (or upserts, single-active-per-identity) the new row.
+//
+// userID is trusted as-is — input shape validation is the caller's
+// responsibility.
+type AnonymousLogin func(ctx context.Context, userID string, ipHash string) (domain.AuthSession, error)
+
+func BuildAnonymousLogin(
+	repo anonymousLoginRepository,
+	nowFunc func() time.Time,
+	generateSessionID func() (string, error),
+) AnonymousLogin {
+	return func(ctx context.Context, userID string, ipHash string) (domain.AuthSession, error) {
+		now := nowFunc()
+
+		if err := repo.EnforceActiveIPCap(ctx, domain.AuthSessionIdentityAnonymous, ipHash, authAnonymousIPCap, now); err != nil {
+			return domain.AuthSession{}, fmt.Errorf("failed to enforce ip cap: %w", err)
+		}
+
+		id, err := generateSessionID()
+		if err != nil {
+			return domain.AuthSession{}, fmt.Errorf("failed to generate session id: %w", err)
+		}
+
+		sess := domain.AuthSession{
+			ID:             id,
+			IdentityType:   domain.AuthSessionIdentityAnonymous,
+			IdentityKey:    userID,
+			IPHash:         ipHash,
+			CreatedAt:      now,
+			ExpiresAt:      now.Add(authSessionTTL),
+			RefreshUntil:   now.Add(authRefreshWindow),
+			LifetimeEndsAt: now.Add(authMaxSessionAge),
+			LastUsedAt:     now,
+		}
+
+		if err := repo.Create(ctx, sess); err != nil {
+			return domain.AuthSession{}, fmt.Errorf("failed to create anonymous session: %w", err)
+		}
+
+		return sess, nil
+	}
+}

--- a/internal/app/auth_anonymous_login_test.go
+++ b/internal/app/auth_anonymous_login_test.go
@@ -1,0 +1,99 @@
+package app_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Amund211/flashlight/internal/app"
+	"github.com/Amund211/flashlight/internal/domain"
+)
+
+// authAnonymousIPCap mirrors the production constant in
+// auth_anonymous_login.go. Kept here because it's anonymous-specific
+// and only referenced by these tests.
+const authAnonymousIPCap = 4
+
+func TestBuildAnonymousLogin(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("issues a session with computed timestamps and a generated id", func(t *testing.T) {
+		t.Parallel()
+		now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+
+		var enforceCalled, createCalled, generated bool
+		repo := &fakeAuthSessionRepo{
+			enforceActiveIPCapFn: func(_ context.Context, identityType domain.AuthSessionIdentityType, ipHash string, maxActive int, capNow time.Time) error {
+				enforceCalled = true
+				require.Equal(t, domain.AuthSessionIdentityAnonymous, identityType)
+				require.Equal(t, "iphash-abc", ipHash)
+				require.Equal(t, authAnonymousIPCap, maxActive)
+				require.Equal(t, now, capNow)
+				return nil
+			},
+			createFn: func(_ context.Context, sess domain.AuthSession) error {
+				createCalled = true
+				require.Equal(t, "flsess_test-id", sess.ID)
+				require.Equal(t, domain.AuthSessionIdentityAnonymous, sess.IdentityType)
+				require.Equal(t, "user-12345", sess.IdentityKey)
+				require.Equal(t, "iphash-abc", sess.IPHash)
+				require.Equal(t, now, sess.CreatedAt)
+				require.Equal(t, now.Add(authSessionTTL), sess.ExpiresAt)
+				require.Equal(t, now.Add(authRefreshWindow), sess.RefreshUntil)
+				require.Equal(t, now, sess.LastUsedAt,
+					"app should set LastUsedAt to CreatedAt on issue")
+				return nil
+			},
+		}
+		generate := func() (string, error) {
+			generated = true
+			return "flsess_test-id", nil
+		}
+
+		login := app.BuildAnonymousLogin(repo, func() time.Time { return now }, generate)
+		sess, err := login(ctx, "user-12345", "iphash-abc")
+		require.NoError(t, err)
+
+		require.True(t, enforceCalled)
+		require.True(t, generated)
+		require.True(t, createCalled)
+		require.Equal(t, "flsess_test-id", sess.ID)
+		require.Equal(t, now, sess.LastUsedAt)
+	})
+
+	t.Run("propagates EnforceActiveIPCap errors and does not generate or Create", func(t *testing.T) {
+		t.Parallel()
+		repo := &fakeAuthSessionRepo{
+			enforceActiveIPCapFn: func(_ context.Context, _ domain.AuthSessionIdentityType, _ string, _ int, _ time.Time) error {
+				return errors.New("ip cap query failed")
+			},
+		}
+		generate := func() (string, error) {
+			t.Fatal("generate should not be called when EnforceActiveIPCap fails")
+			return "", nil
+		}
+		login := app.BuildAnonymousLogin(repo, time.Now, generate)
+		_, err := login(ctx, "user-A", "ipA")
+		require.Error(t, err)
+	})
+
+	t.Run("propagates generator errors and does not Create", func(t *testing.T) {
+		t.Parallel()
+		repo := &fakeAuthSessionRepo{
+			enforceActiveIPCapFn: func(_ context.Context, _ domain.AuthSessionIdentityType, _ string, _ int, _ time.Time) error {
+				return nil
+			},
+		}
+		generate := func() (string, error) {
+			return "", errors.New("rand failed")
+		}
+		login := app.BuildAnonymousLogin(repo, time.Now, generate)
+		_, err := login(ctx, "user-A", "ipA")
+		require.Error(t, err)
+	})
+}

--- a/internal/app/auth_helpers_test.go
+++ b/internal/app/auth_helpers_test.go
@@ -1,0 +1,54 @@
+package app_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/Amund211/flashlight/internal/domain"
+)
+
+// Local mirrors of the production tier-agnostic tunables. Kept in
+// lockstep manually: if you change a value in auth_session.go, change
+// it here too. We duplicate rather than export to keep the production
+// package's surface internal — these values are policy, not API.
+const (
+	authSessionTTL    = 1 * time.Hour
+	authRefreshWindow = 2 * time.Hour
+	authMaxSessionAge = 24 * time.Hour
+)
+
+const sessionIDPrefix = "flsess_"
+
+// fakeAuthSessionRepo is a function-field stub satisfying the
+// file-local repository interfaces in the app package by structural
+// typing. Each test wires up only the methods it expects to be called;
+// an unconfigured method will panic with a nil-pointer dereference,
+// which is the signal that the use case touched a repo method the test
+// didn't expect.
+type fakeAuthSessionRepo struct {
+	createFn             func(ctx context.Context, sess domain.AuthSession) error
+	updateFn             func(ctx context.Context, id string, update func(domain.AuthSession) (domain.AuthSession, error)) (domain.AuthSession, error)
+	enforceActiveIPCapFn func(ctx context.Context, identityType domain.AuthSessionIdentityType, ipHash string, maxActive int, now time.Time) error
+}
+
+func (f *fakeAuthSessionRepo) Create(ctx context.Context, sess domain.AuthSession) error {
+	return f.createFn(ctx, sess)
+}
+
+func (f *fakeAuthSessionRepo) Update(
+	ctx context.Context,
+	id string,
+	update func(domain.AuthSession) (domain.AuthSession, error),
+) (domain.AuthSession, error) {
+	return f.updateFn(ctx, id, update)
+}
+
+func (f *fakeAuthSessionRepo) EnforceActiveIPCap(
+	ctx context.Context,
+	identityType domain.AuthSessionIdentityType,
+	ipHash string,
+	maxActive int,
+	now time.Time,
+) error {
+	return f.enforceActiveIPCapFn(ctx, identityType, ipHash, maxActive, now)
+}

--- a/internal/app/auth_refresh.go
+++ b/internal/app/auth_refresh.go
@@ -1,0 +1,59 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Amund211/flashlight/internal/domain"
+)
+
+// refreshRepository is the subset of the auth-session repository that
+// BuildRefreshSession depends on.
+type refreshRepository interface {
+	Update(ctx context.Context, id string, update func(domain.AuthSession) (domain.AuthSession, error)) (domain.AuthSession, error)
+}
+
+// RefreshSession bumps the lifetime of an existing session given its
+// bearer id. Accepts ids that are past expires_at but still within
+// refresh_until and lifetime_ends_at. Updates ip_hash so roaming
+// clients don't get stuck on stale ip counters.
+type RefreshSession func(ctx context.Context, sessionID string, ipHash string) (domain.AuthSession, error)
+
+func BuildRefreshSession(repo refreshRepository, nowFunc func() time.Time) RefreshSession {
+	return func(ctx context.Context, sessionID string, ipHash string) (domain.AuthSession, error) {
+		if sessionID == "" {
+			return domain.AuthSession{}, domain.ErrAuthSessionNotFound
+		}
+
+		now := nowFunc()
+
+		sess, err := repo.Update(ctx, sessionID, func(s domain.AuthSession) (domain.AuthSession, error) {
+			if now.After(s.RefreshUntil) {
+				return domain.AuthSession{}, domain.ErrAuthSessionRefreshExpired
+			}
+			if !now.Before(s.LifetimeEndsAt) {
+				return domain.AuthSession{}, domain.ErrAuthSessionRefreshExpired
+			}
+
+			newExpiresAt := now.Add(authSessionTTL)
+			newRefreshUntil := now.Add(authRefreshWindow)
+			if newExpiresAt.After(s.LifetimeEndsAt) {
+				newExpiresAt = s.LifetimeEndsAt
+			}
+			if newRefreshUntil.After(s.LifetimeEndsAt) {
+				newRefreshUntil = s.LifetimeEndsAt
+			}
+
+			s.ExpiresAt = newExpiresAt
+			s.RefreshUntil = newRefreshUntil
+			s.IPHash = ipHash
+			s.LastUsedAt = now
+			return s, nil
+		})
+		if err != nil {
+			return domain.AuthSession{}, fmt.Errorf("failed to refresh session: %w", err)
+		}
+		return sess, nil
+	}
+}

--- a/internal/app/auth_refresh_test.go
+++ b/internal/app/auth_refresh_test.go
@@ -1,0 +1,180 @@
+package app_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Amund211/flashlight/internal/app"
+	"github.com/Amund211/flashlight/internal/domain"
+)
+
+func TestBuildRefreshSession(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// refreshUpdateRepo wires up Update so the test's "current session"
+	// value is passed to the fn under test, and the fn's transformed
+	// result is returned to the caller as if it had been persisted.
+	refreshUpdateRepo := func(t *testing.T, current domain.AuthSession, wantID string) *fakeAuthSessionRepo {
+		return &fakeAuthSessionRepo{
+			updateFn: func(_ context.Context, id string, fn func(domain.AuthSession) (domain.AuthSession, error)) (domain.AuthSession, error) {
+				require.Equal(t, wantID, id)
+				return fn(current)
+			},
+		}
+	}
+
+	t.Run("bumps lifetimes and ip_hash on a valid session", func(t *testing.T) {
+		t.Parallel()
+		now := time.Date(2026, 1, 1, 12, 30, 0, 0, time.UTC)
+		current := domain.AuthSession{
+			ID:             "flsess_sid",
+			IdentityType:   domain.AuthSessionIdentityAnonymous,
+			IdentityKey:    "user-A",
+			IPHash:         "old-ip",
+			CreatedAt:      now.Add(-30 * time.Minute),
+			ExpiresAt:      now.Add(30 * time.Minute),
+			RefreshUntil:   now.Add(90 * time.Minute),
+			LifetimeEndsAt: now.Add(authMaxSessionAge - 30*time.Minute),
+			LastUsedAt:     now.Add(-30 * time.Minute),
+		}
+
+		refresh := app.BuildRefreshSession(refreshUpdateRepo(t, current, "flsess_sid"), func() time.Time { return now })
+		session, err := refresh(ctx, "flsess_sid", "new-ip")
+		require.NoError(t, err)
+
+		require.Equal(t, "flsess_sid", session.ID)
+		require.Equal(t, now.Add(authSessionTTL), session.ExpiresAt)
+		require.Equal(t, now.Add(authRefreshWindow), session.RefreshUntil)
+	})
+
+	t.Run("update callback returns the exact session the repo would persist", func(t *testing.T) {
+		t.Parallel()
+		// The use case's contract with the repo is "call my update
+		// closure on the current row and persist whatever it returns."
+		// This test captures the closure's *output* directly so we pin
+		// down every field — including the ones that aren't part of
+		// the use case's return value (IPHash, LastUsedAt) and the
+		// immutable fields (ID, IdentityType, CreatedAt,
+		// LifetimeEndsAt) that must round-trip unchanged.
+		now := time.Date(2026, 1, 1, 12, 30, 0, 0, time.UTC)
+		current := domain.AuthSession{
+			ID:             "flsess_sid",
+			IdentityType:   domain.AuthSessionIdentityAnonymous,
+			IdentityKey:    "user-A",
+			IPHash:         "old-ip",
+			CreatedAt:      now.Add(-30 * time.Minute),
+			ExpiresAt:      now.Add(30 * time.Minute),
+			RefreshUntil:   now.Add(90 * time.Minute),
+			LifetimeEndsAt: now.Add(authMaxSessionAge - 30*time.Minute),
+			LastUsedAt:     now.Add(-30 * time.Minute),
+		}
+
+		var captured domain.AuthSession
+		repo := &fakeAuthSessionRepo{
+			updateFn: func(_ context.Context, id string, fn func(domain.AuthSession) (domain.AuthSession, error)) (domain.AuthSession, error) {
+				require.Equal(t, "flsess_sid", id)
+				updated, err := fn(current)
+				captured = updated
+				return updated, err
+			},
+		}
+
+		refresh := app.BuildRefreshSession(repo, func() time.Time { return now })
+		_, err := refresh(ctx, "flsess_sid", "new-ip")
+		require.NoError(t, err)
+
+		require.Equal(t, domain.AuthSession{
+			ID:             current.ID,
+			IdentityType:   current.IdentityType,
+			IdentityKey:    current.IdentityKey,
+			IPHash:         "new-ip",
+			CreatedAt:      current.CreatedAt,
+			ExpiresAt:      now.Add(authSessionTTL),
+			RefreshUntil:   now.Add(authRefreshWindow),
+			LifetimeEndsAt: current.LifetimeEndsAt,
+			LastUsedAt:     now,
+		}, captured)
+	})
+
+	t.Run("rejects refresh past refresh_until", func(t *testing.T) {
+		t.Parallel()
+		now := time.Date(2026, 1, 1, 12, 30, 0, 0, time.UTC)
+		current := domain.AuthSession{
+			ID:             "flsess_sid",
+			IdentityType:   domain.AuthSessionIdentityAnonymous,
+			CreatedAt:      now.Add(-3 * time.Hour),
+			ExpiresAt:      now.Add(-2 * time.Hour),
+			RefreshUntil:   now.Add(-1 * time.Hour),
+			LifetimeEndsAt: now.Add(authMaxSessionAge - 3*time.Hour),
+			LastUsedAt:     now.Add(-3 * time.Hour),
+		}
+		refresh := app.BuildRefreshSession(refreshUpdateRepo(t, current, "flsess_sid"), func() time.Time { return now })
+		_, err := refresh(ctx, "flsess_sid", "ip")
+		require.ErrorIs(t, err, domain.ErrAuthSessionRefreshExpired)
+	})
+
+	t.Run("rejects refresh past lifetime_ends_at", func(t *testing.T) {
+		t.Parallel()
+		now := time.Date(2026, 1, 1, 12, 30, 0, 0, time.UTC)
+		current := domain.AuthSession{
+			ID:           "flsess_sid",
+			IdentityType: domain.AuthSessionIdentityAnonymous,
+			CreatedAt:    now.Add(-(authMaxSessionAge + time.Hour)),
+			// refresh_until still ahead, but the absolute lifetime cap
+			// has passed — refresh must refuse.
+			ExpiresAt:      now.Add(30 * time.Minute),
+			RefreshUntil:   now.Add(90 * time.Minute),
+			LifetimeEndsAt: now.Add(-time.Hour),
+			LastUsedAt:     now.Add(-(authMaxSessionAge + time.Hour)),
+		}
+		refresh := app.BuildRefreshSession(refreshUpdateRepo(t, current, "flsess_sid"), func() time.Time { return now })
+		_, err := refresh(ctx, "flsess_sid", "ip")
+		require.ErrorIs(t, err, domain.ErrAuthSessionRefreshExpired)
+	})
+
+	t.Run("clamps new expires_at and refresh_until to lifetime_ends_at", func(t *testing.T) {
+		t.Parallel()
+		now := time.Date(2026, 1, 1, 12, 30, 0, 0, time.UTC)
+		// Lifetime ends 30 min from now — both the 1h expires window
+		// and the 2h refresh window should get clipped to that.
+		lifetimeEndsAt := now.Add(30 * time.Minute)
+		current := domain.AuthSession{
+			ID:             "flsess_sid",
+			IdentityType:   domain.AuthSessionIdentityAnonymous,
+			CreatedAt:      now.Add(-(authMaxSessionAge - 30*time.Minute)),
+			ExpiresAt:      now.Add(5 * time.Minute),
+			RefreshUntil:   now.Add(25 * time.Minute),
+			LifetimeEndsAt: lifetimeEndsAt,
+			LastUsedAt:     now.Add(-(authMaxSessionAge - 30*time.Minute)),
+		}
+		refresh := app.BuildRefreshSession(refreshUpdateRepo(t, current, "flsess_sid"), func() time.Time { return now })
+		session, err := refresh(ctx, "flsess_sid", "ip")
+		require.NoError(t, err)
+		require.Equal(t, lifetimeEndsAt, session.ExpiresAt)
+		require.Equal(t, lifetimeEndsAt, session.RefreshUntil)
+	})
+
+	t.Run("missing id returns ErrAuthSessionNotFound", func(t *testing.T) {
+		t.Parallel()
+		repo := &fakeAuthSessionRepo{
+			updateFn: func(_ context.Context, _ string, _ func(domain.AuthSession) (domain.AuthSession, error)) (domain.AuthSession, error) {
+				return domain.AuthSession{}, domain.ErrAuthSessionNotFound
+			},
+		}
+		refresh := app.BuildRefreshSession(repo, time.Now)
+		_, err := refresh(ctx, "no-such", "ip")
+		require.ErrorIs(t, err, domain.ErrAuthSessionNotFound)
+	})
+
+	t.Run("empty id rejected without a lookup", func(t *testing.T) {
+		t.Parallel()
+		refresh := app.BuildRefreshSession(&fakeAuthSessionRepo{}, time.Now)
+		_, err := refresh(ctx, "", "ip")
+		require.ErrorIs(t, err, domain.ErrAuthSessionNotFound)
+	})
+}

--- a/internal/app/auth_session.go
+++ b/internal/app/auth_session.go
@@ -1,0 +1,46 @@
+package app
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"time"
+)
+
+// Tier-agnostic tunables that govern session issuance and refresh.
+// Each session row carries the lifetime_ends_at value derived from
+// authMaxSessionAge at issue time, so changing this constant won't
+// retroactively extend already-issued sessions.
+const (
+	// authSessionTTL is how long after creation an issued session can
+	// be used on regular endpoints. Past expires_at the session is
+	// still refreshable up to authRefreshWindow.
+	authSessionTTL = 1 * time.Hour
+
+	// authRefreshWindow is the total window after creation during
+	// which a session can be refreshed. Past it, refresh fails and the
+	// client must re-auth.
+	authRefreshWindow = 2 * time.Hour
+
+	// authMaxSessionAge is the absolute lifetime cap on a session.
+	// Stamped onto each row as lifetime_ends_at at issue time, then
+	// used to clamp refresh extensions; never re-evaluated.
+	authMaxSessionAge = 24 * time.Hour
+)
+
+// sessionIDPrefix tags every server-issued session ID so logs and
+// scraping tools can recognize them at a glance, and so the format can
+// evolve later without breaking comparisons. Tier-agnostic — both
+// anonymous and (future) Microsoft sessions share the prefix.
+const sessionIDPrefix = "flsess_"
+
+// GenerateAuthSessionID returns a 32-byte URL-safe base64 session id
+// with sessionIDPrefix applied. Total length is len(prefix) + 43
+// chars (base64 of 32 bytes without padding).
+func GenerateAuthSessionID() (string, error) {
+	var b [32]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("failed to generate session id: %w", err)
+	}
+	return sessionIDPrefix + base64.RawURLEncoding.EncodeToString(b[:]), nil
+}

--- a/internal/app/auth_session_test.go
+++ b/internal/app/auth_session_test.go
@@ -1,0 +1,30 @@
+package app_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Amund211/flashlight/internal/app"
+)
+
+func TestGenerateAuthSessionID(t *testing.T) {
+	t.Parallel()
+	id1, err := app.GenerateAuthSessionID()
+	require.NoError(t, err)
+	id2, err := app.GenerateAuthSessionID()
+	require.NoError(t, err)
+	// Pin the wire format with a literal so this test fails if the
+	// production prefix ever drifts away from "flsess_" — independent
+	// of whether the test-local mirror happens to be in lockstep.
+	require.True(t, strings.HasPrefix(id1, "flsess_"),
+		"session ids must start with the literal flsess_ prefix")
+	require.True(t, strings.HasPrefix(id2, "flsess_"),
+		"session ids must start with the literal flsess_ prefix")
+	require.True(t, strings.HasPrefix(id1, sessionIDPrefix))
+	require.True(t, strings.HasPrefix(id2, sessionIDPrefix))
+	require.NotEqual(t, id1, id2)
+	// prefix + base64-encoded 32 bytes = 7 + 43 = 50 chars
+	require.Len(t, id1, len(sessionIDPrefix)+43)
+}

--- a/internal/app/auth_validate.go
+++ b/internal/app/auth_validate.go
@@ -1,0 +1,59 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Amund211/flashlight/internal/adapters/cache"
+	"github.com/Amund211/flashlight/internal/domain"
+)
+
+// validateRepository is the subset of the auth-session repository
+// that BuildValidateSession depends on.
+type validateRepository interface {
+	Update(ctx context.Context, id string, update func(domain.AuthSession) (domain.AuthSession, error)) (domain.AuthSession, error)
+}
+
+// ValidateSession looks up a session by id, checks it's still within
+// its expires_at and max-age windows, and bumps last_used_at — all
+// inside a single repository Update call. Used by the bearer
+// middleware on each request.
+//
+// Successful validations are cached so repeat requests from the same
+// session don't hammer Postgres. The cache TTL is the caller's choice;
+// a 1-minute TTL trades up to one minute of staleness (a recently
+// revoked / expired session can still be served from cache that long,
+// and last_used_at gets bumped at most once per TTL window) for a
+// large reduction in DB load on the validate hot path.
+type ValidateSession func(ctx context.Context, sessionID string) (domain.AuthSession, error)
+
+func BuildValidateSession(
+	repo validateRepository,
+	nowFunc func() time.Time,
+	sessionCache cache.Cache[domain.AuthSession],
+) ValidateSession {
+	return func(ctx context.Context, sessionID string) (domain.AuthSession, error) {
+		if sessionID == "" {
+			return domain.AuthSession{}, domain.ErrAuthSessionNotFound
+		}
+
+		sess, _, err := cache.GetOrCreate(ctx, sessionCache, sessionID, func() (domain.AuthSession, error) {
+			now := nowFunc()
+			return repo.Update(ctx, sessionID, func(s domain.AuthSession) (domain.AuthSession, error) {
+				if now.After(s.ExpiresAt) {
+					return domain.AuthSession{}, domain.ErrAuthSessionExpired
+				}
+				if !now.Before(s.LifetimeEndsAt) {
+					return domain.AuthSession{}, domain.ErrAuthSessionExpired
+				}
+				s.LastUsedAt = now
+				return s, nil
+			})
+		})
+		if err != nil {
+			return domain.AuthSession{}, fmt.Errorf("failed to validate session: %w", err)
+		}
+		return sess, nil
+	}
+}

--- a/internal/app/auth_validate_test.go
+++ b/internal/app/auth_validate_test.go
@@ -1,0 +1,181 @@
+package app_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Amund211/flashlight/internal/adapters/cache"
+	"github.com/Amund211/flashlight/internal/app"
+	"github.com/Amund211/flashlight/internal/domain"
+)
+
+// validateUpdateRepo wires up Update so the test's "current session"
+// value is passed to the update closure, and the closure's
+// transformed result is returned to the caller as if it had been
+// persisted. Lets each test verify both the validation branches and
+// the LastUsedAt mutation in one place.
+func validateUpdateRepo(t *testing.T, current domain.AuthSession, wantID string) *fakeAuthSessionRepo {
+	return &fakeAuthSessionRepo{
+		updateFn: func(_ context.Context, id string, update func(domain.AuthSession) (domain.AuthSession, error)) (domain.AuthSession, error) {
+			require.Equal(t, wantID, id)
+			return update(current)
+		},
+	}
+}
+
+func TestBuildValidateSession(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("returns session and bumps last_used_at for a valid session", func(t *testing.T) {
+		t.Parallel()
+		now := time.Date(2026, 1, 1, 12, 30, 0, 0, time.UTC)
+		current := domain.AuthSession{
+			ID:             "flsess_sid",
+			IdentityType:   domain.AuthSessionIdentityAnonymous,
+			IdentityKey:    "user-A",
+			CreatedAt:      now.Add(-10 * time.Minute),
+			ExpiresAt:      now.Add(50 * time.Minute),
+			RefreshUntil:   now.Add(110 * time.Minute),
+			LifetimeEndsAt: now.Add(authMaxSessionAge - 10*time.Minute),
+			LastUsedAt:     now.Add(-5 * time.Minute),
+		}
+
+		var captured domain.AuthSession
+		repo := &fakeAuthSessionRepo{
+			updateFn: func(_ context.Context, id string, update func(domain.AuthSession) (domain.AuthSession, error)) (domain.AuthSession, error) {
+				require.Equal(t, "flsess_sid", id)
+				updated, err := update(current)
+				captured = updated
+				return updated, err
+			},
+		}
+
+		validate := app.BuildValidateSession(repo, func() time.Time { return now }, cache.NewBasicCache[domain.AuthSession]())
+		sess, err := validate(ctx, "flsess_sid")
+		require.NoError(t, err)
+		require.Equal(t, "flsess_sid", sess.ID)
+		require.Equal(t, now, captured.LastUsedAt,
+			"validate should bump LastUsedAt to now")
+	})
+
+	t.Run("second call within cache window skips the repository", func(t *testing.T) {
+		t.Parallel()
+		now := time.Date(2026, 1, 1, 12, 30, 0, 0, time.UTC)
+		current := domain.AuthSession{
+			ID:             "flsess_sid",
+			IdentityType:   domain.AuthSessionIdentityAnonymous,
+			IdentityKey:    "user-A",
+			CreatedAt:      now.Add(-10 * time.Minute),
+			ExpiresAt:      now.Add(50 * time.Minute),
+			RefreshUntil:   now.Add(110 * time.Minute),
+			LifetimeEndsAt: now.Add(authMaxSessionAge - 10*time.Minute),
+			LastUsedAt:     now.Add(-5 * time.Minute),
+		}
+
+		updateCalls := 0
+		repo := &fakeAuthSessionRepo{
+			updateFn: func(_ context.Context, id string, update func(domain.AuthSession) (domain.AuthSession, error)) (domain.AuthSession, error) {
+				updateCalls++
+				return update(current)
+			},
+		}
+
+		validate := app.BuildValidateSession(repo, func() time.Time { return now }, cache.NewBasicCache[domain.AuthSession]())
+		_, err := validate(ctx, "flsess_sid")
+		require.NoError(t, err)
+		_, err = validate(ctx, "flsess_sid")
+		require.NoError(t, err)
+		require.Equal(t, 1, updateCalls,
+			"second call should be served from cache without touching the repo")
+	})
+
+	t.Run("rejects expired session via the update closure", func(t *testing.T) {
+		t.Parallel()
+		now := time.Date(2026, 1, 1, 12, 30, 0, 0, time.UTC)
+		current := domain.AuthSession{
+			ID:             "flsess_sid",
+			IdentityType:   domain.AuthSessionIdentityAnonymous,
+			CreatedAt:      now.Add(-90 * time.Minute),
+			ExpiresAt:      now.Add(-30 * time.Minute),
+			RefreshUntil:   now.Add(30 * time.Minute),
+			LifetimeEndsAt: now.Add(authMaxSessionAge - 90*time.Minute),
+			LastUsedAt:     now.Add(-90 * time.Minute),
+		}
+		validate := app.BuildValidateSession(validateUpdateRepo(t, current, "flsess_sid"), func() time.Time { return now }, cache.NewBasicCache[domain.AuthSession]())
+		_, err := validate(ctx, "flsess_sid")
+		require.ErrorIs(t, err, domain.ErrAuthSessionExpired)
+	})
+
+	t.Run("rejects session past lifetime_ends_at", func(t *testing.T) {
+		t.Parallel()
+		now := time.Date(2026, 1, 1, 12, 30, 0, 0, time.UTC)
+		current := domain.AuthSession{
+			ID:           "flsess_sid",
+			IdentityType: domain.AuthSessionIdentityAnonymous,
+			CreatedAt:    now.Add(-(authMaxSessionAge + 5*time.Minute)),
+			// Within expires_at but past the absolute lifetime cap:
+			ExpiresAt:      now.Add(30 * time.Minute),
+			RefreshUntil:   now.Add(60 * time.Minute),
+			LifetimeEndsAt: now.Add(-5 * time.Minute),
+			LastUsedAt:     now.Add(-(authMaxSessionAge + 5*time.Minute)),
+		}
+		validate := app.BuildValidateSession(validateUpdateRepo(t, current, "flsess_sid"), func() time.Time { return now }, cache.NewBasicCache[domain.AuthSession]())
+		_, err := validate(ctx, "flsess_sid")
+		require.ErrorIs(t, err, domain.ErrAuthSessionExpired)
+	})
+
+	t.Run("missing returns ErrAuthSessionNotFound", func(t *testing.T) {
+		t.Parallel()
+		repo := &fakeAuthSessionRepo{
+			updateFn: func(_ context.Context, _ string, _ func(domain.AuthSession) (domain.AuthSession, error)) (domain.AuthSession, error) {
+				return domain.AuthSession{}, domain.ErrAuthSessionNotFound
+			},
+		}
+		validate := app.BuildValidateSession(repo, time.Now, cache.NewBasicCache[domain.AuthSession]())
+		_, err := validate(ctx, "no-such")
+		require.ErrorIs(t, err, domain.ErrAuthSessionNotFound)
+	})
+
+	t.Run("propagates repo errors", func(t *testing.T) {
+		t.Parallel()
+		repo := &fakeAuthSessionRepo{
+			updateFn: func(_ context.Context, _ string, _ func(domain.AuthSession) (domain.AuthSession, error)) (domain.AuthSession, error) {
+				return domain.AuthSession{}, errors.New("db down")
+			},
+		}
+		validate := app.BuildValidateSession(repo, time.Now, cache.NewBasicCache[domain.AuthSession]())
+		_, err := validate(ctx, "flsess_sid")
+		require.Error(t, err)
+	})
+
+	t.Run("validation errors are not cached", func(t *testing.T) {
+		t.Parallel()
+		updateCalls := 0
+		repo := &fakeAuthSessionRepo{
+			updateFn: func(_ context.Context, _ string, _ func(domain.AuthSession) (domain.AuthSession, error)) (domain.AuthSession, error) {
+				updateCalls++
+				return domain.AuthSession{}, domain.ErrAuthSessionNotFound
+			},
+		}
+		validate := app.BuildValidateSession(repo, time.Now, cache.NewBasicCache[domain.AuthSession]())
+		_, err := validate(ctx, "flsess_sid")
+		require.ErrorIs(t, err, domain.ErrAuthSessionNotFound)
+		_, err = validate(ctx, "flsess_sid")
+		require.ErrorIs(t, err, domain.ErrAuthSessionNotFound)
+		require.Equal(t, 2, updateCalls,
+			"failed validations should not be cached; both calls should hit the repo")
+	})
+
+	t.Run("empty id rejected without a lookup", func(t *testing.T) {
+		t.Parallel()
+		validate := app.BuildValidateSession(&fakeAuthSessionRepo{}, time.Now, cache.NewBasicCache[domain.AuthSession]())
+		_, err := validate(ctx, "")
+		require.ErrorIs(t, err, domain.ErrAuthSessionNotFound)
+	})
+}

--- a/internal/domain/auth_session.go
+++ b/internal/domain/auth_session.go
@@ -1,0 +1,52 @@
+package domain
+
+import (
+	"errors"
+	"time"
+)
+
+// AuthSessionIdentityType discriminates the tier the session represents.
+// Only the anonymous tier is implemented today; the Microsoft tier will
+// add a value here when it lands.
+type AuthSessionIdentityType string
+
+const AuthSessionIdentityAnonymous AuthSessionIdentityType = "anonymous"
+
+// AuthSession is one row in the auth_sessions table — a server-side
+// bearer session, regardless of tier. The discriminator is IdentityType.
+//
+// RevokedAt is nil iff the session is still active (which is to say:
+// not explicitly ended; natural expiry past refresh_until is a
+// separate concept and doesn't set this field). The reason a session
+// was revoked is recorded in the DB but not exposed on the typed
+// model — it's audit data, not load-bearing logic.
+type AuthSession struct {
+	ID           string
+	IdentityType AuthSessionIdentityType
+	IdentityKey  string
+	IPHash       string
+	CreatedAt    time.Time
+	ExpiresAt    time.Time
+	RefreshUntil time.Time
+	// LifetimeEndsAt is the absolute deadline past which this session
+	// can no longer be refreshed, regardless of how many refreshes have
+	// happened. Fixed at issue, never extended.
+	LifetimeEndsAt time.Time
+	LastUsedAt     time.Time
+	RevokedAt      *time.Time
+}
+
+// ErrAuthSessionNotFound is returned when a session id is unknown to the repo.
+var ErrAuthSessionNotFound = errors.New("auth session not found")
+
+// ErrAuthSessionRevoked is returned when an operation is attempted on
+// a session that has been explicitly ended (replaced, evicted, etc.).
+var ErrAuthSessionRevoked = errors.New("auth session revoked")
+
+// ErrAuthSessionExpired is returned by app-layer validation when the
+// session is past its expiry (still potentially refreshable).
+var ErrAuthSessionExpired = errors.New("auth session expired")
+
+// ErrAuthSessionRefreshExpired is returned when the session is past the
+// refresh window or its 24h hard max-age.
+var ErrAuthSessionRefreshExpired = errors.New("auth session refresh window expired")

--- a/internal/ports/auth_anonymous_login.go
+++ b/internal/ports/auth_anonymous_login.go
@@ -1,0 +1,84 @@
+package ports
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/Amund211/flashlight/internal/app"
+	"github.com/Amund211/flashlight/internal/logging"
+	"github.com/Amund211/flashlight/internal/reporting"
+)
+
+type anonymousLoginRequest struct {
+	UserID string `json:"userId"`
+}
+
+// userIDMaxLength is the hard cap above which we reject the request.
+// The legacy X-User-Id header silently truncates at 50 chars
+// (internal/ports/userid.go) and real overlay-generated user_ids are
+// 32 chars (uuid4 hex), so 100 is comfortably above expected traffic;
+// the over-length report below gives us data to tighten the cap later.
+const userIDMaxLength = 100
+
+// userIDWarnLength is the threshold above which we still accept the
+// userId but log to Sentry. Anything above 50 is unexpected (matches
+// the legacy header truncation point) — keep an eye on real-world
+// values before deciding whether to lower the hard cap.
+const userIDWarnLength = 50
+
+// MakeAnonymousLoginHandler returns a handler for POST /v1/auth/anonymous/login.
+// Body: { userId }. Response: a fresh session payload.
+func MakeAnonymousLoginHandler(
+	login app.AnonymousLogin,
+	nowFunc func() time.Time,
+	rootLogger *slog.Logger,
+	sentryMiddleware func(http.HandlerFunc) http.HandlerFunc,
+	blocklistConfig BlocklistConfig,
+) http.HandlerFunc {
+	middleware := ComposeMiddlewares(
+		NewRequestLoggerMiddleware(rootLogger),
+		sentryMiddleware,
+		BuildBlocklistMiddleware(blocklistConfig),
+		buildMetricsMiddleware("auth-anonymous-login"),
+		NewReportingMetaMiddleware("auth-anonymous-login"),
+	)
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		var body anonymousLoginRequest
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1024)).Decode(&body); err != nil {
+			logging.FromContext(ctx).InfoContext(ctx, "Failed to decode anonymous login body", "error", err.Error())
+			http.Error(w, "Invalid request body", http.StatusBadRequest)
+			return
+		}
+
+		if body.UserID == "" || len(body.UserID) > userIDMaxLength {
+			http.Error(w, "Invalid userId", http.StatusBadRequest)
+			return
+		}
+		if len(body.UserID) > userIDWarnLength {
+			reporting.Report(
+				ctx,
+				fmt.Errorf("anonymous login userId longer than expected: len=%d", len(body.UserID)),
+			)
+		}
+
+		ipHash := GetIP(r).Hash()
+
+		sess, err := login(ctx, body.UserID, ipHash)
+		if err != nil {
+			logging.FromContext(ctx).ErrorContext(ctx, "Anonymous login failed", "error", err.Error())
+			reporting.Report(ctx, fmt.Errorf("anonymous login: %w", err))
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+
+		writeAuthSessionResponse(ctx, w, sess, nowFunc())
+	}
+
+	return middleware(handler)
+}

--- a/internal/ports/auth_anonymous_login_test.go
+++ b/internal/ports/auth_anonymous_login_test.go
@@ -1,0 +1,211 @@
+package ports_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Amund211/flashlight/internal/domain"
+	"github.com/Amund211/flashlight/internal/ports"
+)
+
+func TestAnonymousLoginHandler(t *testing.T) {
+	t.Parallel()
+
+	// fixedNow returns a stable nowFunc and the matching base time —
+	// gives the test deterministic deltas to assert against.
+	fixedNow := func(t time.Time) func() time.Time {
+		return func() time.Time { return t }
+	}
+
+	t.Run("returns 200 with duration-based session payload", func(t *testing.T) {
+		t.Parallel()
+		now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+		var sawUserID, sawIPHash string
+		login := func(ctx context.Context, userID, ipHash string) (domain.AuthSession, error) {
+			sawUserID = userID
+			sawIPHash = ipHash
+			return domain.AuthSession{
+				ID:             "sid-123",
+				IdentityType:   domain.AuthSessionIdentityAnonymous,
+				IdentityKey:    userID,
+				CreatedAt:      now,
+				ExpiresAt:      now.Add(1 * time.Hour),
+				RefreshUntil:   now.Add(2 * time.Hour),
+				LifetimeEndsAt: now.Add(24 * time.Hour),
+			}, nil
+		}
+
+		handler := ports.MakeAnonymousLoginHandler(login, fixedNow(now), authTestLogger, noopAuthMiddleware, ports.BlocklistConfig{})
+		body := strings.NewReader(`{"userId":"user-abc"}`)
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/auth/anonymous/login", body)
+		withRequestIP(r, "1.2.3.4")
+		w := httptest.NewRecorder()
+
+		handler(w, r)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+		var resp struct {
+			SessionID             string `json:"sessionId"`
+			Tier                  string `json:"tier"`
+			ExpiresInSeconds      int64  `json:"expiresInSeconds"`
+			RefreshUntilInSeconds int64  `json:"refreshUntilInSeconds"`
+			RefreshInSeconds      int64  `json:"refreshInSeconds"`
+			CanRefresh            bool   `json:"canRefresh"`
+		}
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+		require.Equal(t, "sid-123", resp.SessionID)
+		require.Equal(t, "anonymous", resp.Tier)
+		require.Equal(t, int64(3600), resp.ExpiresInSeconds, "expires_at = now + 1h")
+		require.Equal(t, int64(7200), resp.RefreshUntilInSeconds, "refresh_until = now + 2h")
+		require.Equal(t, int64(3300), resp.RefreshInSeconds, "refresh_at = expires_at - 5min = now + 55min")
+		require.True(t, resp.CanRefresh,
+			"refresh_until < lifetime_ends_at; next refresh can still grant a full window")
+		require.Equal(t, "user-abc", sawUserID)
+		require.NotEmpty(t, sawIPHash)
+	})
+
+	t.Run("sets Cache-Control: no-store on the session response", func(t *testing.T) {
+		t.Parallel()
+		now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+		login := func(ctx context.Context, userID, ipHash string) (domain.AuthSession, error) {
+			return domain.AuthSession{
+				ID:             "sid-cache",
+				IdentityType:   domain.AuthSessionIdentityAnonymous,
+				IdentityKey:    userID,
+				CreatedAt:      now,
+				ExpiresAt:      now.Add(1 * time.Hour),
+				RefreshUntil:   now.Add(2 * time.Hour),
+				LifetimeEndsAt: now.Add(24 * time.Hour),
+			}, nil
+		}
+		handler := ports.MakeAnonymousLoginHandler(login, fixedNow(now), authTestLogger, noopAuthMiddleware, ports.BlocklistConfig{})
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/auth/anonymous/login", strings.NewReader(`{"userId":"user-abc"}`))
+		withRequestIP(r, "1.2.3.4")
+		w := httptest.NewRecorder()
+		handler(w, r)
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "no-store", w.Header().Get("Cache-Control"),
+			"session responses carry a bearer token; no intermediary should cache them")
+	})
+
+	t.Run("canRefresh is false on the last refresh whose refresh_until got pinned to lifetime_ends_at", func(t *testing.T) {
+		t.Parallel()
+		now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+		// Refresh near the cap: refresh_until exactly equals lifetime_ends_at.
+		// expires_at still has a normal 1h ahead — the client gets a
+		// full session this time but should re-auth on the next tick.
+		login := func(ctx context.Context, userID, ipHash string) (domain.AuthSession, error) {
+			capAt := now.Add(90 * time.Minute)
+			return domain.AuthSession{
+				ID:             "sid-late",
+				IdentityType:   domain.AuthSessionIdentityAnonymous,
+				IdentityKey:    userID,
+				CreatedAt:      now.Add(-22 * time.Hour),
+				ExpiresAt:      now.Add(60 * time.Minute),
+				RefreshUntil:   capAt,
+				LifetimeEndsAt: capAt,
+			}, nil
+		}
+		handler := ports.MakeAnonymousLoginHandler(login, fixedNow(now), authTestLogger, noopAuthMiddleware, ports.BlocklistConfig{})
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/auth/anonymous/login", strings.NewReader(`{"userId":"user-late"}`))
+		withRequestIP(r, "1.2.3.4")
+		w := httptest.NewRecorder()
+		handler(w, r)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var resp struct {
+			ExpiresInSeconds int64 `json:"expiresInSeconds"`
+			CanRefresh       bool  `json:"canRefresh"`
+		}
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+		require.Equal(t, int64(3600), resp.ExpiresInSeconds,
+			"client should still get a full session this round")
+		require.False(t, resp.CanRefresh,
+			"refresh_until == lifetime_ends_at; next refresh is clamped, so client must re-auth instead")
+	})
+
+	t.Run("400 on invalid userId", func(t *testing.T) {
+		t.Parallel()
+		login := func(ctx context.Context, userID, ipHash string) (domain.AuthSession, error) {
+			t.Fatal("login should not be called when userId is invalid")
+			return domain.AuthSession{}, nil
+		}
+		handler := ports.MakeAnonymousLoginHandler(login, time.Now, authTestLogger, noopAuthMiddleware, ports.BlocklistConfig{})
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/auth/anonymous/login", strings.NewReader(`{"userId":""}`))
+		withRequestIP(r, "1.2.3.4")
+		w := httptest.NewRecorder()
+		handler(w, r)
+		require.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("400 on userId longer than the hard cap", func(t *testing.T) {
+		t.Parallel()
+		login := func(ctx context.Context, userID, ipHash string) (domain.AuthSession, error) {
+			t.Fatal("login should not be called when userId is too long")
+			return domain.AuthSession{}, nil
+		}
+		handler := ports.MakeAnonymousLoginHandler(login, time.Now, authTestLogger, noopAuthMiddleware, ports.BlocklistConfig{})
+		// 101 chars — past the 100-char hard cap.
+		body := fmt.Sprintf(`{"userId":%q}`, strings.Repeat("x", 101))
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/auth/anonymous/login", strings.NewReader(body))
+		withRequestIP(r, "1.2.3.4")
+		w := httptest.NewRecorder()
+		handler(w, r)
+		require.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("accepts userId in the warn band (above 50, within 100)", func(t *testing.T) {
+		t.Parallel()
+		// 60 chars — over the previous limit but under the new cap.
+		// Behaviour change introduced when we bumped the cap to 100;
+		// the request also fires a reporting.Report call which Sentry
+		// will pick up (not verified here since the reporter is global).
+		longID := strings.Repeat("x", 60)
+		var sawUserID string
+		login := func(ctx context.Context, userID, ipHash string) (domain.AuthSession, error) {
+			sawUserID = userID
+			now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+			return domain.AuthSession{
+				ID:             "sid-warn",
+				IdentityType:   domain.AuthSessionIdentityAnonymous,
+				IdentityKey:    userID,
+				CreatedAt:      now,
+				ExpiresAt:      now.Add(1 * time.Hour),
+				RefreshUntil:   now.Add(2 * time.Hour),
+				LifetimeEndsAt: now.Add(24 * time.Hour),
+			}, nil
+		}
+		handler := ports.MakeAnonymousLoginHandler(login, time.Now, authTestLogger, noopAuthMiddleware, ports.BlocklistConfig{})
+		body := fmt.Sprintf(`{"userId":%q}`, longID)
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/auth/anonymous/login", strings.NewReader(body))
+		withRequestIP(r, "1.2.3.4")
+		w := httptest.NewRecorder()
+		handler(w, r)
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, longID, sawUserID)
+	})
+
+	t.Run("400 on malformed JSON", func(t *testing.T) {
+		t.Parallel()
+		login := func(ctx context.Context, userID, ipHash string) (domain.AuthSession, error) {
+			t.Fatal("login should not be called on malformed body")
+			return domain.AuthSession{}, nil
+		}
+		handler := ports.MakeAnonymousLoginHandler(login, time.Now, authTestLogger, noopAuthMiddleware, ports.BlocklistConfig{})
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/auth/anonymous/login", strings.NewReader(`not-json`))
+		withRequestIP(r, "1.2.3.4")
+		w := httptest.NewRecorder()
+		handler(w, r)
+		require.Equal(t, http.StatusBadRequest, w.Code)
+	})
+}

--- a/internal/ports/auth_helpers_test.go
+++ b/internal/ports/auth_helpers_test.go
@@ -1,0 +1,21 @@
+package ports_test
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+)
+
+var noopAuthMiddleware = func(h http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) { h(w, r) }
+}
+
+var authTestLogger = slog.New(slog.NewTextHandler(io.Discard, nil))
+
+const testGCPLoadBalancerIP = "34.111.7.239"
+
+func withRequestIP(r *http.Request, ip string) {
+	// GetIP looks at X-Forwarded-For and trims the GCP load-balancer IP
+	// from the tail. Setting just the client IP is enough for tests.
+	r.Header.Set("X-Forwarded-For", ip+","+testGCPLoadBalancerIP)
+}

--- a/internal/ports/auth_middleware.go
+++ b/internal/ports/auth_middleware.go
@@ -1,0 +1,82 @@
+package ports
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/Amund211/flashlight/internal/app"
+	"github.com/Amund211/flashlight/internal/domain"
+	"github.com/Amund211/flashlight/internal/logging"
+)
+
+type authSessionCtxKey struct{}
+
+// AuthContext is what the bearer middleware stashes into the request
+// context when a valid Authorization header is present. Absent when the
+// request had no Authorization header (legacy X-User-Id callers).
+type AuthContext struct {
+	SessionID    string
+	IdentityType domain.AuthSessionIdentityType
+	IdentityKey  string
+}
+
+// AuthFromContext returns the auth context attached by the bearer
+// middleware, or (zero, false) when no bearer was sent.
+func AuthFromContext(ctx context.Context) (AuthContext, bool) {
+	v, ok := ctx.Value(authSessionCtxKey{}).(AuthContext)
+	return v, ok
+}
+
+// NewBearerAuthMiddleware returns a middleware that validates an
+// Authorization: Bearer <session-id> header against the auth session
+// store when present. It is passive: requests without an Authorization
+// header pass through unchanged (preserving the legacy X-User-Id
+// flow). When a header IS present but the session is unknown or
+// expired, the request is rejected with 401 — otherwise a bearer
+// would be silently ignored, which would let clients downgrade to the
+// un-authenticated path just by sending a bad token.
+func NewBearerAuthMiddleware(validate app.ValidateSession) func(http.HandlerFunc) http.HandlerFunc {
+	return func(next http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			rawAuth := r.Header.Get("Authorization")
+			if rawAuth == "" {
+				next(w, r)
+				return
+			}
+
+			sessionID, ok := bearerFromAuthorization(r)
+			if !ok {
+				http.Error(w, "Malformed Authorization header", http.StatusUnauthorized)
+				return
+			}
+
+			ctx := r.Context()
+			view, err := validate(ctx, sessionID)
+			switch {
+			case errors.Is(err, domain.ErrAuthSessionNotFound),
+				errors.Is(err, domain.ErrAuthSessionRevoked),
+				errors.Is(err, domain.ErrAuthSessionExpired):
+				http.Error(w, "Invalid or expired session", http.StatusUnauthorized)
+				return
+			case err != nil:
+				logging.FromContext(ctx).ErrorContext(ctx, "Failed to validate bearer session", "error", err.Error())
+				http.Error(w, "Internal server error", http.StatusInternalServerError)
+				return
+			}
+
+			authCtx := AuthContext{
+				SessionID:    view.ID,
+				IdentityType: view.IdentityType,
+				IdentityKey:  view.IdentityKey,
+			}
+			ctx = context.WithValue(ctx, authSessionCtxKey{}, authCtx)
+			ctx = logging.AddMetaToContext(ctx,
+				slog.String("authTier", string(authCtx.IdentityType)),
+				slog.String("authIdentityKey", authCtx.IdentityKey),
+			)
+			next(w, r.WithContext(ctx))
+		}
+	}
+}

--- a/internal/ports/auth_middleware_test.go
+++ b/internal/ports/auth_middleware_test.go
@@ -1,0 +1,109 @@
+package ports_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Amund211/flashlight/internal/domain"
+	"github.com/Amund211/flashlight/internal/ports"
+)
+
+func TestBearerAuthMiddleware(t *testing.T) {
+	t.Parallel()
+
+	t.Run("passes through with no Authorization header", func(t *testing.T) {
+		t.Parallel()
+		called := false
+		validate := func(ctx context.Context, sessionID string) (domain.AuthSession, error) {
+			t.Fatal("validate should not be called when no Authorization header")
+			return domain.AuthSession{}, nil
+		}
+		mw := ports.NewBearerAuthMiddleware(validate)
+		next := func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			_, ok := ports.AuthFromContext(r.Context())
+			require.False(t, ok, "no auth context should be attached without bearer")
+			w.WriteHeader(http.StatusOK)
+		}
+		handler := mw(next)
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/playerdata", http.NoBody)
+		w := httptest.NewRecorder()
+		handler(w, r)
+		require.True(t, called)
+		require.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("attaches auth context for valid bearer", func(t *testing.T) {
+		t.Parallel()
+		validate := func(ctx context.Context, sessionID string) (domain.AuthSession, error) {
+			return domain.AuthSession{
+				ID:           sessionID,
+				IdentityType: domain.AuthSessionIdentityAnonymous,
+				IdentityKey:  "user-xyz",
+			}, nil
+		}
+		mw := ports.NewBearerAuthMiddleware(validate)
+		var seen ports.AuthContext
+		next := func(w http.ResponseWriter, r *http.Request) {
+			ctx, ok := ports.AuthFromContext(r.Context())
+			require.True(t, ok)
+			seen = ctx
+			w.WriteHeader(http.StatusOK)
+		}
+		handler := mw(next)
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/playerdata", http.NoBody)
+		r.Header.Set("Authorization", "Bearer good-token")
+		w := httptest.NewRecorder()
+		handler(w, r)
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "good-token", seen.SessionID)
+		require.Equal(t, domain.AuthSessionIdentityAnonymous, seen.IdentityType)
+		require.Equal(t, "user-xyz", seen.IdentityKey)
+	})
+
+	t.Run("401 on malformed Authorization header", func(t *testing.T) {
+		t.Parallel()
+		validate := func(ctx context.Context, sessionID string) (domain.AuthSession, error) {
+			t.Fatal("validate should not be called for malformed header")
+			return domain.AuthSession{}, nil
+		}
+		mw := ports.NewBearerAuthMiddleware(validate)
+		next := func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("next should not be invoked on malformed header")
+		}
+		handler := mw(next)
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/playerdata", http.NoBody)
+		r.Header.Set("Authorization", "Basic creds")
+		w := httptest.NewRecorder()
+		handler(w, r)
+		require.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+
+	for _, sentinel := range []error{
+		domain.ErrAuthSessionNotFound,
+		domain.ErrAuthSessionRevoked,
+		domain.ErrAuthSessionExpired,
+	} {
+
+		t.Run("401 on "+sentinel.Error(), func(t *testing.T) {
+			t.Parallel()
+			validate := func(ctx context.Context, sessionID string) (domain.AuthSession, error) {
+				return domain.AuthSession{}, sentinel
+			}
+			mw := ports.NewBearerAuthMiddleware(validate)
+			next := func(w http.ResponseWriter, r *http.Request) {
+				t.Fatal("next should not be invoked on invalid session")
+			}
+			handler := mw(next)
+			r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/playerdata", http.NoBody)
+			r.Header.Set("Authorization", "Bearer dead-token")
+			w := httptest.NewRecorder()
+			handler(w, r)
+			require.Equal(t, http.StatusUnauthorized, w.Code)
+		})
+	}
+}

--- a/internal/ports/auth_refresh.go
+++ b/internal/ports/auth_refresh.go
@@ -1,0 +1,64 @@
+package ports
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/Amund211/flashlight/internal/app"
+	"github.com/Amund211/flashlight/internal/domain"
+	"github.com/Amund211/flashlight/internal/logging"
+	"github.com/Amund211/flashlight/internal/reporting"
+)
+
+// MakeAuthRefreshHandler returns a handler for POST /v1/auth/refresh.
+// Accepts a Bearer token (which may be past expires_at but within
+// refresh_until). Tier-agnostic: the underlying use case branches on
+// the stored session.
+func MakeAuthRefreshHandler(
+	refresh app.RefreshSession,
+	nowFunc func() time.Time,
+	rootLogger *slog.Logger,
+	sentryMiddleware func(http.HandlerFunc) http.HandlerFunc,
+	blocklistConfig BlocklistConfig,
+) http.HandlerFunc {
+	middleware := ComposeMiddlewares(
+		NewRequestLoggerMiddleware(rootLogger),
+		sentryMiddleware,
+		BuildBlocklistMiddleware(blocklistConfig),
+		buildMetricsMiddleware("auth-refresh"),
+		NewReportingMetaMiddleware("auth-refresh"),
+	)
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		sessionID, ok := bearerFromAuthorization(r)
+		if !ok {
+			http.Error(w, "Missing bearer token", http.StatusUnauthorized)
+			return
+		}
+
+		ipHash := GetIP(r).Hash()
+
+		view, err := refresh(ctx, sessionID, ipHash)
+		switch {
+		case errors.Is(err, domain.ErrAuthSessionNotFound),
+			errors.Is(err, domain.ErrAuthSessionRevoked),
+			errors.Is(err, domain.ErrAuthSessionRefreshExpired):
+			http.Error(w, "Session is no longer refreshable", http.StatusUnauthorized)
+			return
+		case err != nil:
+			logging.FromContext(ctx).ErrorContext(ctx, "Session refresh failed", "error", err.Error())
+			reporting.Report(ctx, fmt.Errorf("session refresh: %w", err))
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+
+		writeAuthSessionResponse(ctx, w, view, nowFunc())
+	}
+
+	return middleware(handler)
+}

--- a/internal/ports/auth_refresh_test.go
+++ b/internal/ports/auth_refresh_test.go
@@ -1,0 +1,102 @@
+package ports_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Amund211/flashlight/internal/domain"
+	"github.com/Amund211/flashlight/internal/ports"
+)
+
+func TestAuthRefreshHandler(t *testing.T) {
+	t.Parallel()
+
+	t.Run("happy path returns refreshed session payload", func(t *testing.T) {
+		t.Parallel()
+		var sawSessionID string
+		refresh := func(ctx context.Context, sessionID, ipHash string) (domain.AuthSession, error) {
+			sawSessionID = sessionID
+			now := time.Date(2026, 1, 1, 13, 0, 0, 0, time.UTC)
+			return domain.AuthSession{
+				ID:             sessionID,
+				IdentityType:   domain.AuthSessionIdentityAnonymous,
+				CreatedAt:      now.Add(-30 * time.Minute),
+				ExpiresAt:      now.Add(1 * time.Hour),
+				RefreshUntil:   now.Add(2 * time.Hour),
+				LifetimeEndsAt: now.Add(23 * time.Hour),
+			}, nil
+		}
+		handler := ports.MakeAuthRefreshHandler(refresh, time.Now, authTestLogger, noopAuthMiddleware, ports.BlocklistConfig{})
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/auth/refresh", http.NoBody)
+		r.Header.Set("Authorization", "Bearer my-session-id")
+		withRequestIP(r, "1.2.3.4")
+		w := httptest.NewRecorder()
+		handler(w, r)
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "my-session-id", sawSessionID)
+	})
+
+	t.Run("sets Cache-Control: no-store on the refreshed session response", func(t *testing.T) {
+		t.Parallel()
+		refresh := func(ctx context.Context, sessionID, ipHash string) (domain.AuthSession, error) {
+			now := time.Date(2026, 1, 1, 13, 0, 0, 0, time.UTC)
+			return domain.AuthSession{
+				ID:             sessionID,
+				IdentityType:   domain.AuthSessionIdentityAnonymous,
+				CreatedAt:      now.Add(-30 * time.Minute),
+				ExpiresAt:      now.Add(1 * time.Hour),
+				RefreshUntil:   now.Add(2 * time.Hour),
+				LifetimeEndsAt: now.Add(23 * time.Hour),
+			}, nil
+		}
+		handler := ports.MakeAuthRefreshHandler(refresh, time.Now, authTestLogger, noopAuthMiddleware, ports.BlocklistConfig{})
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/auth/refresh", http.NoBody)
+		r.Header.Set("Authorization", "Bearer my-session-id")
+		withRequestIP(r, "1.2.3.4")
+		w := httptest.NewRecorder()
+		handler(w, r)
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "no-store", w.Header().Get("Cache-Control"),
+			"refresh responses carry a bearer token; no intermediary should cache them")
+	})
+
+	t.Run("401 when bearer is missing", func(t *testing.T) {
+		t.Parallel()
+		refresh := func(ctx context.Context, sessionID, ipHash string) (domain.AuthSession, error) {
+			t.Fatal("should not be called without bearer")
+			return domain.AuthSession{}, nil
+		}
+		handler := ports.MakeAuthRefreshHandler(refresh, time.Now, authTestLogger, noopAuthMiddleware, ports.BlocklistConfig{})
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/auth/refresh", http.NoBody)
+		withRequestIP(r, "1.2.3.4")
+		w := httptest.NewRecorder()
+		handler(w, r)
+		require.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+
+	for _, sentinel := range []error{
+		domain.ErrAuthSessionNotFound,
+		domain.ErrAuthSessionRevoked,
+		domain.ErrAuthSessionRefreshExpired,
+	} {
+
+		t.Run("401 on "+sentinel.Error(), func(t *testing.T) {
+			t.Parallel()
+			refresh := func(ctx context.Context, sessionID, ipHash string) (domain.AuthSession, error) {
+				return domain.AuthSession{}, sentinel
+			}
+			handler := ports.MakeAuthRefreshHandler(refresh, time.Now, authTestLogger, noopAuthMiddleware, ports.BlocklistConfig{})
+			r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/auth/refresh", http.NoBody)
+			r.Header.Set("Authorization", "Bearer some-id")
+			withRequestIP(r, "1.2.3.4")
+			w := httptest.NewRecorder()
+			handler(w, r)
+			require.Equal(t, http.StatusUnauthorized, w.Code)
+		})
+	}
+}

--- a/internal/ports/auth_types.go
+++ b/internal/ports/auth_types.go
@@ -1,0 +1,105 @@
+package ports
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Amund211/flashlight/internal/domain"
+	"github.com/Amund211/flashlight/internal/logging"
+	"github.com/Amund211/flashlight/internal/reporting"
+)
+
+// refreshAtOffset is subtracted from a session's expires_at when
+// computing the recommended refresh delay sent to the client.
+// Lives here because it's purely a wire-shape concern.
+const refreshAtOffset = 5 * time.Minute
+
+// authSessionResponse is the wire shape returned by every session-issuing
+// endpoint (login + refresh). The client never needs a wall clock —
+// every timing field is a delta from the moment this response was
+// produced, so a one-shot setTimeout(refreshInSeconds) is enough.
+//
+// canRefresh is true while the next refresh would still grant a full
+// refresh window; it flips to false on the last refresh whose
+// refresh_until got pinned to the absolute lifetime cap. The client
+// keeps using the session normally and, when its refresh timer fires,
+// does a full re-login instead of calling /refresh.
+type authSessionResponse struct {
+	SessionID             string `json:"sessionId"`
+	Tier                  string `json:"tier"`
+	ExpiresInSeconds      int64  `json:"expiresInSeconds"`
+	RefreshUntilInSeconds int64  `json:"refreshUntilInSeconds"`
+	RefreshInSeconds      int64  `json:"refreshInSeconds"`
+	CanRefresh            bool   `json:"canRefresh"`
+}
+
+// sessionResponseFromSession derives the wire response from a stored
+// session and the moment we're about to send it. All time fields are
+// emitted as seconds-from-now so the client never compares timestamps
+// against its own clock.
+func sessionResponseFromSession(s domain.AuthSession, now time.Time) authSessionResponse {
+	refreshAt := s.ExpiresAt.Add(-refreshAtOffset)
+	if refreshAt.Before(now) {
+		refreshAt = now
+	}
+	return authSessionResponse{
+		SessionID:             s.ID,
+		Tier:                  string(s.IdentityType),
+		ExpiresInSeconds:      secondsUntil(s.ExpiresAt, now),
+		RefreshUntilInSeconds: secondsUntil(s.RefreshUntil, now),
+		RefreshInSeconds:      secondsUntil(refreshAt, now),
+		CanRefresh:            s.RefreshUntil.Before(s.LifetimeEndsAt),
+	}
+}
+
+// secondsUntil returns max(0, floor(t - now in seconds)). Negative
+// deltas would only happen on a clock anomaly or a session served
+// after its expiry; either way we never want to ship a negative
+// duration to the client.
+func secondsUntil(t, now time.Time) int64 {
+	d := int64(t.Sub(now).Seconds())
+	if d < 0 {
+		return 0
+	}
+	return d
+}
+
+func writeAuthSessionResponse(ctx context.Context, w http.ResponseWriter, sess domain.AuthSession, now time.Time) {
+	data, err := json.Marshal(sessionResponseFromSession(sess, now))
+	if err != nil {
+		logging.FromContext(ctx).ErrorContext(ctx, "Failed to marshal session response", "error", err.Error())
+		reporting.Report(ctx, fmt.Errorf("marshal session response: %w", err))
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(data); err != nil {
+		logging.FromContext(ctx).ErrorContext(ctx, "Failed to write session response", "error", err.Error())
+		reporting.Report(ctx, fmt.Errorf("write session response: %w", err))
+	}
+}
+
+// bearerFromAuthorization extracts the bearer token from an Authorization
+// header. Case-insensitive on the scheme per RFC 6750. Returns ok=false
+// if the header is missing or malformed.
+func bearerFromAuthorization(r *http.Request) (string, bool) {
+	raw := r.Header.Get("Authorization")
+	if raw == "" {
+		return "", false
+	}
+	const prefix = "bearer "
+	if len(raw) <= len(prefix) || !strings.EqualFold(raw[:len(prefix)], prefix) {
+		return "", false
+	}
+	token := strings.TrimSpace(raw[len(prefix):])
+	if token == "" {
+		return "", false
+	}
+	return token, true
+}

--- a/internal/ports/player_data.go
+++ b/internal/ports/player_data.go
@@ -23,6 +23,7 @@ func MakeGetPlayerDataHandler(
 	registerUserVisit app.RegisterUserVisit,
 	rootLogger *slog.Logger,
 	sentryMiddleware func(http.HandlerFunc) http.HandlerFunc,
+	bearerAuthMiddleware func(http.HandlerFunc) http.HandlerFunc,
 	blocklistConfig BlocklistConfig,
 ) http.HandlerFunc {
 	tracer := otel.Tracer("flashlight/ports/player_data_v1")
@@ -69,6 +70,7 @@ func MakeGetPlayerDataHandler(
 
 	middleware := ComposeMiddlewares(
 		NewRequestLoggerMiddleware(rootLogger),
+		bearerAuthMiddleware,
 		sentryMiddleware,
 		BuildBlocklistMiddleware(blocklistConfig),
 		buildMetricsMiddleware("playerdata"),

--- a/internal/ports/player_data_test.go
+++ b/internal/ports/player_data_test.go
@@ -31,6 +31,12 @@ func TestMakeGetPlayerDataHandler(t *testing.T) {
 	sentryMiddleware := func(next http.HandlerFunc) http.HandlerFunc {
 		return next
 	}
+	// Pass-through bearer-auth middleware: production wraps the handler
+	// to validate the Authorization header and reject 401s, but for
+	// these tests we just let every request through.
+	bearerAuthMiddleware := func(next http.HandlerFunc) http.HandlerFunc {
+		return next
+	}
 	stubRegisterUserVisit := func(ctx context.Context, userID string, ipHash string, userAgent string) (domain.User, error) {
 		return domain.User{}, nil
 	}
@@ -42,7 +48,7 @@ func TestMakeGetPlayerDataHandler(t *testing.T) {
 
 		getPlayerDataHandler := MakeGetPlayerDataHandler(func(ctx context.Context, uuid string) (*domain.PlayerPIT, error) {
 			return player, nil
-		}, stubRegisterUserVisit, logger, sentryMiddleware, emptyBlocklistConfig)
+		}, stubRegisterUserVisit, logger, sentryMiddleware, bearerAuthMiddleware, emptyBlocklistConfig)
 
 		w := httptest.NewRecorder()
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, target, nil)
@@ -66,7 +72,7 @@ func TestMakeGetPlayerDataHandler(t *testing.T) {
 			t.Helper()
 			t.Fatal("should not be called")
 			return nil, nil
-		}, stubRegisterUserVisit, logger, sentryMiddleware, emptyBlocklistConfig)
+		}, stubRegisterUserVisit, logger, sentryMiddleware, bearerAuthMiddleware, emptyBlocklistConfig)
 		w := httptest.NewRecorder()
 
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/?uuid=1234-1234-1234", nil)
@@ -84,7 +90,7 @@ func TestMakeGetPlayerDataHandler(t *testing.T) {
 
 		getPlayerDataHandler := MakeGetPlayerDataHandler(func(ctx context.Context, uuid string) (*domain.PlayerPIT, error) {
 			return nil, fmt.Errorf("%w: couldn't find him", domain.ErrPlayerNotFound)
-		}, stubRegisterUserVisit, logger, sentryMiddleware, emptyBlocklistConfig)
+		}, stubRegisterUserVisit, logger, sentryMiddleware, bearerAuthMiddleware, emptyBlocklistConfig)
 		w := httptest.NewRecorder()
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, target, nil)
 
@@ -101,7 +107,7 @@ func TestMakeGetPlayerDataHandler(t *testing.T) {
 
 		getPlayerDataHandler := MakeGetPlayerDataHandler(func(ctx context.Context, uuid string) (*domain.PlayerPIT, error) {
 			return nil, fmt.Errorf("error :^(: (%w)", domain.ErrTemporarilyUnavailable)
-		}, stubRegisterUserVisit, logger, sentryMiddleware, emptyBlocklistConfig)
+		}, stubRegisterUserVisit, logger, sentryMiddleware, bearerAuthMiddleware, emptyBlocklistConfig)
 		w := httptest.NewRecorder()
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, target, nil)
 
@@ -120,7 +126,7 @@ func TestMakeGetPlayerDataHandler(t *testing.T) {
 
 		getPlayerDataHandler := MakeGetPlayerDataHandler(func(ctx context.Context, uuid string) (*domain.PlayerPIT, error) {
 			return player, nil
-		}, stubRegisterUserVisit, logger, sentryMiddleware, emptyBlocklistConfig)
+		}, stubRegisterUserVisit, logger, sentryMiddleware, bearerAuthMiddleware, emptyBlocklistConfig)
 
 		// Exhaust the rate limit
 		for range 200 {

--- a/internal/ports/prism_notices.go
+++ b/internal/ports/prism_notices.go
@@ -56,6 +56,7 @@ func MakePrismNoticesHandler(
 	registerUserVisit app.RegisterUserVisit,
 	rootLogger *slog.Logger,
 	sentryMiddleware func(http.HandlerFunc) http.HandlerFunc,
+	bearerAuthMiddleware func(http.HandlerFunc) http.HandlerFunc,
 	blocklistConfig BlocklistConfig,
 ) http.HandlerFunc {
 	ipLimiter, _ := ratelimiting.NewTokenBucketRateLimiter(
@@ -90,6 +91,7 @@ func MakePrismNoticesHandler(
 
 	middleware := ComposeMiddlewares(
 		NewRequestLoggerMiddleware(rootLogger),
+		bearerAuthMiddleware,
 		sentryMiddleware,
 		BuildBlocklistMiddleware(blocklistConfig),
 		buildMetricsMiddleware("prism-notices"),

--- a/internal/ports/prism_notices_test.go
+++ b/internal/ports/prism_notices_test.go
@@ -35,6 +35,7 @@ func makePrismNoticesHandler(t *testing.T, getPrismNotices app.GetPrismNotices) 
 		stubPrismNoticesRegisterUserVisit,
 		prismNoticesTestLogger,
 		noopPrismNoticesMiddleware,
+		noopPrismNoticesMiddleware,
 		emptyBlocklistConfig,
 	)
 }

--- a/internal/ports/tags.go
+++ b/internal/ports/tags.go
@@ -37,6 +37,7 @@ func MakeGetTagsHandler(
 	registerUserVisit app.RegisterUserVisit,
 	rootLogger *slog.Logger,
 	sentryMiddleware func(http.HandlerFunc) http.HandlerFunc,
+	bearerAuthMiddleware func(http.HandlerFunc) http.HandlerFunc,
 	blocklistConfig BlocklistConfig,
 ) http.HandlerFunc {
 	ipLimiter, _ := ratelimiting.NewTokenBucketRateLimiter(
@@ -71,6 +72,7 @@ func MakeGetTagsHandler(
 
 	middleware := ComposeMiddlewares(
 		NewRequestLoggerMiddleware(rootLogger),
+		bearerAuthMiddleware,
 		sentryMiddleware,
 		BuildBlocklistMiddleware(blocklistConfig),
 		buildMetricsMiddleware("tags"),

--- a/internal/ports/tags_test.go
+++ b/internal/ports/tags_test.go
@@ -49,6 +49,7 @@ func TestMakeGetTagsHandler(t *testing.T) {
 			stubRegisterUserVisit,
 			testLogger,
 			noopMiddleware,
+			noopMiddleware,
 			emptyBlocklistConfig,
 		)
 	}

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/Amund211/flashlight/internal/adapters/accountprovider"
 	"github.com/Amund211/flashlight/internal/adapters/accountrepository"
+	"github.com/Amund211/flashlight/internal/adapters/authsessionrepository"
 	"github.com/Amund211/flashlight/internal/adapters/cache"
 	"github.com/Amund211/flashlight/internal/adapters/database"
 	"github.com/Amund211/flashlight/internal/adapters/playerprovider"
@@ -158,6 +159,16 @@ func main() {
 	userRepo := userrepository.NewPostgres(db, repositorySchemaName, time.Now)
 	logger.InfoContext(ctx, "Initialized UserRepository")
 
+	authSessionRepo := authsessionrepository.NewPostgres(db, repositorySchemaName)
+	logger.InfoContext(ctx, "Initialized AuthSessionRepository")
+
+	validateSessionCache := cache.NewTTLCache[domain.AuthSession](1 * time.Minute)
+
+	anonymousLogin := app.BuildAnonymousLogin(authSessionRepo, time.Now, app.GenerateAuthSessionID)
+	refreshSession := app.BuildRefreshSession(authSessionRepo, time.Now)
+	validateSession := app.BuildValidateSession(authSessionRepo, time.Now, validateSessionCache)
+	bearerAuthMiddleware := ports.NewBearerAuthMiddleware(validateSession)
+
 	allowedOrigins, err := ports.NewDomainSuffixes(prodDomainSuffix, stagingDomainSuffix)
 	if err != nil {
 		fail("Failed to initialize allowed origins", "error", err.Error())
@@ -214,6 +225,7 @@ func main() {
 			registerUserVisit,
 			logger.With("port", "prism-notices"),
 			sentryMiddleware,
+			bearerAuthMiddleware,
 			blocklistConfig,
 		),
 	)
@@ -225,6 +237,7 @@ func main() {
 			registerUserVisit,
 			logger.With("port", "playerdata"),
 			sentryMiddleware,
+			bearerAuthMiddleware,
 			blocklistConfig,
 		),
 	)
@@ -235,6 +248,29 @@ func main() {
 			getTags,
 			registerUserVisit,
 			logger.With("port", "tags"),
+			sentryMiddleware,
+			bearerAuthMiddleware,
+			blocklistConfig,
+		),
+	)
+
+	handleFunc(
+		"POST /v1/auth/anonymous/login",
+		ports.MakeAnonymousLoginHandler(
+			anonymousLogin,
+			time.Now,
+			logger.With("port", "auth-anonymous-login"),
+			sentryMiddleware,
+			blocklistConfig,
+		),
+	)
+
+	handleFunc(
+		"POST /v1/auth/refresh",
+		ports.MakeAuthRefreshHandler(
+			refreshSession,
+			time.Now,
+			logger.With("port", "auth-refresh"),
 			sentryMiddleware,
 			blocklistConfig,
 		),
@@ -362,6 +398,7 @@ func main() {
 			registerUserVisit,
 			logger.With("port", "playerdata"),
 			sentryMiddleware,
+			bearerAuthMiddleware,
 			blocklistConfig,
 		),
 	)


### PR DESCRIPTION
Introduces a bearer-token auth surface (`Authorization: Bearer flsess_...`)
for the anonymous tier, with self-healing client semantics and a wire
contract designed to keep client code dumb.

- New `auth_sessions` table with an `identity_type` discriminator
ready to accept the Microsoft tier without schema changes.
- Repository surface is just `Create` / `Update(id, fn)` /
`EnforceActiveIPCap` — `Update` is a load-validate-mutate-write
primitive that absorbs Get/Refresh/Revoke from the original sketch.
- Soft-revoke preserves session history with a `revoked_reason` audit
string (`replaced` / `expired` / `evicted_by_ip_cap`). For
expired-and-reaped rows `revoked_at` is stamped to `expires_at` —
the last point the session was provably usable — so
`AVG(revoked_at - created_at)` is a truthful lifetime distribution.
- Per-row `lifetime_ends_at` is set at issue from `authMaxSessionAge`
so changing the cap can't retroactively extend already-issued
sessions, and a future MS tier can carry a longer cap without
touching this code.
- Per-IP cap (`authAnonymousIPCap = 4`) evicts the oldest excess and
cleans up aged-out rows for the same `(identity_type, ip_hash)` in
one SQL.
- 1-minute TTL cache on `ValidateSession` to keep the per-request DB
load down — trade is up to ~1 min stale revocation.
- Bearer middleware is passive: requests without an `Authorization`
header pass through unchanged, preserving the legacy `X-User-Id`
flow.

Wire shape uses durations, not absolute timestamps. The session
response carries `expiresInSeconds`, `refreshUntilInSeconds`,
`refreshInSeconds`, `canRefresh`, and `tier`. Clients schedule via
their monotonic clock against the duration; no wall-clock comparison
is ever needed and clock skew / frozen laptops / NTP jumps can't
cause spurious refreshes. `canRefresh` flips to false on the final
refresh whose `refresh_until` got pinned to `lifetime_ends_at`,
telling the client to do a full re-login on its next timer fire
instead of another `/refresh`.

Naming is anonymous-explicit (`BuildAnonymousLogin`, `AnonymousLogin`,
`authAnonymousIPCap`, `anonymousLoginRepository`, file
`auth_anonymous_login.go`) so the Microsoft tier can land as a sibling
file without preliminary renames. Tier-agnostic pieces
(`authSessionTTL`/`authRefreshWindow`/`authMaxSessionAge`,
`sessionIDPrefix`, `GenerateAuthSessionID`) live in `auth_session.go`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
