### PR TITLE
feat: Represent session game outcome as win/loss/draw

### DIFF
--- a/internal/app/session_at.go
+++ b/internal/app/session_at.go
@@ -210,6 +210,8 @@ func buildGameSegment(ctx context.Context, prev, curr domain.PlayerPIT) GameSegm
 
 	fdDelta := currStats.FinalDeaths - prevStats.FinalDeaths
 	blDelta := currStats.BedsLost - prevStats.BedsLost
+	winsDelta := currStats.Wins - prevStats.Wins
+	lossesDelta := currStats.Losses - prevStats.Losses
 
 	// Handle weird stat deltas
 	if fdDelta < 0 ||
@@ -230,9 +232,41 @@ func buildGameSegment(ctx context.Context, prev, curr domain.PlayerPIT) GameSegm
 		return seg
 	}
 
+	// A single game moves Wins or Losses by at most one, and not both. A
+	// draw moves neither. Anything else can't be attributed to one game.
+	if winsDelta < 0 ||
+		winsDelta > 1 ||
+		lossesDelta < 0 ||
+		lossesDelta > 1 ||
+		(winsDelta == 1 && lossesDelta == 1) {
+		// unreachable
+		reporting.Report(ctx,
+			fmt.Errorf("weird Wins/Losses delta for single-game segment"),
+			map[string]string{
+				"prevQueriedAt": prev.QueriedAt.Format(time.RFC3339),
+				"currQueriedAt": curr.QueriedAt.Format(time.RFC3339),
+				"gamemode":      string(gamemode),
+				"winsDelta":     fmt.Sprintf("%d", winsDelta),
+				"lossesDelta":   fmt.Sprintf("%d", lossesDelta),
+			},
+		)
+		return seg
+	}
+
+	var outcome domain.GameOutcome
+	switch {
+	case winsDelta == 1:
+		outcome = domain.GameOutcomeWin
+	case lossesDelta == 1:
+		outcome = domain.GameOutcomeLoss
+	default:
+		// Neither Wins nor Losses moved for the single game played.
+		outcome = domain.GameOutcomeDraw
+	}
+
 	seg.Game = &domain.GameResult{
 		Gamemode:   gamemode,
-		Won:        currStats.Wins > prevStats.Wins,
+		Outcome:    outcome,
 		FinalKills: currStats.FinalKills - prevStats.FinalKills,
 		FinalDeath: fdDelta == 1,
 		BedsBroken: currStats.BedsBroken - prevStats.BedsBroken,

--- a/internal/app/session_at_test.go
+++ b/internal/app/session_at_test.go
@@ -107,7 +107,7 @@ func TestBuildGetSessionAt(t *testing.T) {
 			Games: []app.GameSegment{
 				{Start: p0, End: p1, Game: &domain.GameResult{
 					Gamemode:   domain.GamemodeDoubles,
-					Won:        true,
+					Outcome:    domain.GameOutcomeWin,
 					FinalKills: 4,
 					FinalDeath: false,
 					BedsBroken: 1,
@@ -118,7 +118,7 @@ func TestBuildGetSessionAt(t *testing.T) {
 				}},
 				{Start: p1, End: p2, Game: &domain.GameResult{
 					Gamemode:   domain.GamemodeDoubles,
-					Won:        false,
+					Outcome:    domain.GameOutcomeLoss,
 					FinalKills: 2,
 					FinalDeath: true,
 					BedsBroken: 0,
@@ -129,7 +129,7 @@ func TestBuildGetSessionAt(t *testing.T) {
 				}},
 				{Start: p2, End: p3, Game: &domain.GameResult{
 					Gamemode:   domain.GamemodeDoubles,
-					Won:        true,
+					Outcome:    domain.GameOutcomeWin,
 					FinalKills: 4,
 					FinalDeath: false,
 					BedsBroken: 1,
@@ -288,7 +288,7 @@ func TestBuildGetSessionAt(t *testing.T) {
 
 		wonGame := &domain.GameResult{
 			Gamemode:   domain.GamemodeDoubles,
-			Won:        true,
+			Outcome:    domain.GameOutcomeWin,
 			FinalKills: 4,
 			FinalDeath: false,
 			BedsBroken: 1,
@@ -400,7 +400,7 @@ func TestBuildGetSessionAt(t *testing.T) {
 			Games: []app.GameSegment{
 				{Start: p0, End: p1, Game: &domain.GameResult{
 					Gamemode:   domain.GamemodeDoubles,
-					Won:        true,
+					Outcome:    domain.GameOutcomeWin,
 					FinalKills: 4,
 					FinalDeath: false,
 					BedsBroken: 1,
@@ -456,7 +456,7 @@ func TestBuildGetSessionAt(t *testing.T) {
 				{Start: p0, End: p1, Game: nil},
 				{Start: p1, End: p2, Game: &domain.GameResult{
 					Gamemode:   domain.GamemodeDoubles,
-					Won:        true,
+					Outcome:    domain.GameOutcomeWin,
 					FinalKills: 4,
 					FinalDeath: false,
 					BedsBroken: 1,
@@ -514,7 +514,7 @@ func TestBuildGetSessionAt(t *testing.T) {
 			Games: []app.GameSegment{
 				{Start: p0, End: p1, Game: &domain.GameResult{
 					Gamemode:   domain.GamemodeDoubles,
-					Won:        true,
+					Outcome:    domain.GameOutcomeWin,
 					FinalKills: 4,
 					FinalDeath: false,
 					BedsBroken: 1,
@@ -568,7 +568,7 @@ func TestBuildGetSessionAt(t *testing.T) {
 			Games: []app.GameSegment{
 				{Start: p0, End: p1, Game: &domain.GameResult{
 					Gamemode:   domain.GamemodeDoubles,
-					Won:        true,
+					Outcome:    domain.GameOutcomeWin,
 					FinalKills: 4,
 					FinalDeath: false,
 					BedsBroken: 1,
@@ -723,6 +723,43 @@ func TestBuildGetSessionAt(t *testing.T) {
 				},
 			}, result)
 		})
+
+		t.Run("Wins and Losses both advance for a single game", func(t *testing.T) {
+			t.Parallel()
+
+			b := domaintest.NewPlayerBuilder(uuid).
+				WithExperience(1000).FromDB().
+				Doubles().
+				WithGamesPlayed(10).WithWins(5).WithLosses(5).
+				WithBedsBroken(4).WithBedsLost(3).
+				WithFinalKills(20).WithFinalDeaths(10).
+				WithKills(50).WithDeaths(30)
+			p0 := b.Build(at.Add(-15 * time.Minute))
+
+			// Doubles advances by exactly one game, but both Wins and
+			// Losses advanced — can't win and lose the same game.
+			p1 := b.
+				WithExperience(1100).
+				Doubles().
+				WithGamesPlayed(11).WithWins(6).WithLosses(6).
+				WithBedsBroken(5).
+				WithFinalKills(22).
+				WithKills(55).WithDeaths(32).Build(at)
+
+			getSessionAt := app.BuildGetSessionAt(
+				fixedStats([]domain.PlayerPIT{p0, p1}),
+				computeSessions,
+			)
+
+			result, err := getSessionAt(t.Context(), uuid, at)
+			require.NoError(t, err)
+			require.Equal(t, app.SessionAtResult{
+				Session: &domain.Session{Start: p0, End: p1, Consecutive: true},
+				Games: []app.GameSegment{
+					{Start: p0, End: p1, Game: nil},
+				},
+			}, result)
+		})
 	})
 
 	t.Run("getPlayerPITs error is propagated", func(t *testing.T) {
@@ -801,7 +838,7 @@ func TestBuildGetSessionAt(t *testing.T) {
 						Games: []app.GameSegment{
 							{Start: prev, End: curr, Game: &domain.GameResult{
 								Gamemode:   tc.gamemode,
-								Won:        true,
+								Outcome:    domain.GameOutcomeWin,
 								FinalKills: 4,
 								FinalDeath: false,
 								BedsBroken: 1,
@@ -842,7 +879,7 @@ func TestBuildGetSessionAt(t *testing.T) {
 						Games: []app.GameSegment{
 							{Start: prev, End: curr, Game: &domain.GameResult{
 								Gamemode:   tc.gamemode,
-								Won:        false,
+								Outcome:    domain.GameOutcomeLoss,
 								FinalKills: 2,
 								FinalDeath: true,
 								BedsBroken: 0,
@@ -850,6 +887,47 @@ func TestBuildGetSessionAt(t *testing.T) {
 								Kills:      4,
 								Deaths:     4,
 								Experience: 200,
+							}},
+						},
+					}, result)
+				})
+
+				t.Run("draw", func(t *testing.T) {
+					tc.b.WithGamesPlayed(10).WithWins(5).WithLosses(5).
+						WithBedsBroken(4).WithBedsLost(3).
+						WithFinalKills(20).WithFinalDeaths(10).
+						WithKills(50).WithDeaths(30).
+						WithExperience(1000)
+					prev := tc.b.Build(at.Add(-15 * time.Minute))
+
+					// +1 game, but neither Wins nor Losses moved -> draw
+					tc.b.WithGamesPlayed(11).
+						WithBedsBroken(5).
+						WithFinalKills(24).
+						WithKills(58).WithDeaths(32).
+						WithExperience(1300)
+					curr := tc.b.Build(at)
+
+					getSessionAt := app.BuildGetSessionAt(
+						fixedStats([]domain.PlayerPIT{prev, curr}),
+						computeSessions,
+					)
+
+					result, err := getSessionAt(t.Context(), uuid, at)
+					require.NoError(t, err)
+					require.Equal(t, app.SessionAtResult{
+						Session: &domain.Session{Start: prev, End: curr, Consecutive: true},
+						Games: []app.GameSegment{
+							{Start: prev, End: curr, Game: &domain.GameResult{
+								Gamemode:   tc.gamemode,
+								Outcome:    domain.GameOutcomeDraw,
+								FinalKills: 4,
+								FinalDeath: false,
+								BedsBroken: 1,
+								BedLost:    false,
+								Kills:      8,
+								Deaths:     2,
+								Experience: 300,
 							}},
 						},
 					}, result)

--- a/internal/domain/game_result.go
+++ b/internal/domain/game_result.go
@@ -1,11 +1,22 @@
 package domain
 
+// GameOutcome names how a single Bedwars game ended for the player.
+// Draws are rare but do happen, so the outcome is a three-state enum
+// rather than a won/lost boolean.
+type GameOutcome string
+
+const (
+	GameOutcomeWin  GameOutcome = "win"
+	GameOutcomeLoss GameOutcome = "loss"
+	GameOutcomeDraw GameOutcome = "draw"
+)
+
 // GameResult describes what happened in a single Bedwars game — which
-// gamemode it was played in, whether the player won, and the stat deltas
-// that the player accrued during it.
+// gamemode it was played in, how it ended for the player, and the stat
+// deltas that the player accrued during it.
 type GameResult struct {
 	Gamemode   Gamemode
-	Won        bool
+	Outcome    GameOutcome
 	FinalKills int
 	FinalDeath bool
 	BedsBroken int

--- a/internal/ports/rainbow_converters.go
+++ b/internal/ports/rainbow_converters.go
@@ -36,6 +36,28 @@ func gamemodeToRainbowGamemode(g domain.Gamemode) (string, error) {
 	}
 }
 
+// Rainbow-format game outcome names sent on the rainbow JSON responses.
+// Kept distinct from domain.GameOutcome so the JSON contract is fixed
+// regardless of how the domain constants are spelled.
+const (
+	rainbowOutcomeWin  = "win"
+	rainbowOutcomeLoss = "loss"
+	rainbowOutcomeDraw = "draw"
+)
+
+func gameOutcomeToRainbowOutcome(o domain.GameOutcome) (string, error) {
+	switch o {
+	case domain.GameOutcomeWin:
+		return rainbowOutcomeWin, nil
+	case domain.GameOutcomeLoss:
+		return rainbowOutcomeLoss, nil
+	case domain.GameOutcomeDraw:
+		return rainbowOutcomeDraw, nil
+	default:
+		return "", fmt.Errorf("unknown outcome: %q", o)
+	}
+}
+
 type rainbowStatsPIT struct {
 	Winstreak   *int `json:"winstreak"`
 	GamesPlayed int  `json:"gamesPlayed"`

--- a/internal/ports/session_at.go
+++ b/internal/ports/session_at.go
@@ -18,7 +18,7 @@ import (
 
 type rainbowGameResult struct {
 	Gamemode   string `json:"gamemode"`
-	Won        bool   `json:"won"`
+	Outcome    string `json:"outcome"`
 	FinalKills int    `json:"finalKills"`
 	FinalDeath bool   `json:"finalDeath"`
 	BedsBroken int    `json:"bedsBroken"`
@@ -166,9 +166,15 @@ func MakeGetSessionAtHandler(
 					http.Error(w, "Failed to serialise response", http.StatusInternalServerError)
 					return
 				}
+				rainbowOutcome, oErr := gameOutcomeToRainbowOutcome(seg.Game.Outcome)
+				if oErr != nil {
+					reporting.Report(ctx, fmt.Errorf("failed to convert outcome: %w", oErr))
+					http.Error(w, "Failed to serialise response", http.StatusInternalServerError)
+					return
+				}
 				game = &rainbowGameResult{
 					Gamemode:   rainbowGamemode,
-					Won:        seg.Game.Won,
+					Outcome:    rainbowOutcome,
 					FinalKills: seg.Game.FinalKills,
 					FinalDeath: seg.Game.FinalDeath,
 					BedsBroken: seg.Game.BedsBroken,

--- a/internal/ports/session_at_test.go
+++ b/internal/ports/session_at_test.go
@@ -59,7 +59,7 @@ func TestMakeGetSessionAtHandler(t *testing.T) {
 
 	type gameResponse struct {
 		Gamemode   string `json:"gamemode"`
-		Won        bool   `json:"won"`
+		Outcome    string `json:"outcome"`
 		FinalKills int    `json:"finalKills"`
 		FinalDeath bool   `json:"finalDeath"`
 		BedsBroken int    `json:"bedsBroken"`
@@ -108,7 +108,7 @@ func TestMakeGetSessionAtHandler(t *testing.T) {
 					End:   midPIT,
 					Game: &domain.GameResult{
 						Gamemode:   domain.GamemodeDoubles,
-						Won:        true,
+						Outcome:    domain.GameOutcomeWin,
 						FinalKills: 4,
 						FinalDeath: false,
 						BedsBroken: 1,
@@ -150,7 +150,7 @@ func TestMakeGetSessionAtHandler(t *testing.T) {
 		require.Len(t, response.Games, 2)
 		require.NotNil(t, response.Games[0].Game)
 		require.Equal(t, "doubles", response.Games[0].Game.Gamemode)
-		require.True(t, response.Games[0].Game.Won)
+		require.Equal(t, "win", response.Games[0].Game.Outcome)
 		require.Equal(t, 4, response.Games[0].Game.FinalKills)
 		require.False(t, response.Games[0].Game.FinalDeath)
 		require.Equal(t, 1, response.Games[0].Game.BedsBroken)
@@ -174,7 +174,7 @@ func TestMakeGetSessionAtHandler(t *testing.T) {
 			return app.GameSegment{
 				Start: startPIT,
 				End:   startPIT,
-				Game:  &domain.GameResult{Gamemode: g, Won: true},
+				Game:  &domain.GameResult{Gamemode: g, Outcome: domain.GameOutcomeWin},
 			}
 		}
 


### PR DESCRIPTION
## Summary

Replaces the `Won bool` on session-detail game results with a three-state
`GameOutcome` enum (`win` / `loss` / `draw`). Draws are rare but do happen in
Bedwars; today they are silently miscounted as losses because `Wins` doesn't
increment.

## Changes

- `domain.GameResult.Won bool` → `Outcome GameOutcome` (`win`/`loss`/`draw`), a
  new enum mirroring the existing `domain.Gamemode` pattern.
- Outcome is derived from the `Wins`/`Losses` deltas in `buildGameSegment` (the
  `Losses` counter was previously never read). Added a validation guard
  rejecting impossible single-game movement (deltas outside `{0,1}`, or both
  win and loss advancing), consistent with the existing FinalDeaths/BedsLost
  guard → falls back to `Game: nil`.
- **Wire/API change** in `session-at`: `"won": bool` becomes
  `"outcome": "win" | "loss" | "draw"`, with a new
  `gameOutcomeToRainbowOutcome` converter.
- Tests updated to assert outcomes; added draw and invalid-delta cases.

## Detection assumption

A draw is treated as "one game played, but neither `Wins` nor `Losses`
incremented". This relies on a draw still advancing `GamesPlayed` by 1 while
crediting neither counter (otherwise it's filtered out upstream as a non-game).
The enum modeling is correct regardless, but worth confirming against real draw
data if any exists.

## ⚠️ Downstream consumers

This changes the `session-at` JSON contract (`won` → `outcome`). **Rainbow PR
#256 must be updated to work with this updated schema:**
https://github.com/Amund211/rainbow/pull/256

🤖 Generated with [Claude Code](https://claude.com/claude-code)
