### PR TITLE
collector: rename deprecated resourcedetection alias

### DIFF
--- a/collector/config.yaml
+++ b/collector/config.yaml
@@ -20,7 +20,7 @@ processors:
     spike_limit_percentage: 20
 
   # automatically detect Cloud Run resource metadata
-  resourcedetection:
+  resource_detection:
     detectors: [env, gcp]
     timeout: 2s
     override: false
@@ -49,9 +49,9 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch, memory_limiter, resourcedetection, resource]
+      processors: [batch, memory_limiter, resource_detection, resource]
       exporters: [googlecloud]
     metrics:
       receivers: [otlp]
-      processors: [batch, memory_limiter, resourcedetection, resource]
+      processors: [batch, memory_limiter, resource_detection, resource]
       exporters: [googlemanagedprometheus]


### PR DESCRIPTION
## What
Rename the OTel Collector component-type alias `resourcedetection` → `resource_detection` in the collector config.

## Why
Collector v0.153/v0.154 deprecated the concatenated name `resourcedetection` in favour of `resource_detection`, part of the [lower_snake_case naming initiative](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45339). We recently bumped the collector image to v0.154.0, so the old alias now logs deprecation warnings. It still parses and no removal date is announced — purely cosmetic, no behaviour change.

## Changes
- `collector/config.yaml`: `resourcedetection` → `resource_detection` (processor definition + both pipelines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)