### PR TITLE
chore: replace "heartbeat" segment vernacular with "non-game segment"

### DIFF
--- a/internal/app/session_at.go
+++ b/internal/app/session_at.go
@@ -21,8 +21,8 @@ const sessionAtBuffer = 24 * time.Hour
 // gamemode advanced by one, FD/BL within {0, 1}). It is nil when stats
 // moved but couldn't be pinned to a single game — multi-game jumps,
 // simultaneous mode advances, exp drift without games. Adjacent
-// heartbeats are merged upstream, so a nil Game always spans the
-// entire run of unattributable activity.
+// non-game segments are merged upstream, so a nil Game always
+// spans the entire run of unattributable activity.
 type GameSegment struct {
 	Start domain.PlayerPIT
 	End   domain.PlayerPIT

--- a/internal/app/session_at_test.go
+++ b/internal/app/session_at_test.go
@@ -310,13 +310,13 @@ func TestBuildGetSessionAt(t *testing.T) {
 		}, result)
 	})
 
-	t.Run("two adjacent +2-games pairs merge into a single heartbeat segment", func(t *testing.T) {
+	t.Run("two adjacent +2-games pairs merge into a single non-game segment", func(t *testing.T) {
 		t.Parallel()
 
 		// Each adjacent pair shows gamesPlayed jumping by 2 — both
 		// produce a Game=nil segment. Output should be a single merged
-		// heartbeat spanning all three snapshots, not two heartbeats in
-		// a row.
+		// non-game segment spanning all three snapshots, not two
+		// non-game segments in a row.
 		b := domaintest.NewPlayerBuilder(uuid).
 			WithExperience(1000).FromDB().
 			Doubles().
@@ -360,9 +360,10 @@ func TestBuildGetSessionAt(t *testing.T) {
 	t.Run("an ambiguous-stat pair next to a game does NOT merge", func(t *testing.T) {
 		t.Parallel()
 
-		// Pair 1: +1 game (clean game). Pair 2: +2 games (ambiguous
-		// heartbeat). The heartbeat sits next to a game segment so the
-		// merge rule does not apply — we get [game, heartbeat].
+		// Pair 1: +1 game (clean game). Pair 2: +2 games (ambiguous —
+		// no single game). The non-game segment sits next to a game
+		// segment so the merge rule does not apply — we get
+		// [game, non-game].
 		b := domaintest.NewPlayerBuilder(uuid).
 			WithExperience(1000).FromDB().
 			Doubles().
@@ -414,7 +415,7 @@ func TestBuildGetSessionAt(t *testing.T) {
 		}, result)
 	})
 
-	t.Run("experience moves but no game finishes — still a heartbeat", func(t *testing.T) {
+	t.Run("experience moves but no game finishes — still a non-game segment", func(t *testing.T) {
 		t.Parallel()
 
 		// Experience drifted upward but no gamesPlayed changed in any

--- a/internal/ports/session_at_test.go
+++ b/internal/ports/session_at_test.go
@@ -118,7 +118,7 @@ func TestMakeGetSessionAtHandler(t *testing.T) {
 						Experience: 500,
 					},
 				},
-				// Second segment has Game nil (ambiguous / heartbeat).
+				// Second segment has Game nil (ambiguous / non-game segment).
 				{Start: midPIT, End: endPIT, Game: nil},
 			},
 		}


### PR DESCRIPTION
## What

Renames the informal "heartbeat" vernacular in the session-at code to **"non-game segment"**. Touches comments and test names only — no behavior change.

## Why

A `GameSegment` with `Game == nil` is a stretch of a session where the player's stats moved (experience or games-played changed) but the movement couldn't be pinned to a single finished game — multi-game jumps, simultaneous mode advances, exp drift without a game, weird tracker state. The code called these "heartbeats" in comments and `t.Run` names.

The term is misleading: "heartbeat" reads like a keepalive/ping, which is *not* what this is — there is no heartbeat/keepalive mechanism in flashlight (session "ongoing-ness" is driven purely by the 60-minute inactivity threshold). "Non-game segment" says exactly what it is: a session segment that isn't a single attributable game.

## Changes

- `internal/app/session_at.go` — `GameSegment` doc comment
- `internal/app/session_at_test.go` — two `t.Run` names + two explanatory comments
- `internal/ports/session_at_test.go` — one comment

No production logic, types, or wire format changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)