### PR TITLE
chore(dependabot): Use full repo URL in pre-commit ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
       # golangci-lint is driven by the gomod ecosystem (go.mod is the source of
       # truth) and synced into .pre-commit-config.yaml by the check-tool-versions
       # workflow, so don't let pre-commit bump it independently.
-      - dependency-name: 'golangci/golangci-lint'
+      - dependency-name: 'https://github.com/golangci/golangci-lint'
     groups:
       # Group minor+patch updates together
       # Leave major updates and security updates to their own PRs


### PR DESCRIPTION
For the `pre-commit` ecosystem, dependabot identifies dependencies by the full repository URL as written in `.pre-commit-config.yaml` (e.g. `https://github.com/golangci/golangci-lint`), not the `owner/repo` slug. Since `dependency-name` without glob characters is an exact match, the existing ignore for golangci-lint never fired and dependabot could still open bump PRs for it.

Same root cause was found and fixed in Amund211/rainbow for the oxlint/oxfmt mirrors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)