### PR TITLE
feat: Report final death without a lost bed as an invalid game segment

### DIFF
--- a/internal/app/session_at.go
+++ b/internal/app/session_at.go
@@ -232,6 +232,24 @@ func buildGameSegment(ctx context.Context, prev, curr domain.PlayerPIT) GameSegm
 		return seg
 	}
 
+	// A final death is only possible once your bed is gone, so a final death
+	// in a single game implies the bed was lost in that game. NOTE: we can't
+	// make the same check for losses (loss => final death) — you can lose in
+	// sudden death (dragons) without dying.
+	if fdDelta == 1 && blDelta == 0 {
+		reporting.Report(ctx,
+			fmt.Errorf("final death without losing bed for single-game segment"),
+			map[string]string{
+				"prevQueriedAt": prev.QueriedAt.Format(time.RFC3339),
+				"currQueriedAt": curr.QueriedAt.Format(time.RFC3339),
+				"gamemode":      string(gamemode),
+				"fdDelta":       fmt.Sprintf("%d", fdDelta),
+				"blDelta":       fmt.Sprintf("%d", blDelta),
+			},
+		)
+		return seg
+	}
+
 	// A single game moves Wins or Losses by at most one, and not both. A
 	// draw moves neither. Anything else can't be attributed to one game.
 	if winsDelta < 0 ||

--- a/internal/app/session_at_test.go
+++ b/internal/app/session_at_test.go
@@ -761,6 +761,43 @@ func TestBuildGetSessionAt(t *testing.T) {
 				},
 			}, result)
 		})
+
+		t.Run("final death without losing the bed", func(t *testing.T) {
+			t.Parallel()
+
+			b := domaintest.NewPlayerBuilder(uuid).
+				WithExperience(1000).FromDB().
+				Doubles().
+				WithGamesPlayed(10).WithWins(5).WithLosses(5).
+				WithBedsBroken(4).WithBedsLost(3).
+				WithFinalKills(20).WithFinalDeaths(10).
+				WithKills(50).WithDeaths(30)
+			p0 := b.Build(at.Add(-15 * time.Minute))
+
+			// Doubles advances by exactly one game with a final death but
+			// no bed lost — impossible, a final death requires the bed to
+			// be gone.
+			p1 := b.
+				WithExperience(1100).
+				Doubles().
+				WithGamesPlayed(11).WithLosses(6).
+				WithFinalKills(22).WithFinalDeaths(11).
+				WithKills(55).WithDeaths(32).Build(at)
+
+			getSessionAt := app.BuildGetSessionAt(
+				fixedStats([]domain.PlayerPIT{p0, p1}),
+				computeSessions,
+			)
+
+			result, err := getSessionAt(t.Context(), uuid, at)
+			require.NoError(t, err)
+			require.Equal(t, app.SessionAtResult{
+				Session: &domain.Session{Start: p0, End: p1, Consecutive: true},
+				Games: []app.GameSegment{
+					{Start: p0, End: p1, Game: nil},
+				},
+			}, result)
+		})
 	})
 
 	t.Run("getPlayerPITs error is propagated", func(t *testing.T) {


### PR DESCRIPTION
## What

When attributing a snapshot pair to a single game in `buildGameSegment`, add a consistency check: a final death (`fdDelta == 1`) without a lost bed (`blDelta == 0`) is impossible — a final death can only happen once your bed is gone. The violating segment is now reported (like the other impossible-delta checks) and emitted with a nil game result.

A brief comment notes that we deliberately do **not** make the symmetric check for losses (`loss => final death`): you can lose in sudden death (dragons) without dying.

## Changes

- `internal/app/session_at.go` — new cross-check + `reporting.Report` between the FinalDeaths/BedsLost delta guard and the Wins/Losses guard.
- `internal/app/session_at_test.go` — new `final death without losing the bed` case under the existing `strange stats change -> game is nil` subgroup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)