### PR TITLE
flashlight: store 4v4 (two_four) bedwars stats

### DIFF
--- a/internal/adapters/playerprovider/hypixel_response.go
+++ b/internal/adapters/playerprovider/hypixel_response.go
@@ -87,6 +87,17 @@ type HypixelAPIBedwarsStats struct {
 	FoursFinalDeaths int  `json:"four_four_final_deaths_bedwars,omitempty"`
 	FoursKills       int  `json:"four_four_kills_bedwars,omitempty"`
 	FoursDeaths      int  `json:"four_four_deaths_bedwars,omitempty"`
+
+	Fourv4Winstreak   *int `json:"two_four_winstreak,omitempty"`
+	Fourv4GamesPlayed int  `json:"two_four_games_played_bedwars,omitempty"`
+	Fourv4Wins        int  `json:"two_four_wins_bedwars,omitempty"`
+	Fourv4Losses      int  `json:"two_four_losses_bedwars,omitempty"`
+	Fourv4BedsBroken  int  `json:"two_four_beds_broken_bedwars,omitempty"`
+	Fourv4BedsLost    int  `json:"two_four_beds_lost_bedwars,omitempty"`
+	Fourv4FinalKills  int  `json:"two_four_final_kills_bedwars,omitempty"`
+	Fourv4FinalDeaths int  `json:"two_four_final_deaths_bedwars,omitempty"`
+	Fourv4Kills       int  `json:"two_four_kills_bedwars,omitempty"`
+	Fourv4Deaths      int  `json:"two_four_deaths_bedwars,omitempty"`
 }
 
 func ParseHypixelAPIResponse(ctx context.Context, data []byte) (*hypixelAPIResponse, error) {
@@ -204,7 +215,7 @@ func HypixelAPIResponseToPlayerPIT(ctx context.Context, uuid string, queriedAt t
 	}
 
 	var experience int64 = 500
-	var solo, doubles, threes, fours, overall domain.GamemodeStatsPIT
+	var solo, doubles, threes, fours, fourv4, overall domain.GamemodeStatsPIT
 
 	if apiPlayer.Stats != nil && apiPlayer.Stats.Bedwars != nil {
 		bw := apiPlayer.Stats.Bedwars
@@ -265,6 +276,19 @@ func HypixelAPIResponseToPlayerPIT(ctx context.Context, uuid string, queriedAt t
 			Deaths:      bw.FoursDeaths,
 		}
 
+		fourv4 = domain.GamemodeStatsPIT{
+			Winstreak:   apiPlayer.Stats.Bedwars.Fourv4Winstreak,
+			GamesPlayed: bw.Fourv4GamesPlayed,
+			Wins:        bw.Fourv4Wins,
+			Losses:      bw.Fourv4Losses,
+			BedsBroken:  bw.Fourv4BedsBroken,
+			BedsLost:    bw.Fourv4BedsLost,
+			FinalKills:  bw.Fourv4FinalKills,
+			FinalDeaths: bw.Fourv4FinalDeaths,
+			Kills:       bw.Fourv4Kills,
+			Deaths:      bw.Fourv4Deaths,
+		}
+
 		overall = domain.GamemodeStatsPIT{
 			Winstreak:   apiPlayer.Stats.Bedwars.Winstreak,
 			GamesPlayed: bw.GamesPlayed,
@@ -295,6 +319,7 @@ func HypixelAPIResponseToPlayerPIT(ctx context.Context, uuid string, queriedAt t
 		Doubles:    doubles,
 		Threes:     threes,
 		Fours:      fours,
+		Fourv4:     fourv4,
 		Overall:    overall,
 	}, nil
 }

--- a/internal/adapters/playerprovider/hypixel_response_test.go
+++ b/internal/adapters/playerprovider/hypixel_response_test.go
@@ -128,6 +128,51 @@ func TestHypixelAPIResponseToPlayerPIT(t *testing.T) {
 				error:              domain.ErrPlayerNotFound,
 			},
 			{
+				// Only two_four fields are set here so the mapping into
+				// domain.PlayerPIT.Fourv4 is isolated from the other modes.
+				name:      "4v4 (two_four) stats",
+				uuid:      "12345678-90ab-cdef-1234-567890abcdef",
+				queriedAt: now,
+				hypixelAPIResponse: []byte(`{
+					"success": true,
+					"player": {
+						"uuid":"1234567890abcdef1234567890abcdef",
+						"stats": {
+							"Bedwars": {
+								"two_four_winstreak": 5,
+								"two_four_games_played_bedwars": 72,
+								"two_four_wins_bedwars": 40,
+								"two_four_losses_bedwars": 32,
+								"two_four_beds_broken_bedwars": 33,
+								"two_four_beds_lost_bedwars": 30,
+								"two_four_final_kills_bedwars": 60,
+								"two_four_final_deaths_bedwars": 25,
+								"two_four_kills_bedwars": 120,
+								"two_four_deaths_bedwars": 110
+							}
+						}
+					}
+				}`),
+				hypixelStatusCode: 200,
+				result: &domain.PlayerPIT{
+					UUID:       "12345678-90ab-cdef-1234-567890abcdef",
+					QueriedAt:  now,
+					Experience: 500,
+					Fourv4: domain.GamemodeStatsPIT{
+						Winstreak:   new(5),
+						GamesPlayed: 72,
+						Wins:        40,
+						Losses:      32,
+						BedsBroken:  33,
+						BedsLost:    30,
+						FinalKills:  60,
+						FinalDeaths: 25,
+						Kills:       120,
+						Deaths:      110,
+					},
+				},
+			},
+			{
 				name:               "hypixel 500",
 				uuid:               "12345678-90ab-cdef-1234-567890abcdef",
 				queriedAt:          now,

--- a/internal/adapters/playerprovider/testdata/expected_players/175f84462e8a478d90489fa202d75024_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/175f84462e8a478d90489fa202d75024_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 70,
     "Deaths": 295
   },
+  "Fourv4": {
+    "Winstreak": 0,
+    "GamesPlayed": 2,
+    "Wins": 1,
+    "Losses": 1,
+    "BedsBroken": 0,
+    "BedsLost": 1,
+    "FinalKills": 0,
+    "FinalDeaths": 1,
+    "Kills": 0,
+    "Deaths": 7
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 203,

--- a/internal/adapters/playerprovider/testdata/expected_players/1v4_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/1v4_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 3040,
     "Deaths": 4170
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 132,
+    "Wins": 115,
+    "Losses": 11,
+    "BedsBroken": 36,
+    "BedsLost": 17,
+    "FinalKills": 119,
+    "FinalDeaths": 14,
+    "Kills": 113,
+    "Deaths": 184
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 3655,

--- a/internal/adapters/playerprovider/testdata/expected_players/6N0T_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/6N0T_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 49,
     "Deaths": 41
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 0,
+    "Wins": 0,
+    "Losses": 0,
+    "BedsBroken": 0,
+    "BedsLost": 0,
+    "FinalKills": 0,
+    "FinalDeaths": 0,
+    "Kills": 0,
+    "Deaths": 0
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 55,

--- a/internal/adapters/playerprovider/testdata/expected_players/7031b114ba3a4fb4ac07c3a372527a07_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/7031b114ba3a4fb4ac07c3a372527a07_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 0,
     "Deaths": 0
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 0,
+    "Wins": 0,
+    "Losses": 0,
+    "BedsBroken": 0,
+    "BedsLost": 0,
+    "FinalKills": 0,
+    "FinalDeaths": 0,
+    "Kills": 0,
+    "Deaths": 0
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 39,

--- a/internal/adapters/playerprovider/testdata/expected_players/ActuallyRacist_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/ActuallyRacist_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 18,
     "Deaths": 18
   },
+  "Fourv4": {
+    "Winstreak": 3,
+    "GamesPlayed": 5,
+    "Wins": 4,
+    "Losses": 1,
+    "BedsBroken": 0,
+    "BedsLost": 1,
+    "FinalKills": 3,
+    "FinalDeaths": 1,
+    "Kills": 1,
+    "Deaths": 5
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 343,

--- a/internal/adapters/playerprovider/testdata/expected_players/AgedM_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/AgedM_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 95,
     "Deaths": 31
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 0,
+    "Wins": 0,
+    "Losses": 0,
+    "BedsBroken": 0,
+    "BedsLost": 0,
+    "FinalKills": 0,
+    "FinalDeaths": 0,
+    "Kills": 0,
+    "Deaths": 0
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 43,

--- a/internal/adapters/playerprovider/testdata/expected_players/Andorite_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Andorite_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 27735,
     "Deaths": 58400
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 309,
+    "Wins": 294,
+    "Losses": 11,
+    "BedsBroken": 99,
+    "BedsLost": 13,
+    "FinalKills": 286,
+    "FinalDeaths": 12,
+    "Kills": 254,
+    "Deaths": 350
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 41254,

--- a/internal/adapters/playerprovider/testdata/expected_players/Arnav_The_Great_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Arnav_The_Great_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 1407,
     "Deaths": 3320
   },
+  "Fourv4": {
+    "Winstreak": 6,
+    "GamesPlayed": 66,
+    "Wins": 48,
+    "Losses": 17,
+    "BedsBroken": 28,
+    "BedsLost": 20,
+    "FinalKills": 62,
+    "FinalDeaths": 18,
+    "Kills": 143,
+    "Deaths": 162
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 2869,

--- a/internal/adapters/playerprovider/testdata/expected_players/Aspectable_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Aspectable_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 1471,
     "Deaths": 2104
   },
+  "Fourv4": {
+    "Winstreak": 5,
+    "GamesPlayed": 21,
+    "Wins": 15,
+    "Losses": 4,
+    "BedsBroken": 3,
+    "BedsLost": 4,
+    "FinalKills": 8,
+    "FinalDeaths": 3,
+    "Kills": 21,
+    "Deaths": 46
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 3096,

--- a/internal/adapters/playerprovider/testdata/expected_players/AustrisB_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/AustrisB_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 7,
     "Deaths": 6
   },
+  "Fourv4": {
+    "Winstreak": 0,
+    "GamesPlayed": 6,
+    "Wins": 2,
+    "Losses": 4,
+    "BedsBroken": 0,
+    "BedsLost": 4,
+    "FinalKills": 1,
+    "FinalDeaths": 4,
+    "Kills": 22,
+    "Deaths": 15
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 169,

--- a/internal/adapters/playerprovider/testdata/expected_players/BIDENBLASTO_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/BIDENBLASTO_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 37,
     "Deaths": 31
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 0,
+    "Wins": 0,
+    "Losses": 0,
+    "BedsBroken": 0,
+    "BedsLost": 0,
+    "FinalKills": 0,
+    "FinalDeaths": 0,
+    "Kills": 0,
+    "Deaths": 0
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 21,

--- a/internal/adapters/playerprovider/testdata/expected_players/Bloomingly_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Bloomingly_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 22227,
     "Deaths": 37868
   },
+  "Fourv4": {
+    "Winstreak": 33,
+    "GamesPlayed": 351,
+    "Wins": 300,
+    "Losses": 47,
+    "BedsBroken": 107,
+    "BedsLost": 61,
+    "FinalKills": 268,
+    "FinalDeaths": 47,
+    "Kills": 423,
+    "Deaths": 694
+  },
   "Overall": {
     "Winstreak": 89,
     "GamesPlayed": 31662,

--- a/internal/adapters/playerprovider/testdata/expected_players/BritishPoggers_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/BritishPoggers_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 1852,
     "Deaths": 4657
   },
+  "Fourv4": {
+    "Winstreak": 4,
+    "GamesPlayed": 44,
+    "Wins": 38,
+    "Losses": 5,
+    "BedsBroken": 6,
+    "BedsLost": 5,
+    "FinalKills": 32,
+    "FinalDeaths": 4,
+    "Kills": 61,
+    "Deaths": 108
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 2728,

--- a/internal/adapters/playerprovider/testdata/expected_players/Buhzai_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Buhzai_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 1821,
     "Deaths": 3090
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 29,
+    "Wins": 19,
+    "Losses": 9,
+    "BedsBroken": 9,
+    "BedsLost": 12,
+    "FinalKills": 19,
+    "FinalDeaths": 10,
+    "Kills": 20,
+    "Deaths": 49
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 3876,

--- a/internal/adapters/playerprovider/testdata/expected_players/CantTalkMewingRn_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/CantTalkMewingRn_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 4803,
     "Deaths": 6286
   },
+  "Fourv4": {
+    "Winstreak": 0,
+    "GamesPlayed": 2,
+    "Wins": 1,
+    "Losses": 1,
+    "BedsBroken": 1,
+    "BedsLost": 1,
+    "FinalKills": 1,
+    "FinalDeaths": 1,
+    "Kills": 8,
+    "Deaths": 1
+  },
   "Overall": {
     "Winstreak": 17,
     "GamesPlayed": 4187,

--- a/internal/adapters/playerprovider/testdata/expected_players/Chapeey_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Chapeey_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 19198,
     "Deaths": 31535
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 1074,
+    "Wins": 1035,
+    "Losses": 23,
+    "BedsBroken": 352,
+    "BedsLost": 39,
+    "FinalKills": 891,
+    "FinalDeaths": 26,
+    "Kills": 678,
+    "Deaths": 1262
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 38801,

--- a/internal/adapters/playerprovider/testdata/expected_players/Cliendence_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Cliendence_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 949,
     "Deaths": 1875
   },
+  "Fourv4": {
+    "Winstreak": 16,
+    "GamesPlayed": 57,
+    "Wins": 35,
+    "Losses": 21,
+    "BedsBroken": 20,
+    "BedsLost": 19,
+    "FinalKills": 59,
+    "FinalDeaths": 21,
+    "Kills": 120,
+    "Deaths": 146
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 3464,

--- a/internal/adapters/playerprovider/testdata/expected_players/Cold_Showers_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Cold_Showers_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 316,
     "Deaths": 252
   },
+  "Fourv4": {
+    "Winstreak": 0,
+    "GamesPlayed": 36,
+    "Wins": 14,
+    "Losses": 22,
+    "BedsBroken": 2,
+    "BedsLost": 20,
+    "FinalKills": 6,
+    "FinalDeaths": 19,
+    "Kills": 71,
+    "Deaths": 81
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 617,

--- a/internal/adapters/playerprovider/testdata/expected_players/Crawdead_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Crawdead_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 8387,
     "Deaths": 10430
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 95,
+    "Wins": 68,
+    "Losses": 23,
+    "BedsBroken": 21,
+    "BedsLost": 21,
+    "FinalKills": 68,
+    "FinalDeaths": 21,
+    "Kills": 94,
+    "Deaths": 137
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 41714,

--- a/internal/adapters/playerprovider/testdata/expected_players/DaddyToeFungus_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/DaddyToeFungus_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 17096,
     "Deaths": 18528
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 29,
+    "Wins": 27,
+    "Losses": 2,
+    "BedsBroken": 12,
+    "BedsLost": 3,
+    "FinalKills": 31,
+    "FinalDeaths": 2,
+    "Kills": 62,
+    "Deaths": 56
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 13143,

--- a/internal/adapters/playerprovider/testdata/expected_players/DeathDorito_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/DeathDorito_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 1254,
     "Deaths": 1977
   },
+  "Fourv4": {
+    "Winstreak": 0,
+    "GamesPlayed": 36,
+    "Wins": 20,
+    "Losses": 16,
+    "BedsBroken": 12,
+    "BedsLost": 17,
+    "FinalKills": 31,
+    "FinalDeaths": 16,
+    "Kills": 82,
+    "Deaths": 115
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 4233,

--- a/internal/adapters/playerprovider/testdata/expected_players/DefiantTech_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/DefiantTech_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 25138,
     "Deaths": 42009
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 198,
+    "Wins": 192,
+    "Losses": 1,
+    "BedsBroken": 60,
+    "BedsLost": 2,
+    "FinalKills": 142,
+    "FinalDeaths": 2,
+    "Kills": 81,
+    "Deaths": 207
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 32088,

--- a/internal/adapters/playerprovider/testdata/expected_players/Defone_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Defone_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 24179,
     "Deaths": 24439
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 1509,
+    "Wins": 1501,
+    "Losses": 1,
+    "BedsBroken": 529,
+    "BedsLost": 4,
+    "FinalKills": 2585,
+    "FinalDeaths": 1,
+    "Kills": 1683,
+    "Deaths": 884
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 29847,

--- a/internal/adapters/playerprovider/testdata/expected_players/Dir3d_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Dir3d_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 15021,
     "Deaths": 21488
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 147,
+    "Wins": 136,
+    "Losses": 9,
+    "BedsBroken": 43,
+    "BedsLost": 14,
+    "FinalKills": 118,
+    "FinalDeaths": 12,
+    "Kills": 139,
+    "Deaths": 186
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 16726,

--- a/internal/adapters/playerprovider/testdata/expected_players/Dog8116_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Dog8116_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 0,
     "Deaths": 0
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 0,
+    "Wins": 0,
+    "Losses": 0,
+    "BedsBroken": 0,
+    "BedsLost": 0,
+    "FinalKills": 0,
+    "FinalDeaths": 0,
+    "Kills": 0,
+    "Deaths": 0
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 0,

--- a/internal/adapters/playerprovider/testdata/expected_players/DucktheShuk_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/DucktheShuk_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 157,
     "Deaths": 315
   },
+  "Fourv4": {
+    "Winstreak": 12,
+    "GamesPlayed": 17,
+    "Wins": 14,
+    "Losses": 2,
+    "BedsBroken": 3,
+    "BedsLost": 4,
+    "FinalKills": 9,
+    "FinalDeaths": 2,
+    "Kills": 5,
+    "Deaths": 27
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 1959,

--- a/internal/adapters/playerprovider/testdata/expected_players/Dxante_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Dxante_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 5731,
     "Deaths": 11569
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 451,
+    "Wins": 256,
+    "Losses": 191,
+    "BedsBroken": 86,
+    "BedsLost": 199,
+    "FinalKills": 248,
+    "FinalDeaths": 184,
+    "Kills": 1316,
+    "Deaths": 1432
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 10017,

--- a/internal/adapters/playerprovider/testdata/expected_players/ETGX_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/ETGX_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 468,
     "Deaths": 505
   },
+  "Fourv4": {
+    "Winstreak": 1,
+    "GamesPlayed": 308,
+    "Wins": 215,
+    "Losses": 92,
+    "BedsBroken": 123,
+    "BedsLost": 103,
+    "FinalKills": 441,
+    "FinalDeaths": 99,
+    "Kills": 871,
+    "Deaths": 849
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 1679,

--- a/internal/adapters/playerprovider/testdata/expected_players/EX38_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/EX38_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 2191,
     "Deaths": 2356
   },
+  "Fourv4": {
+    "Winstreak": 0,
+    "GamesPlayed": 67,
+    "Wins": 37,
+    "Losses": 29,
+    "BedsBroken": 9,
+    "BedsLost": 22,
+    "FinalKills": 40,
+    "FinalDeaths": 31,
+    "Kills": 120,
+    "Deaths": 187
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 1403,

--- a/internal/adapters/playerprovider/testdata/expected_players/Ehyu_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Ehyu_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 1551,
     "Deaths": 2339
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 32,
+    "Wins": 22,
+    "Losses": 8,
+    "BedsBroken": 11,
+    "BedsLost": 8,
+    "FinalKills": 22,
+    "FinalDeaths": 7,
+    "Kills": 22,
+    "Deaths": 60
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 3826,

--- a/internal/adapters/playerprovider/testdata/expected_players/Eyr_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Eyr_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 1483,
     "Deaths": 2240
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 40,
+    "Wins": 36,
+    "Losses": 2,
+    "BedsBroken": 4,
+    "BedsLost": 2,
+    "FinalKills": 29,
+    "FinalDeaths": 2,
+    "Kills": 54,
+    "Deaths": 79
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 1945,

--- a/internal/adapters/playerprovider/testdata/expected_players/FavoAsian_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/FavoAsian_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 585,
     "Deaths": 716
   },
+  "Fourv4": {
+    "Winstreak": 3,
+    "GamesPlayed": 9,
+    "Wins": 5,
+    "Losses": 2,
+    "BedsBroken": 1,
+    "BedsLost": 4,
+    "FinalKills": 6,
+    "FinalDeaths": 3,
+    "Kills": 13,
+    "Deaths": 26
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 1446,

--- a/internal/adapters/playerprovider/testdata/expected_players/GOATIS313_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/GOATIS313_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 0,
     "Deaths": 0
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 0,
+    "Wins": 0,
+    "Losses": 0,
+    "BedsBroken": 0,
+    "BedsLost": 0,
+    "FinalKills": 0,
+    "FinalDeaths": 0,
+    "Kills": 0,
+    "Deaths": 0
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 4,

--- a/internal/adapters/playerprovider/testdata/expected_players/Galnox_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Galnox_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 560,
     "Deaths": 1304
   },
+  "Fourv4": {
+    "Winstreak": 1,
+    "GamesPlayed": 102,
+    "Wins": 45,
+    "Losses": 55,
+    "BedsBroken": 6,
+    "BedsLost": 50,
+    "FinalKills": 35,
+    "FinalDeaths": 59,
+    "Kills": 181,
+    "Deaths": 404
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 2075,

--- a/internal/adapters/playerprovider/testdata/expected_players/Gatore_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Gatore_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 6879,
     "Deaths": 10230
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 151,
+    "Wins": 114,
+    "Losses": 33,
+    "BedsBroken": 65,
+    "BedsLost": 39,
+    "FinalKills": 162,
+    "FinalDeaths": 33,
+    "Kills": 370,
+    "Deaths": 328
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 10193,

--- a/internal/adapters/playerprovider/testdata/expected_players/Gauss_TW_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Gauss_TW_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 2561,
     "Deaths": 3767
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 259,
+    "Wins": 199,
+    "Losses": 52,
+    "BedsBroken": 86,
+    "BedsLost": 53,
+    "FinalKills": 243,
+    "FinalDeaths": 40,
+    "Kills": 345,
+    "Deaths": 562
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 4308,

--- a/internal/adapters/playerprovider/testdata/expected_players/GawCHINKK_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/GawCHINKK_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 436,
     "Deaths": 674
   },
+  "Fourv4": {
+    "Winstreak": 13,
+    "GamesPlayed": 13,
+    "Wins": 13,
+    "Losses": 0,
+    "BedsBroken": 3,
+    "BedsLost": 0,
+    "FinalKills": 15,
+    "FinalDeaths": 0,
+    "Kills": 12,
+    "Deaths": 10
+  },
   "Overall": {
     "Winstreak": 16,
     "GamesPlayed": 854,

--- a/internal/adapters/playerprovider/testdata/expected_players/Golzdom_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Golzdom_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 642,
     "Deaths": 892
   },
+  "Fourv4": {
+    "Winstreak": 0,
+    "GamesPlayed": 21,
+    "Wins": 5,
+    "Losses": 16,
+    "BedsBroken": 0,
+    "BedsLost": 14,
+    "FinalKills": 2,
+    "FinalDeaths": 14,
+    "Kills": 14,
+    "Deaths": 13
+  },
   "Overall": {
     "Winstreak": 1,
     "GamesPlayed": 575,

--- a/internal/adapters/playerprovider/testdata/expected_players/Grampslikefood_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Grampslikefood_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 1569,
     "Deaths": 1473
   },
+  "Fourv4": {
+    "Winstreak": 0,
+    "GamesPlayed": 101,
+    "Wins": 61,
+    "Losses": 39,
+    "BedsBroken": 31,
+    "BedsLost": 38,
+    "FinalKills": 89,
+    "FinalDeaths": 37,
+    "Kills": 169,
+    "Deaths": 278
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 2266,

--- a/internal/adapters/playerprovider/testdata/expected_players/GreenJedia04_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/GreenJedia04_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 18019,
     "Deaths": 31895
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 2740,
+    "Wins": 2650,
+    "Losses": 27,
+    "BedsBroken": 715,
+    "BedsLost": 63,
+    "FinalKills": 2146,
+    "FinalDeaths": 33,
+    "Kills": 1798,
+    "Deaths": 3161
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 43721,

--- a/internal/adapters/playerprovider/testdata/expected_players/GreenSheepi_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/GreenSheepi_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 18873,
     "Deaths": 25801
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 771,
+    "Wins": 744,
+    "Losses": 12,
+    "BedsBroken": 196,
+    "BedsLost": 18,
+    "FinalKills": 755,
+    "FinalDeaths": 12,
+    "Kills": 530,
+    "Deaths": 818
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 46622,

--- a/internal/adapters/playerprovider/testdata/expected_players/Hashito_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Hashito_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 1949,
     "Deaths": 3286
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 0,
+    "Wins": 0,
+    "Losses": 0,
+    "BedsBroken": 0,
+    "BedsLost": 0,
+    "FinalKills": 0,
+    "FinalDeaths": 0,
+    "Kills": 0,
+    "Deaths": 0
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 46182,

--- a/internal/adapters/playerprovider/testdata/expected_players/Hfoxlord_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Hfoxlord_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 39,
     "Deaths": 134
   },
+  "Fourv4": {
+    "Winstreak": 0,
+    "GamesPlayed": 12,
+    "Wins": 5,
+    "Losses": 7,
+    "BedsBroken": 3,
+    "BedsLost": 7,
+    "FinalKills": 8,
+    "FinalDeaths": 7,
+    "Kills": 8,
+    "Deaths": 31
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 250,

--- a/internal/adapters/playerprovider/testdata/expected_players/ImRegretWhatIDid_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/ImRegretWhatIDid_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 12104,
     "Deaths": 22181
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 2896,
+    "Wins": 2815,
+    "Losses": 45,
+    "BedsBroken": 1034,
+    "BedsLost": 97,
+    "FinalKills": 1829,
+    "FinalDeaths": 60,
+    "Kills": 988,
+    "Deaths": 2996
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 33773,

--- a/internal/adapters/playerprovider/testdata/expected_players/Its_The_Guy_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Its_The_Guy_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 32,
     "Deaths": 35
   },
+  "Fourv4": {
+    "Winstreak": 2,
+    "GamesPlayed": 116,
+    "Wins": 59,
+    "Losses": 55,
+    "BedsBroken": 8,
+    "BedsLost": 52,
+    "FinalKills": 39,
+    "FinalDeaths": 55,
+    "Kills": 241,
+    "Deaths": 267
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 155,

--- a/internal/adapters/playerprovider/testdata/expected_players/Itz_Theo_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Itz_Theo_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 190,
     "Deaths": 387
   },
+  "Fourv4": {
+    "Winstreak": 1,
+    "GamesPlayed": 15,
+    "Wins": 5,
+    "Losses": 10,
+    "BedsBroken": 4,
+    "BedsLost": 9,
+    "FinalKills": 5,
+    "FinalDeaths": 10,
+    "Kills": 28,
+    "Deaths": 52
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 906,

--- a/internal/adapters/playerprovider/testdata/expected_players/Jedv_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Jedv_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 575,
     "Deaths": 511
   },
+  "Fourv4": {
+    "Winstreak": 3,
+    "GamesPlayed": 75,
+    "Wins": 62,
+    "Losses": 12,
+    "BedsBroken": 13,
+    "BedsLost": 11,
+    "FinalKills": 55,
+    "FinalDeaths": 10,
+    "Kills": 118,
+    "Deaths": 141
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 1577,

--- a/internal/adapters/playerprovider/testdata/expected_players/Jifc_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Jifc_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 216,
     "Deaths": 154
   },
+  "Fourv4": {
+    "Winstreak": 1,
+    "GamesPlayed": 2,
+    "Wins": 1,
+    "Losses": 1,
+    "BedsBroken": 1,
+    "BedsLost": 1,
+    "FinalKills": 1,
+    "FinalDeaths": 1,
+    "Kills": 6,
+    "Deaths": 4
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 343,

--- a/internal/adapters/playerprovider/testdata/expected_players/Jqsie_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Jqsie_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 29440,
     "Deaths": 37811
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 397,
+    "Wins": 390,
+    "Losses": 4,
+    "BedsBroken": 86,
+    "BedsLost": 7,
+    "FinalKills": 328,
+    "FinalDeaths": 4,
+    "Kills": 352,
+    "Deaths": 450
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 43047,

--- a/internal/adapters/playerprovider/testdata/expected_players/Juaaann_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Juaaann_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 14488,
     "Deaths": 26835
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 331,
+    "Wins": 261,
+    "Losses": 64,
+    "BedsBroken": 106,
+    "BedsLost": 68,
+    "FinalKills": 242,
+    "FinalDeaths": 53,
+    "Kills": 473,
+    "Deaths": 689
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 20055,

--- a/internal/adapters/playerprovider/testdata/expected_players/JuiiceWRLD_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/JuiiceWRLD_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 4245,
     "Deaths": 5714
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 574,
+    "Wins": 336,
+    "Losses": 238,
+    "BedsBroken": 109,
+    "BedsLost": 258,
+    "FinalKills": 364,
+    "FinalDeaths": 254,
+    "Kills": 1247,
+    "Deaths": 1487
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 5350,

--- a/internal/adapters/playerprovider/testdata/expected_players/JustACasualDay_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/JustACasualDay_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 448,
     "Deaths": 597
   },
+  "Fourv4": {
+    "Winstreak": 3,
+    "GamesPlayed": 3,
+    "Wins": 3,
+    "Losses": 0,
+    "BedsBroken": 2,
+    "BedsLost": 1,
+    "FinalKills": 7,
+    "FinalDeaths": 0,
+    "Kills": 7,
+    "Deaths": 10
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 466,

--- a/internal/adapters/playerprovider/testdata/expected_players/Kelsov_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Kelsov_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 6760,
     "Deaths": 8951
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 250,
+    "Wins": 178,
+    "Losses": 55,
+    "BedsBroken": 94,
+    "BedsLost": 60,
+    "FinalKills": 214,
+    "FinalDeaths": 50,
+    "Kills": 483,
+    "Deaths": 532
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 8802,

--- a/internal/adapters/playerprovider/testdata/expected_players/Kubcn_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Kubcn_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 10724,
     "Deaths": 21179
   },
+  "Fourv4": {
+    "Winstreak": 49,
+    "GamesPlayed": 222,
+    "Wins": 210,
+    "Losses": 8,
+    "BedsBroken": 52,
+    "BedsLost": 11,
+    "FinalKills": 174,
+    "FinalDeaths": 9,
+    "Kills": 164,
+    "Deaths": 294
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 33914,

--- a/internal/adapters/playerprovider/testdata/expected_players/Leopardiston_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Leopardiston_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 39058,
     "Deaths": 36584
   },
+  "Fourv4": {
+    "Winstreak": 16,
+    "GamesPlayed": 26,
+    "Wins": 22,
+    "Losses": 2,
+    "BedsBroken": 7,
+    "BedsLost": 2,
+    "FinalKills": 15,
+    "FinalDeaths": 2,
+    "Kills": 25,
+    "Deaths": 35
+  },
   "Overall": {
     "Winstreak": 2,
     "GamesPlayed": 36377,

--- a/internal/adapters/playerprovider/testdata/expected_players/Lintels_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Lintels_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 26954,
     "Deaths": 50367
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 3648,
+    "Wins": 3522,
+    "Losses": 47,
+    "BedsBroken": 622,
+    "BedsLost": 91,
+    "FinalKills": 2874,
+    "FinalDeaths": 56,
+    "Kills": 1640,
+    "Deaths": 2854
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 41929,

--- a/internal/adapters/playerprovider/testdata/expected_players/LlamaFan54_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/LlamaFan54_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 21,
     "Deaths": 57
   },
+  "Fourv4": {
+    "Winstreak": 0,
+    "GamesPlayed": 5,
+    "Wins": 2,
+    "Losses": 3,
+    "BedsBroken": 0,
+    "BedsLost": 4,
+    "FinalKills": 3,
+    "FinalDeaths": 4,
+    "Kills": 7,
+    "Deaths": 14
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 1058,

--- a/internal/adapters/playerprovider/testdata/expected_players/Luify_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Luify_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 5492,
     "Deaths": 5298
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 77,
+    "Wins": 53,
+    "Losses": 22,
+    "BedsBroken": 20,
+    "BedsLost": 26,
+    "FinalKills": 64,
+    "FinalDeaths": 22,
+    "Kills": 158,
+    "Deaths": 164
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 6462,

--- a/internal/adapters/playerprovider/testdata/expected_players/Lyndonz_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Lyndonz_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 22106,
     "Deaths": 34615
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 139,
+    "Wins": 128,
+    "Losses": 6,
+    "BedsBroken": 45,
+    "BedsLost": 9,
+    "FinalKills": 99,
+    "FinalDeaths": 5,
+    "Kills": 128,
+    "Deaths": 199
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 21423,

--- a/internal/adapters/playerprovider/testdata/expected_players/M0KKY__2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/M0KKY__2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 7192,
     "Deaths": 10729
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 624,
+    "Wins": 610,
+    "Losses": 9,
+    "BedsBroken": 229,
+    "BedsLost": 21,
+    "FinalKills": 733,
+    "FinalDeaths": 9,
+    "Kills": 401,
+    "Deaths": 553
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 27528,

--- a/internal/adapters/playerprovider/testdata/expected_players/MAHMOUD_GAMEING_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/MAHMOUD_GAMEING_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 25274,
     "Deaths": 28997
   },
+  "Fourv4": {
+    "Winstreak": 28,
+    "GamesPlayed": 2578,
+    "Wins": 2550,
+    "Losses": 11,
+    "BedsBroken": 1033,
+    "BedsLost": 22,
+    "FinalKills": 3760,
+    "FinalDeaths": 11,
+    "Kills": 2651,
+    "Deaths": 2397
+  },
   "Overall": {
     "Winstreak": 286,
     "GamesPlayed": 63190,

--- a/internal/adapters/playerprovider/testdata/expected_players/MEEMAWSUS_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/MEEMAWSUS_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 1889,
     "Deaths": 3554
   },
+  "Fourv4": {
+    "Winstreak": 0,
+    "GamesPlayed": 127,
+    "Wins": 70,
+    "Losses": 52,
+    "BedsBroken": 23,
+    "BedsLost": 47,
+    "FinalKills": 62,
+    "FinalDeaths": 48,
+    "Kills": 212,
+    "Deaths": 382
+  },
   "Overall": {
     "Winstreak": 9,
     "GamesPlayed": 2665,

--- a/internal/adapters/playerprovider/testdata/expected_players/MR_money_bags777_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/MR_money_bags777_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 927,
     "Deaths": 547
   },
+  "Fourv4": {
+    "Winstreak": 0,
+    "GamesPlayed": 626,
+    "Wins": 289,
+    "Losses": 331,
+    "BedsBroken": 48,
+    "BedsLost": 314,
+    "FinalKills": 254,
+    "FinalDeaths": 343,
+    "Kills": 1172,
+    "Deaths": 808
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 1633,

--- a/internal/adapters/playerprovider/testdata/expected_players/Manhal_IQ__2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Manhal_IQ__2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 31230,
     "Deaths": 44553
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 3947,
+    "Wins": 3810,
+    "Losses": 54,
+    "BedsBroken": 1192,
+    "BedsLost": 103,
+    "FinalKills": 4094,
+    "FinalDeaths": 57,
+    "Kills": 2813,
+    "Deaths": 3244
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 61000,

--- a/internal/adapters/playerprovider/testdata/expected_players/MaxBuilder4X_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/MaxBuilder4X_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 418,
     "Deaths": 508
   },
+  "Fourv4": {
+    "Winstreak": 10,
+    "GamesPlayed": 25,
+    "Wins": 21,
+    "Losses": 4,
+    "BedsBroken": 7,
+    "BedsLost": 8,
+    "FinalKills": 27,
+    "FinalDeaths": 6,
+    "Kills": 26,
+    "Deaths": 42
+  },
   "Overall": {
     "Winstreak": 2,
     "GamesPlayed": 2969,

--- a/internal/adapters/playerprovider/testdata/expected_players/MonsterGG_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/MonsterGG_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 15628,
     "Deaths": 34343
   },
+  "Fourv4": {
+    "Winstreak": 256,
+    "GamesPlayed": 265,
+    "Wins": 263,
+    "Losses": 0,
+    "BedsBroken": 75,
+    "BedsLost": 2,
+    "FinalKills": 250,
+    "FinalDeaths": 1,
+    "Kills": 140,
+    "Deaths": 239
+  },
   "Overall": {
     "Winstreak": 11,
     "GamesPlayed": 29996,

--- a/internal/adapters/playerprovider/testdata/expected_players/MrPoluxX_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/MrPoluxX_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 183,
     "Deaths": 375
   },
+  "Fourv4": {
+    "Winstreak": 0,
+    "GamesPlayed": 409,
+    "Wins": 155,
+    "Losses": 251,
+    "BedsBroken": 55,
+    "BedsLost": 255,
+    "FinalKills": 180,
+    "FinalDeaths": 255,
+    "Kills": 927,
+    "Deaths": 1459
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 2573,

--- a/internal/adapters/playerprovider/testdata/expected_players/NeinReich_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/NeinReich_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 42,
     "Deaths": 52
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 0,
+    "Wins": 0,
+    "Losses": 0,
+    "BedsBroken": 0,
+    "BedsLost": 0,
+    "FinalKills": 0,
+    "FinalDeaths": 0,
+    "Kills": 0,
+    "Deaths": 0
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 24,

--- a/internal/adapters/playerprovider/testdata/expected_players/NoSDaemon_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/NoSDaemon_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 29471,
     "Deaths": 33252
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 147,
+    "Wins": 144,
+    "Losses": 2,
+    "BedsBroken": 61,
+    "BedsLost": 7,
+    "FinalKills": 169,
+    "FinalDeaths": 4,
+    "Kills": 83,
+    "Deaths": 120
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 42329,

--- a/internal/adapters/playerprovider/testdata/expected_players/OSound_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/OSound_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 466,
     "Deaths": 783
   },
+  "Fourv4": {
+    "Winstreak": 0,
+    "GamesPlayed": 359,
+    "Wins": 139,
+    "Losses": 219,
+    "BedsBroken": 15,
+    "BedsLost": 182,
+    "FinalKills": 94,
+    "FinalDeaths": 220,
+    "Kills": 603,
+    "Deaths": 972
+  },
   "Overall": {
     "Winstreak": 19,
     "GamesPlayed": 3367,

--- a/internal/adapters/playerprovider/testdata/expected_players/Ohfound_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Ohfound_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 2844,
     "Deaths": 3421
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 4,
+    "Wins": 4,
+    "Losses": 0,
+    "BedsBroken": 2,
+    "BedsLost": 0,
+    "FinalKills": 6,
+    "FinalDeaths": 0,
+    "Kills": 6,
+    "Deaths": 8
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 2110,

--- a/internal/adapters/playerprovider/testdata/expected_players/Ohhhduck_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Ohhhduck_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 230,
     "Deaths": 265
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 192,
+    "Wins": 140,
+    "Losses": 51,
+    "BedsBroken": 59,
+    "BedsLost": 57,
+    "FinalKills": 189,
+    "FinalDeaths": 53,
+    "Kills": 533,
+    "Deaths": 428
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 2595,

--- a/internal/adapters/playerprovider/testdata/expected_players/OkayShawny_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/OkayShawny_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 146,
     "Deaths": 98
   },
+  "Fourv4": {
+    "Winstreak": 1,
+    "GamesPlayed": 1,
+    "Wins": 1,
+    "Losses": 0,
+    "BedsBroken": 1,
+    "BedsLost": 0,
+    "FinalKills": 3,
+    "FinalDeaths": 0,
+    "Kills": 1,
+    "Deaths": 3
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 88,

--- a/internal/adapters/playerprovider/testdata/expected_players/OpGoDnEsSs_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/OpGoDnEsSs_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 34793,
     "Deaths": 63672
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 434,
+    "Wins": 387,
+    "Losses": 6,
+    "BedsBroken": 112,
+    "BedsLost": 6,
+    "FinalKills": 311,
+    "FinalDeaths": 3,
+    "Kills": 244,
+    "Deaths": 404
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 33896,

--- a/internal/adapters/playerprovider/testdata/expected_players/PRO10MIXALIS_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/PRO10MIXALIS_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 39,
     "Deaths": 52
   },
+  "Fourv4": {
+    "Winstreak": 0,
+    "GamesPlayed": 3,
+    "Wins": 1,
+    "Losses": 2,
+    "BedsBroken": 0,
+    "BedsLost": 1,
+    "FinalKills": 1,
+    "FinalDeaths": 2,
+    "Kills": 10,
+    "Deaths": 12
+  },
   "Overall": {
     "Winstreak": 1,
     "GamesPlayed": 143,

--- a/internal/adapters/playerprovider/testdata/expected_players/ParCrayDragon1_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/ParCrayDragon1_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 792,
     "Deaths": 993
   },
+  "Fourv4": {
+    "Winstreak": 0,
+    "GamesPlayed": 863,
+    "Wins": 429,
+    "Losses": 425,
+    "BedsBroken": 74,
+    "BedsLost": 334,
+    "FinalKills": 417,
+    "FinalDeaths": 450,
+    "Kills": 2638,
+    "Deaths": 3130
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 2586,

--- a/internal/adapters/playerprovider/testdata/expected_players/Pheenus_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Pheenus_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 3664,
     "Deaths": 3528
   },
+  "Fourv4": {
+    "Winstreak": 0,
+    "GamesPlayed": 17,
+    "Wins": 3,
+    "Losses": 14,
+    "BedsBroken": 0,
+    "BedsLost": 13,
+    "FinalKills": 2,
+    "FinalDeaths": 13,
+    "Kills": 31,
+    "Deaths": 39
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 1871,

--- a/internal/adapters/playerprovider/testdata/expected_players/PlzFightMe_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/PlzFightMe_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 48159,
     "Deaths": 52228
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 1293,
+    "Wins": 1266,
+    "Losses": 13,
+    "BedsBroken": 412,
+    "BedsLost": 20,
+    "FinalKills": 1583,
+    "FinalDeaths": 15,
+    "Kills": 1025,
+    "Deaths": 1114
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 33812,

--- a/internal/adapters/playerprovider/testdata/expected_players/Popcornfroid_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Popcornfroid_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 15,
     "Deaths": 58
   },
+  "Fourv4": {
+    "Winstreak": 0,
+    "GamesPlayed": 38,
+    "Wins": 14,
+    "Losses": 24,
+    "BedsBroken": 1,
+    "BedsLost": 21,
+    "FinalKills": 5,
+    "FinalDeaths": 25,
+    "Kills": 24,
+    "Deaths": 103
+  },
   "Overall": {
     "Winstreak": 1,
     "GamesPlayed": 1581,

--- a/internal/adapters/playerprovider/testdata/expected_players/Quagalicious_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Quagalicious_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 505,
     "Deaths": 814
   },
+  "Fourv4": {
+    "Winstreak": 1,
+    "GamesPlayed": 47,
+    "Wins": 21,
+    "Losses": 26,
+    "BedsBroken": 5,
+    "BedsLost": 27,
+    "FinalKills": 19,
+    "FinalDeaths": 27,
+    "Kills": 75,
+    "Deaths": 95
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 1673,

--- a/internal/adapters/playerprovider/testdata/expected_players/Quan10_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Quan10_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 3160,
     "Deaths": 4280
   },
+  "Fourv4": {
+    "Winstreak": 1,
+    "GamesPlayed": 104,
+    "Wins": 45,
+    "Losses": 55,
+    "BedsBroken": 16,
+    "BedsLost": 57,
+    "FinalKills": 49,
+    "FinalDeaths": 55,
+    "Kills": 282,
+    "Deaths": 324
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 5353,

--- a/internal/adapters/playerprovider/testdata/expected_players/QuitFanning_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/QuitFanning_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 33,
     "Deaths": 25
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 0,
+    "Wins": 0,
+    "Losses": 0,
+    "BedsBroken": 0,
+    "BedsLost": 0,
+    "FinalKills": 0,
+    "FinalDeaths": 0,
+    "Kills": 0,
+    "Deaths": 0
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 185,

--- a/internal/adapters/playerprovider/testdata/expected_players/RRG__2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/RRG__2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 15657,
     "Deaths": 27911
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 994,
+    "Wins": 920,
+    "Losses": 51,
+    "BedsBroken": 248,
+    "BedsLost": 79,
+    "FinalKills": 843,
+    "FinalDeaths": 64,
+    "Kills": 759,
+    "Deaths": 1528
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 48987,

--- a/internal/adapters/playerprovider/testdata/expected_players/Red_Dolphin34_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Red_Dolphin34_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 530,
     "Deaths": 1249
   },
+  "Fourv4": {
+    "Winstreak": 0,
+    "GamesPlayed": 2,
+    "Wins": 0,
+    "Losses": 2,
+    "BedsBroken": 0,
+    "BedsLost": 1,
+    "FinalKills": 0,
+    "FinalDeaths": 2,
+    "Kills": 15,
+    "Deaths": 10
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 421,

--- a/internal/adapters/playerprovider/testdata/expected_players/Rizzone_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Rizzone_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 193,
     "Deaths": 654
   },
+  "Fourv4": {
+    "Winstreak": 4,
+    "GamesPlayed": 6,
+    "Wins": 5,
+    "Losses": 1,
+    "BedsBroken": 2,
+    "BedsLost": 4,
+    "FinalKills": 3,
+    "FinalDeaths": 2,
+    "Kills": 6,
+    "Deaths": 17
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 1799,

--- a/internal/adapters/playerprovider/testdata/expected_players/Sharmoy_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Sharmoy_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 2340,
     "Deaths": 2620
   },
+  "Fourv4": {
+    "Winstreak": 0,
+    "GamesPlayed": 14,
+    "Wins": 11,
+    "Losses": 3,
+    "BedsBroken": 2,
+    "BedsLost": 4,
+    "FinalKills": 9,
+    "FinalDeaths": 3,
+    "Kills": 17,
+    "Deaths": 21
+  },
   "Overall": {
     "Winstreak": 4,
     "GamesPlayed": 2343,

--- a/internal/adapters/playerprovider/testdata/expected_players/SixtoTheGreat_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/SixtoTheGreat_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 9774,
     "Deaths": 22493
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 544,
+    "Wins": 512,
+    "Losses": 22,
+    "BedsBroken": 143,
+    "BedsLost": 40,
+    "FinalKills": 452,
+    "FinalDeaths": 27,
+    "Kills": 322,
+    "Deaths": 634
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 53995,

--- a/internal/adapters/playerprovider/testdata/expected_players/Sixx_0_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Sixx_0_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 107,
     "Deaths": 101
   },
+  "Fourv4": {
+    "Winstreak": 2,
+    "GamesPlayed": 7,
+    "Wins": 4,
+    "Losses": 3,
+    "BedsBroken": 1,
+    "BedsLost": 2,
+    "FinalKills": 2,
+    "FinalDeaths": 3,
+    "Kills": 10,
+    "Deaths": 25
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 159,

--- a/internal/adapters/playerprovider/testdata/expected_players/Skydeaf_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Skydeaf_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 1256,
     "Deaths": 1740
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 5,
+    "Wins": 5,
+    "Losses": 0,
+    "BedsBroken": 2,
+    "BedsLost": 0,
+    "FinalKills": 11,
+    "FinalDeaths": 0,
+    "Kills": 9,
+    "Deaths": 14
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 1417,

--- a/internal/adapters/playerprovider/testdata/expected_players/Skydeath_2021_01_07.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Skydeath_2021_01_07.json
@@ -54,6 +54,18 @@
     "Kills": 2370,
     "Deaths": 3576
   },
+  "Fourv4": {
+    "Winstreak": 0,
+    "GamesPlayed": 67,
+    "Wins": 39,
+    "Losses": 26,
+    "BedsBroken": 33,
+    "BedsLost": 33,
+    "FinalKills": 66,
+    "FinalDeaths": 26,
+    "Kills": 215,
+    "Deaths": 186
+  },
   "Overall": {
     "Winstreak": 7,
     "GamesPlayed": 3940,

--- a/internal/adapters/playerprovider/testdata/expected_players/Skydeath_2024_02_03.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Skydeath_2024_02_03.json
@@ -54,6 +54,18 @@
     "Kills": 5864,
     "Deaths": 8750
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 72,
+    "Wins": 44,
+    "Losses": 26,
+    "BedsBroken": 33,
+    "BedsLost": 33,
+    "FinalKills": 73,
+    "FinalDeaths": 26,
+    "Kills": 220,
+    "Deaths": 196
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 7867,

--- a/internal/adapters/playerprovider/testdata/expected_players/Skydeath_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Skydeath_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 5864,
     "Deaths": 8750
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 72,
+    "Wins": 44,
+    "Losses": 26,
+    "BedsBroken": 33,
+    "BedsLost": 33,
+    "FinalKills": 73,
+    "FinalDeaths": 26,
+    "Kills": 220,
+    "Deaths": 196
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 7867,

--- a/internal/adapters/playerprovider/testdata/expected_players/SuperAlexNoob_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/SuperAlexNoob_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 7484,
     "Deaths": 12741
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 333,
+    "Wins": 312,
+    "Losses": 13,
+    "BedsBroken": 97,
+    "BedsLost": 21,
+    "FinalKills": 280,
+    "FinalDeaths": 13,
+    "Kills": 228,
+    "Deaths": 419
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 36288,

--- a/internal/adapters/playerprovider/testdata/expected_players/TeamLuxGlez_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/TeamLuxGlez_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 11570,
     "Deaths": 17182
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 12,
+    "Wins": 11,
+    "Losses": 1,
+    "BedsBroken": 5,
+    "BedsLost": 2,
+    "FinalKills": 17,
+    "FinalDeaths": 2,
+    "Kills": 11,
+    "Deaths": 3
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 32332,

--- a/internal/adapters/playerprovider/testdata/expected_players/TheCleb_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/TheCleb_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 33884,
     "Deaths": 72105
   },
+  "Fourv4": {
+    "Winstreak": 3,
+    "GamesPlayed": 5,
+    "Wins": 4,
+    "Losses": 1,
+    "BedsBroken": 2,
+    "BedsLost": 2,
+    "FinalKills": 1,
+    "FinalDeaths": 1,
+    "Kills": 11,
+    "Deaths": 11
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 33891,

--- a/internal/adapters/playerprovider/testdata/expected_players/TheGoldenBalls_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/TheGoldenBalls_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 256,
     "Deaths": 533
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 0,
+    "Wins": 0,
+    "Losses": 0,
+    "BedsBroken": 0,
+    "BedsLost": 0,
+    "FinalKills": 0,
+    "FinalDeaths": 0,
+    "Kills": 0,
+    "Deaths": 0
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 541,

--- a/internal/adapters/playerprovider/testdata/expected_players/TigerboyBob_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/TigerboyBob_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 736,
     "Deaths": 1914
   },
+  "Fourv4": {
+    "Winstreak": 1,
+    "GamesPlayed": 813,
+    "Wins": 312,
+    "Losses": 497,
+    "BedsBroken": 99,
+    "BedsLost": 391,
+    "FinalKills": 263,
+    "FinalDeaths": 519,
+    "Kills": 928,
+    "Deaths": 2206
+  },
   "Overall": {
     "Winstreak": 1,
     "GamesPlayed": 2396,

--- a/internal/adapters/playerprovider/testdata/expected_players/Tolered_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Tolered_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 455,
     "Deaths": 1033
   },
+  "Fourv4": {
+    "Winstreak": 2,
+    "GamesPlayed": 426,
+    "Wins": 143,
+    "Losses": 283,
+    "BedsBroken": 21,
+    "BedsLost": 280,
+    "FinalKills": 89,
+    "FinalDeaths": 294,
+    "Kills": 648,
+    "Deaths": 1041
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 1830,

--- a/internal/adapters/playerprovider/testdata/expected_players/U5BB_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/U5BB_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 544,
     "Deaths": 509
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 9,
+    "Wins": 5,
+    "Losses": 2,
+    "BedsBroken": 0,
+    "BedsLost": 2,
+    "FinalKills": 4,
+    "FinalDeaths": 2,
+    "Kills": 7,
+    "Deaths": 1
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 1034,

--- a/internal/adapters/playerprovider/testdata/expected_players/USBB_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/USBB_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 21442,
     "Deaths": 29878
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 438,
+    "Wins": 329,
+    "Losses": 96,
+    "BedsBroken": 182,
+    "BedsLost": 106,
+    "FinalKills": 392,
+    "FinalDeaths": 97,
+    "Kills": 901,
+    "Deaths": 1177
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 21632,

--- a/internal/adapters/playerprovider/testdata/expected_players/Ultrailuminado_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Ultrailuminado_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 0,
     "Deaths": 0
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 0,
+    "Wins": 0,
+    "Losses": 0,
+    "BedsBroken": 0,
+    "BedsLost": 0,
+    "FinalKills": 0,
+    "FinalDeaths": 0,
+    "Kills": 0,
+    "Deaths": 0
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 4968,

--- a/internal/adapters/playerprovider/testdata/expected_players/VEZYxVOLTEYxEROS_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/VEZYxVOLTEYxEROS_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 70910,
     "Deaths": 76790
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 122,
+    "Wins": 118,
+    "Losses": 1,
+    "BedsBroken": 5,
+    "BedsLost": 4,
+    "FinalKills": 61,
+    "FinalDeaths": 1,
+    "Kills": 51,
+    "Deaths": 62
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 44390,

--- a/internal/adapters/playerprovider/testdata/expected_players/WarOG_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/WarOG_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 78325,
     "Deaths": 66455
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 1541,
+    "Wins": 1473,
+    "Losses": 35,
+    "BedsBroken": 638,
+    "BedsLost": 72,
+    "FinalKills": 1711,
+    "FinalDeaths": 41,
+    "Kills": 1606,
+    "Deaths": 1838
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 68795,

--- a/internal/adapters/playerprovider/testdata/expected_players/Wizarro_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Wizarro_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 29354,
     "Deaths": 50252
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 685,
+    "Wins": 666,
+    "Losses": 6,
+    "BedsBroken": 183,
+    "BedsLost": 13,
+    "FinalKills": 531,
+    "FinalDeaths": 5,
+    "Kills": 498,
+    "Deaths": 713
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 36070,

--- a/internal/adapters/playerprovider/testdata/expected_players/Wlnks_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Wlnks_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 12590,
     "Deaths": 23729
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 41,
+    "Wins": 32,
+    "Losses": 8,
+    "BedsBroken": 12,
+    "BedsLost": 7,
+    "FinalKills": 43,
+    "FinalDeaths": 7,
+    "Kills": 64,
+    "Deaths": 100
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 45583,

--- a/internal/adapters/playerprovider/testdata/expected_players/Wonkky_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Wonkky_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 14914,
     "Deaths": 22389
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 91,
+    "Wins": 76,
+    "Losses": 11,
+    "BedsBroken": 31,
+    "BedsLost": 17,
+    "FinalKills": 68,
+    "FinalDeaths": 13,
+    "Kills": 154,
+    "Deaths": 210
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 8735,

--- a/internal/adapters/playerprovider/testdata/expected_players/Yaomi_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Yaomi_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 11456,
     "Deaths": 13952
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 196,
+    "Wins": 188,
+    "Losses": 7,
+    "BedsBroken": 42,
+    "BedsLost": 10,
+    "FinalKills": 194,
+    "FinalDeaths": 10,
+    "Kills": 166,
+    "Deaths": 223
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 9879,

--- a/internal/adapters/playerprovider/testdata/expected_players/Zeit_Gaming_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/Zeit_Gaming_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 7383,
     "Deaths": 8708
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 78,
+    "Wins": 59,
+    "Losses": 19,
+    "BedsBroken": 37,
+    "BedsLost": 23,
+    "FinalKills": 80,
+    "FinalDeaths": 19,
+    "Kills": 157,
+    "Deaths": 161
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 42938,

--- a/internal/adapters/playerprovider/testdata/expected_players/_JBC__2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/_JBC__2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 2789,
     "Deaths": 4474
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 179,
+    "Wins": 101,
+    "Losses": 77,
+    "BedsBroken": 63,
+    "BedsLost": 85,
+    "FinalKills": 107,
+    "FinalDeaths": 78,
+    "Kills": 294,
+    "Deaths": 559
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 39209,

--- a/internal/adapters/playerprovider/testdata/expected_players/_RazeReflex__2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/_RazeReflex__2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 65,
     "Deaths": 161
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 0,
+    "Wins": 0,
+    "Losses": 0,
+    "BedsBroken": 0,
+    "BedsLost": 0,
+    "FinalKills": 0,
+    "FinalDeaths": 0,
+    "Kills": 0,
+    "Deaths": 0
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 391,

--- a/internal/adapters/playerprovider/testdata/expected_players/____WaFFlz______2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/____WaFFlz______2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 93,
     "Deaths": 249
   },
+  "Fourv4": {
+    "Winstreak": 0,
+    "GamesPlayed": 15,
+    "Wins": 2,
+    "Losses": 13,
+    "BedsBroken": 0,
+    "BedsLost": 12,
+    "FinalKills": 4,
+    "FinalDeaths": 13,
+    "Kills": 17,
+    "Deaths": 21
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 394,

--- a/internal/adapters/playerprovider/testdata/expected_players/_lazor_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/_lazor_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 515,
     "Deaths": 2408
   },
+  "Fourv4": {
+    "Winstreak": 0,
+    "GamesPlayed": 133,
+    "Wins": 50,
+    "Losses": 76,
+    "BedsBroken": 2,
+    "BedsLost": 77,
+    "FinalKills": 15,
+    "FinalDeaths": 76,
+    "Kills": 114,
+    "Deaths": 399
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 1161,

--- a/internal/adapters/playerprovider/testdata/expected_players/acehubs_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/acehubs_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 220,
     "Deaths": 407
   },
+  "Fourv4": {
+    "Winstreak": 3,
+    "GamesPlayed": 146,
+    "Wins": 71,
+    "Losses": 75,
+    "BedsBroken": 35,
+    "BedsLost": 79,
+    "FinalKills": 81,
+    "FinalDeaths": 79,
+    "Kills": 302,
+    "Deaths": 433
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 1799,

--- a/internal/adapters/playerprovider/testdata/expected_players/ares_2023_01_30.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/ares_2023_01_30.json
@@ -54,6 +54,18 @@
     "Kills": 0,
     "Deaths": 0
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 0,
+    "Wins": 0,
+    "Losses": 0,
+    "BedsBroken": 0,
+    "BedsLost": 0,
+    "FinalKills": 0,
+    "FinalDeaths": 0,
+    "Kills": 0,
+    "Deaths": 0
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 0,

--- a/internal/adapters/playerprovider/testdata/expected_players/baller_NY_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/baller_NY_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 2696,
     "Deaths": 5195
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 97,
+    "Wins": 90,
+    "Losses": 7,
+    "BedsBroken": 28,
+    "BedsLost": 10,
+    "FinalKills": 98,
+    "FinalDeaths": 8,
+    "Kills": 148,
+    "Deaths": 203
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 8142,

--- a/internal/adapters/playerprovider/testdata/expected_players/bigboicarrot_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/bigboicarrot_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 405,
     "Deaths": 680
   },
+  "Fourv4": {
+    "Winstreak": 8,
+    "GamesPlayed": 132,
+    "Wins": 67,
+    "Losses": 61,
+    "BedsBroken": 27,
+    "BedsLost": 58,
+    "FinalKills": 64,
+    "FinalDeaths": 61,
+    "Kills": 381,
+    "Deaths": 524
+  },
   "Overall": {
     "Winstreak": 1,
     "GamesPlayed": 1173,

--- a/internal/adapters/playerprovider/testdata/expected_players/blazing_lord_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/blazing_lord_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 20800,
     "Deaths": 37985
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 2095,
+    "Wins": 2036,
+    "Losses": 44,
+    "BedsBroken": 636,
+    "BedsLost": 74,
+    "FinalKills": 2060,
+    "FinalDeaths": 45,
+    "Kills": 1076,
+    "Deaths": 1649
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 38305,

--- a/internal/adapters/playerprovider/testdata/expected_players/bulizhnik3012_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/bulizhnik3012_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 85,
     "Deaths": 82
   },
+  "Fourv4": {
+    "Winstreak": 1,
+    "GamesPlayed": 7,
+    "Wins": 3,
+    "Losses": 4,
+    "BedsBroken": 0,
+    "BedsLost": 4,
+    "FinalKills": 0,
+    "FinalDeaths": 4,
+    "Kills": 11,
+    "Deaths": 11
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 228,

--- a/internal/adapters/playerprovider/testdata/expected_players/calceta_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/calceta_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 18467,
     "Deaths": 23814
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 45,
+    "Wins": 42,
+    "Losses": 2,
+    "BedsBroken": 13,
+    "BedsLost": 2,
+    "FinalKills": 28,
+    "FinalDeaths": 3,
+    "Kills": 39,
+    "Deaths": 55
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 16296,

--- a/internal/adapters/playerprovider/testdata/expected_players/cocoasann_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/cocoasann_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 36666,
     "Deaths": 49589
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 7665,
+    "Wins": 7625,
+    "Losses": 23,
+    "BedsBroken": 2016,
+    "BedsLost": 46,
+    "FinalKills": 7300,
+    "FinalDeaths": 21,
+    "Kills": 3882,
+    "Deaths": 5661
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 44981,

--- a/internal/adapters/playerprovider/testdata/expected_players/comfywick_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/comfywick_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 5989,
     "Deaths": 8697
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 89,
+    "Wins": 72,
+    "Losses": 16,
+    "BedsBroken": 27,
+    "BedsLost": 16,
+    "FinalKills": 81,
+    "FinalDeaths": 15,
+    "Kills": 117,
+    "Deaths": 173
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 8942,

--- a/internal/adapters/playerprovider/testdata/expected_players/dd7124b051074c9fb40a62475cace943_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/dd7124b051074c9fb40a62475cace943_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 0,
     "Deaths": 0
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 0,
+    "Wins": 0,
+    "Losses": 0,
+    "BedsBroken": 0,
+    "BedsLost": 0,
+    "FinalKills": 0,
+    "FinalDeaths": 0,
+    "Kills": 0,
+    "Deaths": 0
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 0,

--- a/internal/adapters/playerprovider/testdata/expected_players/dsbmlover_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/dsbmlover_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 3108,
     "Deaths": 3586
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 694,
+    "Wins": 396,
+    "Losses": 278,
+    "BedsBroken": 162,
+    "BedsLost": 287,
+    "FinalKills": 505,
+    "FinalDeaths": 274,
+    "Kills": 2118,
+    "Deaths": 1635
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 3341,

--- a/internal/adapters/playerprovider/testdata/expected_players/egg4999953332egg_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/egg4999953332egg_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 7932,
     "Deaths": 9406
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 112,
+    "Wins": 111,
+    "Losses": 0,
+    "BedsBroken": 22,
+    "BedsLost": 0,
+    "FinalKills": 115,
+    "FinalDeaths": 0,
+    "Kills": 50,
+    "Deaths": 112
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 38759,

--- a/internal/adapters/playerprovider/testdata/expected_players/eggyu_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/eggyu_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 3817,
     "Deaths": 8101
   },
+  "Fourv4": {
+    "Winstreak": 5,
+    "GamesPlayed": 211,
+    "Wins": 151,
+    "Losses": 58,
+    "BedsBroken": 40,
+    "BedsLost": 63,
+    "FinalKills": 87,
+    "FinalDeaths": 59,
+    "Kills": 295,
+    "Deaths": 601
+  },
   "Overall": {
     "Winstreak": 2,
     "GamesPlayed": 5420,

--- a/internal/adapters/playerprovider/testdata/expected_players/f69ba2c027c8472ab9514a9e6795c64f_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/f69ba2c027c8472ab9514a9e6795c64f_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 140,
     "Deaths": 329
   },
+  "Fourv4": {
+    "Winstreak": 0,
+    "GamesPlayed": 212,
+    "Wins": 86,
+    "Losses": 125,
+    "BedsBroken": 36,
+    "BedsLost": 117,
+    "FinalKills": 82,
+    "FinalDeaths": 130,
+    "Kills": 264,
+    "Deaths": 637
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 1435,

--- a/internal/adapters/playerprovider/testdata/expected_players/fart_da_ass_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/fart_da_ass_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 1511,
     "Deaths": 1318
   },
+  "Fourv4": {
+    "Winstreak": 3,
+    "GamesPlayed": 14,
+    "Wins": 9,
+    "Losses": 5,
+    "BedsBroken": 4,
+    "BedsLost": 7,
+    "FinalKills": 15,
+    "FinalDeaths": 5,
+    "Kills": 33,
+    "Deaths": 33
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 1053,

--- a/internal/adapters/playerprovider/testdata/expected_players/fortnitebob2013_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/fortnitebob2013_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 0,
     "Deaths": 0
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 0,
+    "Wins": 0,
+    "Losses": 0,
+    "BedsBroken": 0,
+    "BedsLost": 0,
+    "FinalKills": 0,
+    "FinalDeaths": 0,
+    "Kills": 0,
+    "Deaths": 0
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 3,

--- a/internal/adapters/playerprovider/testdata/expected_players/gamerboy80_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/gamerboy80_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 14093,
     "Deaths": 21087
   },
+  "Fourv4": {
+    "Winstreak": 3,
+    "GamesPlayed": 42,
+    "Wins": 35,
+    "Losses": 7,
+    "BedsBroken": 23,
+    "BedsLost": 9,
+    "FinalKills": 55,
+    "FinalDeaths": 7,
+    "Kills": 82,
+    "Deaths": 85
+  },
   "Overall": {
     "Winstreak": 1,
     "GamesPlayed": 28731,

--- a/internal/adapters/playerprovider/testdata/expected_players/hotmami_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/hotmami_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 2371,
     "Deaths": 4565
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 129,
+    "Wins": 129,
+    "Losses": 0,
+    "BedsBroken": 28,
+    "BedsLost": 1,
+    "FinalKills": 102,
+    "FinalDeaths": 0,
+    "Kills": 68,
+    "Deaths": 133
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 3520,

--- a/internal/adapters/playerprovider/testdata/expected_players/hubbabubba3_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/hubbabubba3_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 404,
     "Deaths": 490
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 153,
+    "Wins": 138,
+    "Losses": 15,
+    "BedsBroken": 83,
+    "BedsLost": 18,
+    "FinalKills": 260,
+    "FinalDeaths": 16,
+    "Kills": 320,
+    "Deaths": 274
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 604,

--- a/internal/adapters/playerprovider/testdata/expected_players/hypixel_2024_02_03.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/hypixel_2024_02_03.json
@@ -54,6 +54,18 @@
     "Kills": 0,
     "Deaths": 1
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 0,
+    "Wins": 0,
+    "Losses": 0,
+    "BedsBroken": 0,
+    "BedsLost": 0,
+    "FinalKills": 0,
+    "FinalDeaths": 0,
+    "Kills": 0,
+    "Deaths": 0
+  },
   "Overall": {
     "Winstreak": 2,
     "GamesPlayed": 3,

--- a/internal/adapters/playerprovider/testdata/expected_players/iCiara_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/iCiara_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 4085,
     "Deaths": 10725
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 11,
+    "Wins": 6,
+    "Losses": 5,
+    "BedsBroken": 2,
+    "BedsLost": 5,
+    "FinalKills": 4,
+    "FinalDeaths": 6,
+    "Kills": 10,
+    "Deaths": 19
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 6301,

--- a/internal/adapters/playerprovider/testdata/expected_players/iElephant_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/iElephant_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 42113,
     "Deaths": 72205
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 4115,
+    "Wins": 4048,
+    "Losses": 30,
+    "BedsBroken": 866,
+    "BedsLost": 61,
+    "FinalKills": 3557,
+    "FinalDeaths": 32,
+    "Kills": 2091,
+    "Deaths": 3970
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 40762,

--- a/internal/adapters/playerprovider/testdata/expected_players/iFrqnk__2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/iFrqnk__2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 2707,
     "Deaths": 2864
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 0,
+    "Wins": 0,
+    "Losses": 0,
+    "BedsBroken": 0,
+    "BedsLost": 0,
+    "FinalKills": 0,
+    "FinalDeaths": 0,
+    "Kills": 0,
+    "Deaths": 0
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 2259,

--- a/internal/adapters/playerprovider/testdata/expected_players/insecuregf_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/insecuregf_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 766,
     "Deaths": 1084
   },
+  "Fourv4": {
+    "Winstreak": 5,
+    "GamesPlayed": 46,
+    "Wins": 42,
+    "Losses": 4,
+    "BedsBroken": 10,
+    "BedsLost": 0,
+    "FinalKills": 16,
+    "FinalDeaths": 5,
+    "Kills": 9,
+    "Deaths": 22
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 1464,

--- a/internal/adapters/playerprovider/testdata/expected_players/ipwningnoobs_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/ipwningnoobs_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 47,
     "Deaths": 84
   },
+  "Fourv4": {
+    "Winstreak": 0,
+    "GamesPlayed": 54,
+    "Wins": 24,
+    "Losses": 30,
+    "BedsBroken": 13,
+    "BedsLost": 30,
+    "FinalKills": 48,
+    "FinalDeaths": 30,
+    "Kills": 240,
+    "Deaths": 212
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 1131,

--- a/internal/adapters/playerprovider/testdata/expected_players/j0kic_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/j0kic_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 198,
     "Deaths": 313
   },
+  "Fourv4": {
+    "Winstreak": 14,
+    "GamesPlayed": 279,
+    "Wins": 193,
+    "Losses": 86,
+    "BedsBroken": 81,
+    "BedsLost": 94,
+    "FinalKills": 265,
+    "FinalDeaths": 86,
+    "Kills": 721,
+    "Deaths": 759
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 1734,

--- a/internal/adapters/playerprovider/testdata/expected_players/jfaf_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/jfaf_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 97,
     "Deaths": 156
   },
+  "Fourv4": {
+    "Winstreak": 0,
+    "GamesPlayed": 32,
+    "Wins": 24,
+    "Losses": 8,
+    "BedsBroken": 3,
+    "BedsLost": 7,
+    "FinalKills": 18,
+    "FinalDeaths": 7,
+    "Kills": 70,
+    "Deaths": 86
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 1722,

--- a/internal/adapters/playerprovider/testdata/expected_players/jmcomic__2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/jmcomic__2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 37,
     "Deaths": 58
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 0,
+    "Wins": 0,
+    "Losses": 0,
+    "BedsBroken": 0,
+    "BedsLost": 0,
+    "FinalKills": 0,
+    "FinalDeaths": 0,
+    "Kills": 0,
+    "Deaths": 0
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 21,

--- a/internal/adapters/playerprovider/testdata/expected_players/jonzus_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/jonzus_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 163,
     "Deaths": 148
   },
+  "Fourv4": {
+    "Winstreak": 1,
+    "GamesPlayed": 28,
+    "Wins": 12,
+    "Losses": 15,
+    "BedsBroken": 2,
+    "BedsLost": 12,
+    "FinalKills": 16,
+    "FinalDeaths": 13,
+    "Kills": 45,
+    "Deaths": 50
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 468,

--- a/internal/adapters/playerprovider/testdata/expected_players/kippi_games_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/kippi_games_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 324,
     "Deaths": 1328
   },
+  "Fourv4": {
+    "Winstreak": 1,
+    "GamesPlayed": 298,
+    "Wins": 100,
+    "Losses": 195,
+    "BedsBroken": 11,
+    "BedsLost": 185,
+    "FinalKills": 52,
+    "FinalDeaths": 204,
+    "Kills": 357,
+    "Deaths": 936
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 1762,

--- a/internal/adapters/playerprovider/testdata/expected_players/kittycatopmine_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/kittycatopmine_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 22035,
     "Deaths": 32981
   },
+  "Fourv4": {
+    "Winstreak": 27,
+    "GamesPlayed": 7131,
+    "Wins": 6943,
+    "Losses": 62,
+    "BedsBroken": 1637,
+    "BedsLost": 142,
+    "FinalKills": 5100,
+    "FinalDeaths": 67,
+    "Kills": 3771,
+    "Deaths": 5664
+  },
   "Overall": {
     "Winstreak": 14,
     "GamesPlayed": 49136,

--- a/internal/adapters/playerprovider/testdata/expected_players/kittycatzenshi_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/kittycatzenshi_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 27338,
     "Deaths": 28980
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 33,
+    "Wins": 31,
+    "Losses": 2,
+    "BedsBroken": 10,
+    "BedsLost": 2,
+    "FinalKills": 25,
+    "FinalDeaths": 2,
+    "Kills": 62,
+    "Deaths": 39
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 36789,

--- a/internal/adapters/playerprovider/testdata/expected_players/kkbwf123_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/kkbwf123_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 294,
     "Deaths": 429
   },
+  "Fourv4": {
+    "Winstreak": 1,
+    "GamesPlayed": 1,
+    "Wins": 1,
+    "Losses": 0,
+    "BedsBroken": 0,
+    "BedsLost": 0,
+    "FinalKills": 3,
+    "FinalDeaths": 0,
+    "Kills": 0,
+    "Deaths": 1
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 133,

--- a/internal/adapters/playerprovider/testdata/expected_players/l_PoopJuice_l_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/l_PoopJuice_l_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 347,
     "Deaths": 458
   },
+  "Fourv4": {
+    "Winstreak": 6,
+    "GamesPlayed": 91,
+    "Wins": 36,
+    "Losses": 55,
+    "BedsBroken": 0,
+    "BedsLost": 57,
+    "FinalKills": 7,
+    "FinalDeaths": 59,
+    "Kills": 177,
+    "Deaths": 141
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 611,

--- a/internal/adapters/playerprovider/testdata/expected_players/learnsomemoney_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/learnsomemoney_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 17,
     "Deaths": 12
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 0,
+    "Wins": 0,
+    "Losses": 0,
+    "BedsBroken": 0,
+    "BedsLost": 0,
+    "FinalKills": 0,
+    "FinalDeaths": 0,
+    "Kills": 0,
+    "Deaths": 0
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 5,

--- a/internal/adapters/playerprovider/testdata/expected_players/mineplayz2020_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/mineplayz2020_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 1703,
     "Deaths": 3837
   },
+  "Fourv4": {
+    "Winstreak": 0,
+    "GamesPlayed": 640,
+    "Wins": 324,
+    "Losses": 307,
+    "BedsBroken": 91,
+    "BedsLost": 297,
+    "FinalKills": 298,
+    "FinalDeaths": 303,
+    "Kills": 965,
+    "Deaths": 2075
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 5059,

--- a/internal/adapters/playerprovider/testdata/expected_players/naxsps17_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/naxsps17_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 2354,
     "Deaths": 5980
   },
+  "Fourv4": {
+    "Winstreak": 0,
+    "GamesPlayed": 1080,
+    "Wins": 455,
+    "Losses": 618,
+    "BedsBroken": 117,
+    "BedsLost": 637,
+    "FinalKills": 322,
+    "FinalDeaths": 651,
+    "Kills": 1223,
+    "Deaths": 3470
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 4031,

--- a/internal/adapters/playerprovider/testdata/expected_players/nobmo_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/nobmo_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 37855,
     "Deaths": 60961
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 2840,
+    "Wins": 2700,
+    "Losses": 73,
+    "BedsBroken": 826,
+    "BedsLost": 142,
+    "FinalKills": 2207,
+    "FinalDeaths": 88,
+    "Kills": 2011,
+    "Deaths": 3428
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 55836,

--- a/internal/adapters/playerprovider/testdata/expected_players/noneleft_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/noneleft_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 16745,
     "Deaths": 31484
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 12,
+    "Wins": 3,
+    "Losses": 8,
+    "BedsBroken": 1,
+    "BedsLost": 7,
+    "FinalKills": 0,
+    "FinalDeaths": 7,
+    "Kills": 17,
+    "Deaths": 12
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 34672,

--- a/internal/adapters/playerprovider/testdata/expected_players/oCheddar_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/oCheddar_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 169,
     "Deaths": 218
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 13,
+    "Wins": 12,
+    "Losses": 1,
+    "BedsBroken": 6,
+    "BedsLost": 2,
+    "FinalKills": 21,
+    "FinalDeaths": 1,
+    "Kills": 37,
+    "Deaths": 33
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 407,

--- a/internal/adapters/playerprovider/testdata/expected_players/oFlab_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/oFlab_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 203,
     "Deaths": 215
   },
+  "Fourv4": {
+    "Winstreak": 0,
+    "GamesPlayed": 12,
+    "Wins": 11,
+    "Losses": 1,
+    "BedsBroken": 4,
+    "BedsLost": 1,
+    "FinalKills": 11,
+    "FinalDeaths": 1,
+    "Kills": 9,
+    "Deaths": 27
+  },
   "Overall": {
     "Winstreak": 1,
     "GamesPlayed": 150,

--- a/internal/adapters/playerprovider/testdata/expected_players/ohDevil_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/ohDevil_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 10712,
     "Deaths": 19197
   },
+  "Fourv4": {
+    "Winstreak": 38,
+    "GamesPlayed": 568,
+    "Wins": 547,
+    "Losses": 15,
+    "BedsBroken": 170,
+    "BedsLost": 28,
+    "FinalKills": 458,
+    "FinalDeaths": 16,
+    "Kills": 473,
+    "Deaths": 696
+  },
   "Overall": {
     "Winstreak": 1047,
     "GamesPlayed": 40770,

--- a/internal/adapters/playerprovider/testdata/expected_players/poopoosnake75_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/poopoosnake75_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 53671,
     "Deaths": 69155
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 578,
+    "Wins": 467,
+    "Losses": 93,
+    "BedsBroken": 215,
+    "BedsLost": 125,
+    "FinalKills": 621,
+    "FinalDeaths": 98,
+    "Kills": 1050,
+    "Deaths": 1170
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 37174,

--- a/internal/adapters/playerprovider/testdata/expected_players/prvx_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/prvx_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 54,
     "Deaths": 66
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 0,
+    "Wins": 0,
+    "Losses": 0,
+    "BedsBroken": 0,
+    "BedsLost": 0,
+    "FinalKills": 0,
+    "FinalDeaths": 0,
+    "Kills": 0,
+    "Deaths": 0
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 955,

--- a/internal/adapters/playerprovider/testdata/expected_players/rvdes_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/rvdes_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 38409,
     "Deaths": 42367
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 603,
+    "Wins": 566,
+    "Losses": 22,
+    "BedsBroken": 124,
+    "BedsLost": 45,
+    "FinalKills": 505,
+    "FinalDeaths": 26,
+    "Kills": 569,
+    "Deaths": 732
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 31086,

--- a/internal/adapters/playerprovider/testdata/expected_players/scazzey_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/scazzey_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 0,
     "Deaths": 0
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 0,
+    "Wins": 0,
+    "Losses": 0,
+    "BedsBroken": 0,
+    "BedsLost": 0,
+    "FinalKills": 0,
+    "FinalDeaths": 0,
+    "Kills": 0,
+    "Deaths": 0
+  },
   "Overall": {
     "Winstreak": 2,
     "GamesPlayed": 23,

--- a/internal/adapters/playerprovider/testdata/expected_players/schmorr84_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/schmorr84_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 6,
     "Deaths": 33
   },
+  "Fourv4": {
+    "Winstreak": 1,
+    "GamesPlayed": 113,
+    "Wins": 56,
+    "Losses": 55,
+    "BedsBroken": 6,
+    "BedsLost": 55,
+    "FinalKills": 23,
+    "FinalDeaths": 57,
+    "Kills": 110,
+    "Deaths": 291
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 1146,

--- a/internal/adapters/playerprovider/testdata/expected_players/seeecret_2023_05_14.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/seeecret_2023_05_14.json
@@ -54,6 +54,18 @@
     "Kills": 2697,
     "Deaths": 2359
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 0,
+    "Wins": 0,
+    "Losses": 0,
+    "BedsBroken": 0,
+    "BedsLost": 0,
+    "FinalKills": 0,
+    "FinalDeaths": 0,
+    "Kills": 0,
+    "Deaths": 0
+  },
   "Overall": {
     "Winstreak": 3238,
     "GamesPlayed": 3237,

--- a/internal/adapters/playerprovider/testdata/expected_players/slimy55_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/slimy55_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 438,
     "Deaths": 765
   },
+  "Fourv4": {
+    "Winstreak": 1,
+    "GamesPlayed": 2,
+    "Wins": 1,
+    "Losses": 1,
+    "BedsBroken": 0,
+    "BedsLost": 0,
+    "FinalKills": 0,
+    "FinalDeaths": 0,
+    "Kills": 1,
+    "Deaths": 5
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 2069,

--- a/internal/adapters/playerprovider/testdata/expected_players/stephen0726_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/stephen0726_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 263,
     "Deaths": 888
   },
+  "Fourv4": {
+    "Winstreak": 0,
+    "GamesPlayed": 552,
+    "Wins": 184,
+    "Losses": 360,
+    "BedsBroken": 11,
+    "BedsLost": 318,
+    "FinalKills": 88,
+    "FinalDeaths": 367,
+    "Kills": 753,
+    "Deaths": 1754
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 1152,

--- a/internal/adapters/playerprovider/testdata/expected_players/technoblade_2022_06_10.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/technoblade_2022_06_10.json
@@ -54,6 +54,18 @@
     "Kills": 3489,
     "Deaths": 4483
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 11,
+    "Wins": 10,
+    "Losses": 1,
+    "BedsBroken": 5,
+    "BedsLost": 1,
+    "FinalKills": 10,
+    "FinalDeaths": 1,
+    "Kills": 15,
+    "Deaths": 14
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 5184,

--- a/internal/adapters/playerprovider/testdata/expected_players/tiltings_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/tiltings_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 25005,
     "Deaths": 32819
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 1152,
+    "Wins": 1102,
+    "Losses": 34,
+    "BedsBroken": 312,
+    "BedsLost": 62,
+    "FinalKills": 1073,
+    "FinalDeaths": 39,
+    "Kills": 1112,
+    "Deaths": 1929
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 48513,

--- a/internal/adapters/playerprovider/testdata/expected_players/tiltingsson_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/tiltingsson_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 15663,
     "Deaths": 17373
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 2655,
+    "Wins": 2624,
+    "Losses": 18,
+    "BedsBroken": 857,
+    "BedsLost": 31,
+    "FinalKills": 2781,
+    "FinalDeaths": 18,
+    "Kills": 1666,
+    "Deaths": 1974
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 45665,

--- a/internal/adapters/playerprovider/testdata/expected_players/tqrm_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/tqrm_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 9830,
     "Deaths": 11635
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 1122,
+    "Wins": 1081,
+    "Losses": 21,
+    "BedsBroken": 308,
+    "BedsLost": 34,
+    "FinalKills": 1054,
+    "FinalDeaths": 21,
+    "Kills": 591,
+    "Deaths": 1076
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 44912,

--- a/internal/adapters/playerprovider/testdata/expected_players/undefiedd_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/undefiedd_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 4635,
     "Deaths": 5873
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 41,
+    "Wins": 37,
+    "Losses": 3,
+    "BedsBroken": 19,
+    "BedsLost": 4,
+    "FinalKills": 52,
+    "FinalDeaths": 3,
+    "Kills": 70,
+    "Deaths": 97
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 7329,

--- a/internal/adapters/playerprovider/testdata/expected_players/wact_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/wact_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 12023,
     "Deaths": 17803
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 1236,
+    "Wins": 1205,
+    "Losses": 4,
+    "BedsBroken": 381,
+    "BedsLost": 8,
+    "FinalKills": 1437,
+    "FinalDeaths": 4,
+    "Kills": 938,
+    "Deaths": 896
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 41629,

--- a/internal/adapters/playerprovider/testdata/expected_players/xLectroLiqhtnin_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/xLectroLiqhtnin_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 45290,
     "Deaths": 117853
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 54,
+    "Wins": 51,
+    "Losses": 2,
+    "BedsBroken": 28,
+    "BedsLost": 3,
+    "FinalKills": 44,
+    "FinalDeaths": 2,
+    "Kills": 36,
+    "Deaths": 70
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 48307,

--- a/internal/adapters/playerprovider/testdata/expected_players/xxzz_GUTS_xxzz_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/xxzz_GUTS_xxzz_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 0,
     "Deaths": 0
   },
+  "Fourv4": {
+    "Winstreak": null,
+    "GamesPlayed": 0,
+    "Wins": 0,
+    "Losses": 0,
+    "BedsBroken": 0,
+    "BedsLost": 0,
+    "FinalKills": 0,
+    "FinalDeaths": 0,
+    "Kills": 0,
+    "Deaths": 0
+  },
   "Overall": {
     "Winstreak": null,
     "GamesPlayed": 0,

--- a/internal/adapters/playerprovider/testdata/expected_players/yippeyay_2024_02_25.json
+++ b/internal/adapters/playerprovider/testdata/expected_players/yippeyay_2024_02_25.json
@@ -54,6 +54,18 @@
     "Kills": 2222,
     "Deaths": 3469
   },
+  "Fourv4": {
+    "Winstreak": 0,
+    "GamesPlayed": 1811,
+    "Wins": 1118,
+    "Losses": 682,
+    "BedsBroken": 452,
+    "BedsLost": 681,
+    "FinalKills": 1356,
+    "FinalDeaths": 691,
+    "Kills": 2855,
+    "Deaths": 4356
+  },
   "Overall": {
     "Winstreak": 0,
     "GamesPlayed": 6325,

--- a/internal/adapters/playerrepository/repository.go
+++ b/internal/adapters/playerrepository/repository.go
@@ -22,7 +22,7 @@ import (
 	"github.com/Amund211/flashlight/internal/strutils"
 )
 
-const dataFormatVersion = 1
+const dataFormatVersion = 2
 
 type PostgresPlayerRepository struct {
 	db     *sqlx.DB
@@ -47,6 +47,7 @@ type playerDataStorage struct {
 	Doubles    statsDataStorage `json:"2"`
 	Threes     statsDataStorage `json:"3"`
 	Fours      statsDataStorage `json:"4"`
+	Fourv4     statsDataStorage `json:"4v4"`
 	Overall    statsDataStorage `json:"all"`
 }
 
@@ -102,6 +103,7 @@ func playerToDataStorage(player *domain.PlayerPIT) ([]byte, error) {
 		Doubles:    gamemodeStatsToDataStorage(&player.Doubles),
 		Threes:     gamemodeStatsToDataStorage(&player.Threes),
 		Fours:      gamemodeStatsToDataStorage(&player.Fours),
+		Fourv4:     gamemodeStatsToDataStorage(&player.Fourv4),
 		Overall:    gamemodeStatsToDataStorage(&player.Overall),
 	}
 
@@ -156,6 +158,7 @@ func dbStatToPlayerPIT(dbStat dbStat) (*domain.PlayerPIT, error) {
 		Doubles:    *gamemodeStatsPITFromDataStorage(&playerData.Doubles),
 		Threes:     *gamemodeStatsPITFromDataStorage(&playerData.Threes),
 		Fours:      *gamemodeStatsPITFromDataStorage(&playerData.Fours),
+		Fourv4:     *gamemodeStatsPITFromDataStorage(&playerData.Fourv4),
 		Overall:    *gamemodeStatsPITFromDataStorage(&playerData.Overall),
 	}, nil
 }

--- a/internal/adapters/playerrepository/repository_test.go
+++ b/internal/adapters/playerrepository/repository_test.go
@@ -496,6 +496,18 @@ func TestPostgresPlayerRepository(t *testing.T) {
 					Kills:       308,
 					Deaths:      309,
 				},
+				Fourv4: domain.GamemodeStatsPIT{
+					Winstreak:   new(350),
+					GamesPlayed: 351,
+					Wins:        352,
+					Losses:      353,
+					BedsBroken:  354,
+					BedsLost:    355,
+					FinalKills:  356,
+					FinalDeaths: 357,
+					Kills:       358,
+					Deaths:      359,
+				},
 				Overall: domain.GamemodeStatsPIT{
 					Winstreak:   nil,
 					GamesPlayed: 401,
@@ -525,6 +537,7 @@ func TestPostgresPlayerRepository(t *testing.T) {
 			domaintest.RequireEqualStats(t, player.Doubles, result.Doubles)
 			domaintest.RequireEqualStats(t, player.Threes, result.Threes)
 			domaintest.RequireEqualStats(t, player.Fours, result.Fours)
+			domaintest.RequireEqualStats(t, player.Fourv4, result.Fourv4)
 			domaintest.RequireEqualStats(t, player.Overall, result.Overall)
 
 			// Not stored to postgres

--- a/internal/domain/player.go
+++ b/internal/domain/player.go
@@ -23,6 +23,7 @@ type PlayerPIT struct {
 	Doubles    GamemodeStatsPIT
 	Threes     GamemodeStatsPIT
 	Fours      GamemodeStatsPIT
+	Fourv4     GamemodeStatsPIT
 	Overall    GamemodeStatsPIT
 }
 


### PR DESCRIPTION
## Why

The Hypixel API's overall bedwars stats are the sum of solo, doubles, threes, fours **and 4v4** (internal name `two_four`). We only persisted the first four modes, so 4v4 activity was silently dropped from stored history and can't be recovered later. This starts capturing it so the data is there going forward.

## What

- Add `Fourv4` to the domain `PlayerPIT`.
- Parse the `two_four_*` fields in the Hypixel API adapter.
- Write it to the player repository (new `"4v4"` key in the stored JSON blob).
- Bump the stored data format version `1 -> 2`.

Nothing reads 4v4 yet — the prism-style API response is unchanged (the `expected_hypixel_style_responses` fixtures did not change; only `expected_players` gained the new block).

## Tests (red-green TDD)

- Adapter: new `hypixel_response_test` case asserting `two_four_*` → `PlayerPIT.Fourv4`, plus all 171 regenerated fixture expectations.
- Repository: extended the `GetPlayerPITs` round-trip test to store and read back `Fourv4`.
