### PR TITLE
Fix data races and a cache torn-read flake found by go test -race

### DIFF
--- a/.github/workflows/test-and-deploy.yaml
+++ b/.github/workflows/test-and-deploy.yaml
@@ -59,6 +59,9 @@ jobs:
       - name: Run tests
         run: go test ./...
 
+      - name: Run tests with race detector
+        run: go test -race ./...
+
       - name: Go build
         run: |
           go build

--- a/internal/adapters/cache/get_or_create_test.go
+++ b/internal/adapters/cache/get_or_create_test.go
@@ -72,17 +72,17 @@ func TestGetOrCreateSingle(t *testing.T) {
 
 	go func() {
 		client := clients[0]
-		require.Equal(t, 0, client.server.currentTick)
+		require.Equal(t, 0, int(client.server.currentTick.Load()))
 
 		data, created, err := GetOrCreate(t.Context(), client, "key1", createCallback(1))
 		require.Nil(t, err)
 		require.True(t, created)
 		require.Equal(t, "data1", data)
-		require.Equal(t, 0, client.server.currentTick)
+		require.Equal(t, 0, int(client.server.currentTick.Load()))
 
 		client.wait()
 
-		require.Equal(t, 1, client.server.currentTick)
+		require.Equal(t, 1, int(client.server.currentTick.Load()))
 
 		client.waitUntilDone()
 	}()
@@ -101,13 +101,13 @@ func TestGetOrCreateMultiple(t *testing.T) {
 		require.Nil(t, err)
 		require.True(t, created)
 		require.Equal(t, "data1", data)
-		require.Equal(t, 0, client.server.currentTick)
+		require.Equal(t, 0, int(client.server.currentTick.Load()))
 
 		data, created, err = GetOrCreate(t.Context(), client, "key2", withWait(client, 2, createCallback(2)))
 		require.Nil(t, err)
 		require.True(t, created)
 		require.Equal(t, "data2", data)
-		require.Equal(t, 2, client.server.currentTick)
+		require.Equal(t, 2, int(client.server.currentTick.Load()))
 
 		client.waitUntilDone()
 	}()
@@ -119,7 +119,7 @@ func TestGetOrCreateMultiple(t *testing.T) {
 		require.Nil(t, err)
 		require.False(t, created)
 		require.Equal(t, "data1", data)
-		require.Equal(t, 1, client.server.currentTick)
+		require.Equal(t, 1, int(client.server.currentTick.Load()))
 
 		data, created, err = GetOrCreate(t.Context(), client, "key2", createUnreachable(t))
 		require.Nil(t, err)
@@ -128,7 +128,7 @@ func TestGetOrCreateMultiple(t *testing.T) {
 		// The fist client will insert this during the second tick
 		// If our second tick processes after the first client's we will get it in the second tick
 		// If our second tick processes before the first client's we will get it in the third tick
-		require.True(t, client.server.currentTick == 2 || client.server.currentTick == 3)
+		require.True(t, int(client.server.currentTick.Load()) == 2 || int(client.server.currentTick.Load()) == 3)
 
 		client.waitUntilDone()
 	}()
@@ -145,7 +145,7 @@ func TestGetOrCreateErrorRetries(t *testing.T) {
 		client := clients[0]
 		_, _, err := GetOrCreate(t.Context(), client, "key1", withWait(client, 2, createErrorCallback(1)))
 		require.NotNil(t, err)
-		require.Equal(t, 2, client.server.currentTick)
+		require.Equal(t, 2, int(client.server.currentTick.Load()))
 
 		client.waitUntilDone()
 	}()
@@ -160,7 +160,7 @@ func TestGetOrCreateErrorRetries(t *testing.T) {
 		require.Nil(t, err)
 		require.True(t, created)
 		require.Equal(t, "data1", data)
-		require.True(t, client.server.currentTick == 4 || client.server.currentTick == 5)
+		require.True(t, int(client.server.currentTick.Load()) == 4 || int(client.server.currentTick.Load()) == 5)
 
 		client.waitUntilDone()
 	}()

--- a/internal/adapters/cache/mock.go
+++ b/internal/adapters/cache/mock.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"runtime"
 	"sync"
+	"sync/atomic"
 )
 
 type mockCacheServerEntry[T any] struct {
@@ -14,11 +15,10 @@ type mockCacheServerEntry[T any] struct {
 type mockCacheServer[T any] struct {
 	cache             map[string]mockCacheServerEntry[T]
 	cacheLock         sync.Mutex
-	tickLock          sync.Mutex
-	currentTick       int
+	currentTick       atomic.Int64
 	maxTicks          int
 	numGoroutines     int
-	completedThisTick int
+	completedThisTick atomic.Int64
 }
 
 type mockCacheClient[T any] struct {
@@ -41,7 +41,7 @@ func (cacheClient *mockCacheClient[T]) getOrClaim(uuid string) hitResult[T] {
 
 	cacheClient.server.cache[uuid] = mockCacheServerEntry[T]{
 		valid:      false,
-		insertedAt: cacheClient.server.currentTick,
+		insertedAt: int(cacheClient.server.currentTick.Load()),
 	}
 	return hitResult[T]{
 		valid:   false,
@@ -56,7 +56,7 @@ func (cacheClient *mockCacheClient[T]) set(uuid string, data T) {
 	cacheClient.server.cache[uuid] = mockCacheServerEntry[T]{
 		data:       data,
 		valid:      true,
-		insertedAt: cacheClient.server.currentTick,
+		insertedAt: int(cacheClient.server.currentTick.Load()),
 	}
 }
 
@@ -72,13 +72,11 @@ func (cacheClient *mockCacheClient[T]) wait() {
 		panic("wait() called on a client that is already done")
 	}
 
-	cacheClient.server.tickLock.Lock()
-	cacheClient.server.completedThisTick++
-	cacheClient.server.tickLock.Unlock()
+	cacheClient.server.completedThisTick.Add(1)
 
 	cacheClient.desiredTick++
 
-	for cacheClient.server.currentTick < cacheClient.desiredTick {
+	for cacheClient.server.currentTick.Load() < int64(cacheClient.desiredTick) {
 		runtime.Gosched()
 	}
 }
@@ -90,31 +88,26 @@ func (cacheClient *mockCacheClient[T]) waitUntilDone() {
 }
 
 func (cacheServer *mockCacheServer[T]) isDone() bool {
-	return cacheServer.currentTick >= cacheServer.maxTicks
+	return cacheServer.currentTick.Load() >= int64(cacheServer.maxTicks)
 }
 
 func (cacheServer *mockCacheServer[T]) processTicks() {
 	for !cacheServer.isDone() {
-		if cacheServer.completedThisTick != cacheServer.numGoroutines {
+		if cacheServer.completedThisTick.Load() != int64(cacheServer.numGoroutines) {
 			runtime.Gosched()
 			continue
 		}
 
-		cacheServer.tickLock.Lock()
-		cacheServer.completedThisTick = 0
-		cacheServer.currentTick++
-		cacheServer.tickLock.Unlock()
+		cacheServer.completedThisTick.Store(0)
+		cacheServer.currentTick.Add(1)
 	}
 }
 
 func NewMockCacheServer[T any](numGoroutines int, maxTicks int) (*mockCacheServer[T], []*mockCacheClient[T]) {
 	server := &mockCacheServer[T]{
-		cache:             make(map[string]mockCacheServerEntry[T]),
-		tickLock:          sync.Mutex{},
-		currentTick:       0,
-		maxTicks:          maxTicks,
-		numGoroutines:     numGoroutines,
-		completedThisTick: 0,
+		cache:         make(map[string]mockCacheServerEntry[T]),
+		maxTicks:      maxTicks,
+		numGoroutines: numGoroutines,
 	}
 
 	clients := make([]*mockCacheClient[T], numGoroutines)

--- a/internal/adapters/cache/ttl_cache.go
+++ b/internal/adapters/cache/ttl_cache.go
@@ -19,9 +19,14 @@ func (c *ttlCache[T]) getOrClaim(key string) hitResult[T] {
 	invalid := tllCacheEntry[T]{valid: false}
 	item, existed := c.cache.GetOrSet(key, invalid)
 
+	// Snapshot the value once: a concurrent set() updates the underlying
+	// *Item in place, so reading item.Value() twice can tear (e.g. observe
+	// the old empty data together with the new valid=true).
+	value := item.Value()
+
 	return hitResult[T]{
-		data:    item.Value().data,
-		valid:   item.Value().valid,
+		data:    value.data,
+		valid:   value.valid,
 		claimed: !existed,
 	}
 }

--- a/internal/ratelimiting/requestlimiter_test.go
+++ b/internal/ratelimiting/requestlimiter_test.go
@@ -392,11 +392,11 @@ func TestWindowLimitRequestLimiter(t *testing.T) {
 				// Wait for the requests to start and occupy all slots
 				synctest.Wait()
 
-				ctx, cancel := context.WithCancel(t.Context())
+				cancelableCtx, cancel := context.WithCancel(t.Context())
 
 				requestCanceled := false
 				requestsCompletedWg.Go(func() {
-					ran := l.Limit(ctx, minOperationTime, func(ctx context.Context) {
+					ran := l.Limit(cancelableCtx, minOperationTime, func(ctx context.Context) {
 						t.Helper()
 						assert.False(t, true, "operation should not be called")
 					})
@@ -495,13 +495,13 @@ func TestWindowLimitRequestLimiter(t *testing.T) {
 				// Wait for the requests to start and occupy all slots
 				synctest.Wait()
 
-				ctx, cancel := context.WithCancel(context.Background())
+				canceledCtx, cancel := context.WithCancel(context.Background())
 				cancel() // Cancel immediately
 
 				canceledRequestsWg := sync.WaitGroup{}
 				for range 100 {
 					canceledRequestsWg.Go(func() {
-						ran := l.Limit(ctx, minOperationTime, func(ctx context.Context) {
+						ran := l.Limit(canceledCtx, minOperationTime, func(ctx context.Context) {
 							t.Helper()
 							assert.False(t, true, "operation should not be called")
 						})


### PR DESCRIPTION
## Summary
Ran `go test -race ./...` and fixed every issue it surfaced. Two are test-only data races; one is a genuine production correctness bug exposed under stress. Each is a separate commit.

## Fixes

**1. Data race in the mock cache server** (test-only)
The tick-coordination mock shared `currentTick`/`completedThisTick` across the server and client goroutines as plain `int`s. `processTicks()` read them without holding `tickLock`, racing the locked writes in `wait()`. Switched both to `atomic.Int64` and removed the now-redundant `tickLock`; the handshake is unchanged.

**2. Torn read in `ttlCache.getOrClaim`** (production bug)
`getOrClaim` called `item.Value()` twice. ttlcache's `set()` updates the same `*Item` in place, so a concurrent `set` between the two reads could yield the old empty data together with the new `valid=true` — which `GetOrCreate` then returned as an empty cache hit with a nil error. Surfaced as a flake in the "requests are de-duplicated in highly concurrent environment" test (expected `"data1"`, got `""`). Fixed by taking a single `Value()` snapshot.

**3. Data race on a reused `ctx` variable** (test-only)
Two ratelimiting cancellation subtests spawned goroutines capturing `ctx`, then reassigned the same variable via `ctx, cancel := context.WithCancel(...)` on the main goroutine. Gave the cancelable context its own name, matching the pattern already used in the "during sleep" subtest.

## Test plan
- `go test -race ./...` — all packages pass (incl. DB-backed ones)
- `go test -race -count=5 ./...` — clean, no flakes
- `go vet ./...` and `golangci-lint` on changed packages — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)