### PR TITLE
Log a clear warning when the deprecated /playerdata endpoint is hit

### DIFF
--- a/internal/ports/player_data.go
+++ b/internal/ports/player_data.go
@@ -25,6 +25,7 @@ func MakeGetPlayerDataHandler(
 	sentryMiddleware func(http.HandlerFunc) http.HandlerFunc,
 	bearerAuthMiddleware func(http.HandlerFunc) http.HandlerFunc,
 	blocklistConfig BlocklistConfig,
+	deprecated bool,
 ) http.HandlerFunc {
 	tracer := otel.Tracer("flashlight/ports/player_data_v1")
 
@@ -86,6 +87,10 @@ func MakeGetPlayerDataHandler(
 
 		ctx, span := tracer.Start(ctx, "ports.GetPlayerDataHandler")
 		defer span.End()
+
+		if deprecated {
+			logging.FromContext(ctx).WarnContext(ctx, "Deprecated endpoint hit", "deprecatedEndpoint", fmt.Sprintf("%s %s", r.Method, r.URL.Path))
+		}
 
 		rawUUID := r.URL.Query().Get("uuid")
 		ctx = logging.AddMetaToContext(ctx,

--- a/internal/ports/player_data_test.go
+++ b/internal/ports/player_data_test.go
@@ -48,7 +48,7 @@ func TestMakeGetPlayerDataHandler(t *testing.T) {
 
 		getPlayerDataHandler := MakeGetPlayerDataHandler(func(ctx context.Context, uuid string) (*domain.PlayerPIT, error) {
 			return player, nil
-		}, stubRegisterUserVisit, logger, sentryMiddleware, bearerAuthMiddleware, emptyBlocklistConfig)
+		}, stubRegisterUserVisit, logger, sentryMiddleware, bearerAuthMiddleware, emptyBlocklistConfig, false)
 
 		w := httptest.NewRecorder()
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, target, nil)
@@ -72,7 +72,7 @@ func TestMakeGetPlayerDataHandler(t *testing.T) {
 			t.Helper()
 			t.Fatal("should not be called")
 			return nil, nil
-		}, stubRegisterUserVisit, logger, sentryMiddleware, bearerAuthMiddleware, emptyBlocklistConfig)
+		}, stubRegisterUserVisit, logger, sentryMiddleware, bearerAuthMiddleware, emptyBlocklistConfig, false)
 		w := httptest.NewRecorder()
 
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/?uuid=1234-1234-1234", nil)
@@ -90,7 +90,7 @@ func TestMakeGetPlayerDataHandler(t *testing.T) {
 
 		getPlayerDataHandler := MakeGetPlayerDataHandler(func(ctx context.Context, uuid string) (*domain.PlayerPIT, error) {
 			return nil, fmt.Errorf("%w: couldn't find him", domain.ErrPlayerNotFound)
-		}, stubRegisterUserVisit, logger, sentryMiddleware, bearerAuthMiddleware, emptyBlocklistConfig)
+		}, stubRegisterUserVisit, logger, sentryMiddleware, bearerAuthMiddleware, emptyBlocklistConfig, false)
 		w := httptest.NewRecorder()
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, target, nil)
 
@@ -107,7 +107,7 @@ func TestMakeGetPlayerDataHandler(t *testing.T) {
 
 		getPlayerDataHandler := MakeGetPlayerDataHandler(func(ctx context.Context, uuid string) (*domain.PlayerPIT, error) {
 			return nil, fmt.Errorf("error :^(: (%w)", domain.ErrTemporarilyUnavailable)
-		}, stubRegisterUserVisit, logger, sentryMiddleware, bearerAuthMiddleware, emptyBlocklistConfig)
+		}, stubRegisterUserVisit, logger, sentryMiddleware, bearerAuthMiddleware, emptyBlocklistConfig, false)
 		w := httptest.NewRecorder()
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, target, nil)
 
@@ -126,7 +126,7 @@ func TestMakeGetPlayerDataHandler(t *testing.T) {
 
 		getPlayerDataHandler := MakeGetPlayerDataHandler(func(ctx context.Context, uuid string) (*domain.PlayerPIT, error) {
 			return player, nil
-		}, stubRegisterUserVisit, logger, sentryMiddleware, bearerAuthMiddleware, emptyBlocklistConfig)
+		}, stubRegisterUserVisit, logger, sentryMiddleware, bearerAuthMiddleware, emptyBlocklistConfig, false)
 
 		// Exhaust the rate limit
 		for range 200 {

--- a/main.go
+++ b/main.go
@@ -239,6 +239,7 @@ func main() {
 			sentryMiddleware,
 			bearerAuthMiddleware,
 			blocklistConfig,
+			false,
 		),
 	)
 
@@ -390,7 +391,8 @@ func main() {
 		),
 	)
 
-	// TODO: Remove
+	// TODO: Remove deprecated non-versioned endpoint. Hits are logged with a
+	// "Deprecated endpoint hit" WARN so we can confirm it's safe to drop.
 	handleFunc(
 		"GET /playerdata",
 		ports.MakeGetPlayerDataHandler(
@@ -400,6 +402,7 @@ func main() {
 			sentryMiddleware,
 			bearerAuthMiddleware,
 			blocklistConfig,
+			true,
 		),
 	)
 


### PR DESCRIPTION
## What

The non-versioned `GET /playerdata` endpoint (marked `// TODO: Remove`) reuses the exact same handler as `GET /v1/playerdata` — same `port=playerdata` log field and metrics label — so hits to the deprecated endpoint were indistinguishable from the versioned one in logs and metrics.

This adds a `deprecated bool` flag to `MakeGetPlayerDataHandler`. When set, the handler emits a clear, greppable WARN on every hit:

```
"Deprecated endpoint hit"  deprecatedEndpoint="GET /playerdata"
```

The log is emitted inside the handler, so it inherits `correlationID`, `ipHash`, `userAgent`, and `userId` from the request-logger middleware — enough to see *who* is still calling it before removal.

## Changes

- `internal/ports/player_data.go` — add `deprecated` param; log WARN when true.
- `main.go` — pass `true` for `/playerdata`, `false` for `/v1/playerdata`; expand the `// TODO: Remove` comment.
- `internal/ports/player_data_test.go` — update the five call sites.

## Notes

- Logs at WARN on **every** request to the deprecated endpoint. If it still receives meaningful traffic this could be noisy — happy to switch to INFO or sampled logging if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)