### PR TITLE
build: bump go to 1.26.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.3-alpine AS build
+FROM golang:1.26.4-alpine AS build
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Amund211/flashlight
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/getsentry/sentry-go v0.46.2


### PR DESCRIPTION
Bump Go from 1.26.3 to 1.26.4 (latest stable patch) in go.mod and Dockerfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)