### PR TITLE
docs: note that winstreak presence varies per gamemode

### DIFF
--- a/internal/domain/player.go
+++ b/internal/domain/player.go
@@ -28,6 +28,10 @@ type PlayerPIT struct {
 }
 
 type GamemodeStatsPIT struct {
+	// Winstreak is nil when hidden via Hypixel API settings. Usually all
+	// gamemodes are set or all nil, but they vary independently: a gamemode
+	// can be nil while others are set, and Overall can be nil while individual
+	// gamemodes are set. Do not assume presence is consistent across gamemodes.
 	Winstreak   *int
 	GamesPlayed int
 	Wins        int

--- a/internal/domaintest/player.go
+++ b/internal/domaintest/player.go
@@ -87,6 +87,10 @@ func (pb *playerBuilder) Build(queriedAt time.Time) domain.PlayerPIT {
 		// Winstreak API enablement is all or nothing.
 		// If one gamemode had a winstreak, but another didn't, that gamemode
 		// actually had winstreak 0.
+		//
+		// NOTE: This isn't strictly true of Hypixel/the DB — a gamemode winstreak
+		// can be missing while others are set, and overall can be missing while
+		// individual gamemodes are set. This builder only models all-or-nothing.
 		if player.Solo.Winstreak == nil {
 			player.Solo.Winstreak = new(0)
 		}


### PR DESCRIPTION
Documents that a gamemode's winstreak can be `nil` independently of the other gamemodes — on the domain type (`GamemodeStatsPIT.Winstreak`, the source of truth) and next to the all-or-nothing simplification in the test player builder.

### Why

Looking at winstreak presence across gamemodes in Hypixel responses / the DB:

- **~60%** of players have all winstreaks set, **~14%** have none — so it's *usually* all-or-nothing.
- The remaining **~26%** are mixed: individual gamemode winstreaks can be missing while others are set.

Our theory for the mixed cases: **0 games played in a gamemode yields a missing winstreak for that gamemode, even when the winstreak API is enabled.**

There are also cases where individual gamemode winstreaks are set but the **overall** winstreak is missing, which doesn't obviously make sense and isn't explained by the theory above.

Comment-only change; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
