### PR TITLE
Full 4v4 (two_four) gamemode support

### DIFF
--- a/internal/app/session_at.go
+++ b/internal/app/session_at.go
@@ -196,6 +196,10 @@ func buildGameSegment(ctx context.Context, prev, curr domain.PlayerPIT) GameSegm
 		gamemode = domain.GamemodeFours
 		prevStats = &prev.Fours
 		currStats = &curr.Fours
+	case gamesPlayedDelta(prev.Fourv4, curr.Fourv4) == 1:
+		gamemode = domain.GamemodeFourv4
+		prevStats = &prev.Fourv4
+		currStats = &curr.Fourv4
 	default:
 		// unreachable
 		reporting.Report(ctx,

--- a/internal/app/session_at_test.go
+++ b/internal/app/session_at_test.go
@@ -839,6 +839,7 @@ func TestBuildGetSessionAt(t *testing.T) {
 			{gamemode: domain.GamemodeDoubles, b: domaintest.NewPlayerBuilder(uuid).FromDB().Doubles()},
 			{gamemode: domain.GamemodeThrees, b: domaintest.NewPlayerBuilder(uuid).FromDB().Threes()},
 			{gamemode: domain.GamemodeFours, b: domaintest.NewPlayerBuilder(uuid).FromDB().Fours()},
+			{gamemode: domain.GamemodeFourv4, b: domaintest.NewPlayerBuilder(uuid).FromDB().Fourv4()},
 		}
 
 		for _, tc := range tests {

--- a/internal/domain/gamemode.go
+++ b/internal/domain/gamemode.go
@@ -11,5 +11,6 @@ const (
 	GamemodeDoubles Gamemode = "doubles"
 	GamemodeThrees  Gamemode = "threes"
 	GamemodeFours   Gamemode = "fours"
+	GamemodeFourv4  Gamemode = "4v4"
 	GamemodeOverall Gamemode = "overall"
 )

--- a/internal/domaintest/player.go
+++ b/internal/domaintest/player.go
@@ -12,9 +12,9 @@ import (
 )
 
 type playerBuilder struct {
-	player                       *domain.PlayerPIT
-	solo, doubles, threes, fours *statsBuilder
-	overallWinstreak             *int
+	player                               *domain.PlayerPIT
+	solo, doubles, threes, fours, fourv4 *statsBuilder
+	overallWinstreak                     *int
 	// Whether the player should get a random db id on Build()
 	fromDB bool
 }
@@ -23,6 +23,7 @@ func (pb *playerBuilder) Solo() *statsBuilder    { return pb.solo }
 func (pb *playerBuilder) Doubles() *statsBuilder { return pb.doubles }
 func (pb *playerBuilder) Threes() *statsBuilder  { return pb.threes }
 func (pb *playerBuilder) Fours() *statsBuilder   { return pb.fours }
+func (pb *playerBuilder) Fourv4() *statsBuilder  { return pb.fourv4 }
 
 func (pb *playerBuilder) WithExperience(exp int64) *playerBuilder {
 	pb.player.Experience = exp
@@ -64,6 +65,7 @@ func (pb *playerBuilder) Build(queriedAt time.Time) domain.PlayerPIT {
 	player.Doubles.Winstreak = clonePtr(player.Doubles.Winstreak)
 	player.Threes.Winstreak = clonePtr(player.Threes.Winstreak)
 	player.Fours.Winstreak = clonePtr(player.Fours.Winstreak)
+	player.Fourv4.Winstreak = clonePtr(player.Fourv4.Winstreak)
 
 	if pb.fromDB {
 		uuidv7, err := uuid.NewV7()
@@ -78,6 +80,7 @@ func (pb *playerBuilder) Build(queriedAt time.Time) domain.PlayerPIT {
 		pb.doubles.stats.Winstreak != nil ||
 		pb.threes.stats.Winstreak != nil ||
 		pb.fours.stats.Winstreak != nil ||
+		pb.fourv4.stats.Winstreak != nil ||
 		pb.overallWinstreak != nil
 
 	minOverallWS := -1
@@ -103,6 +106,9 @@ func (pb *playerBuilder) Build(queriedAt time.Time) domain.PlayerPIT {
 		if player.Fours.Winstreak == nil {
 			player.Fours.Winstreak = new(0)
 		}
+		if player.Fourv4.Winstreak == nil {
+			player.Fourv4.Winstreak = new(0)
+		}
 
 		// Overall winstreak is not uniquely determined by gamemode winstreaks
 		// The set of possible values are
@@ -112,23 +118,25 @@ func (pb *playerBuilder) Build(queriedAt time.Time) domain.PlayerPIT {
 			*player.Doubles.Winstreak,
 			*player.Threes.Winstreak,
 			*player.Fours.Winstreak,
+			*player.Fourv4.Winstreak,
 		)
 
 		maxOverallWS = *player.Solo.Winstreak +
 			*player.Doubles.Winstreak +
 			*player.Threes.Winstreak +
-			*player.Fours.Winstreak
+			*player.Fours.Winstreak +
+			*player.Fourv4.Winstreak
 	}
 
-	player.Overall = computeOverallStats(player.Solo, player.Doubles, player.Threes, player.Fours)
+	player.Overall = computeOverallStats(player.Solo, player.Doubles, player.Threes, player.Fours, player.Fourv4)
 
 	if pb.overallWinstreak != nil {
 		// User set overall winstreak. Validate and set
 		if *pb.overallWinstreak < minOverallWS || *pb.overallWinstreak > maxOverallWS {
 			panic(fmt.Sprintf(
-				"overall winstreak %d outside valid range [%d, %d] for gamemode winstreaks (solo=%d, doubles=%d, threes=%d, fours=%d)",
+				"overall winstreak %d outside valid range [%d, %d] for gamemode winstreaks (solo=%d, doubles=%d, threes=%d, fours=%d, 4v4=%d)",
 				*pb.overallWinstreak, minOverallWS, maxOverallWS,
-				*player.Solo.Winstreak, *player.Doubles.Winstreak, *player.Threes.Winstreak, *player.Fours.Winstreak,
+				*player.Solo.Winstreak, *player.Doubles.Winstreak, *player.Threes.Winstreak, *player.Fours.Winstreak, *player.Fourv4.Winstreak,
 			))
 		}
 
@@ -185,12 +193,13 @@ func NewPlayerBuilder(uuid string) *playerBuilder {
 	pb.doubles = &statsBuilder{playerBuilder: pb, stats: &player.Doubles}
 	pb.threes = &statsBuilder{playerBuilder: pb, stats: &player.Threes}
 	pb.fours = &statsBuilder{playerBuilder: pb, stats: &player.Fours}
+	pb.fourv4 = &statsBuilder{playerBuilder: pb, stats: &player.Fourv4}
 	return pb
 }
 
 // statsBuilder mutates a single gamemode's stats on its parent
 // playerBuilder. It embeds *playerBuilder so player-level methods
-// (Solo/Doubles/Threes/Fours, WithExperience, FromDB, Build, ...) are
+// (Solo/Doubles/Threes/Fours/Fourv4, WithExperience, FromDB, Build, ...) are
 // reachable directly through the stats builder. This makes chains like
 // NewPlayerBuilder(...).Fours().WithGamesPlayed(10).Build(at) work inline.
 type statsBuilder struct {

--- a/internal/ports/prism_converters.go
+++ b/internal/ports/prism_converters.go
@@ -82,6 +82,17 @@ type hypixelAPIBedwarsStats struct {
 	FoursFinalDeaths int  `json:"four_four_final_deaths_bedwars,omitempty"`
 	FoursKills       int  `json:"four_four_kills_bedwars,omitempty"`
 	FoursDeaths      int  `json:"four_four_deaths_bedwars,omitempty"`
+
+	Fourv4Winstreak   *int `json:"two_four_winstreak,omitempty"`
+	Fourv4GamesPlayed int  `json:"two_four_games_played_bedwars,omitempty"`
+	Fourv4Wins        int  `json:"two_four_wins_bedwars,omitempty"`
+	Fourv4Losses      int  `json:"two_four_losses_bedwars,omitempty"`
+	Fourv4BedsBroken  int  `json:"two_four_beds_broken_bedwars,omitempty"`
+	Fourv4BedsLost    int  `json:"two_four_beds_lost_bedwars,omitempty"`
+	Fourv4FinalKills  int  `json:"two_four_final_kills_bedwars,omitempty"`
+	Fourv4FinalDeaths int  `json:"two_four_final_deaths_bedwars,omitempty"`
+	Fourv4Kills       int  `json:"two_four_kills_bedwars,omitempty"`
+	Fourv4Deaths      int  `json:"two_four_deaths_bedwars,omitempty"`
 }
 
 func playerToPrismPlayerDataResponse(player *domain.PlayerPIT) *hypixelAPIResponse {
@@ -159,6 +170,17 @@ func playerToPrismPlayerDataResponse(player *domain.PlayerPIT) *hypixelAPIRespon
 		FoursFinalDeaths: player.Fours.FinalDeaths,
 		FoursKills:       player.Fours.Kills,
 		FoursDeaths:      player.Fours.Deaths,
+
+		Fourv4Winstreak:   player.Fourv4.Winstreak,
+		Fourv4GamesPlayed: player.Fourv4.GamesPlayed,
+		Fourv4Wins:        player.Fourv4.Wins,
+		Fourv4Losses:      player.Fourv4.Losses,
+		Fourv4BedsBroken:  player.Fourv4.BedsBroken,
+		Fourv4BedsLost:    player.Fourv4.BedsLost,
+		Fourv4FinalKills:  player.Fourv4.FinalKills,
+		Fourv4FinalDeaths: player.Fourv4.FinalDeaths,
+		Fourv4Kills:       player.Fourv4.Kills,
+		Fourv4Deaths:      player.Fourv4.Deaths,
 	}
 
 	return &hypixelAPIResponse{

--- a/internal/ports/rainbow_converters.go
+++ b/internal/ports/rainbow_converters.go
@@ -16,6 +16,7 @@ const (
 	rainbowGamemodeDoubles = "doubles"
 	rainbowGamemodeThrees  = "threes"
 	rainbowGamemodeFours   = "fours"
+	rainbowGamemodeFourv4  = "4v4"
 	rainbowGamemodeOverall = "overall"
 )
 
@@ -29,6 +30,8 @@ func gamemodeToRainbowGamemode(g domain.Gamemode) (string, error) {
 		return rainbowGamemodeThrees, nil
 	case domain.GamemodeFours:
 		return rainbowGamemodeFours, nil
+	case domain.GamemodeFourv4:
+		return rainbowGamemodeFourv4, nil
 	case domain.GamemodeOverall:
 		return rainbowGamemodeOverall, nil
 	default:
@@ -79,6 +82,7 @@ type rainbowPlayerDataPIT struct {
 	Doubles    rainbowStatsPIT `json:"doubles"`
 	Threes     rainbowStatsPIT `json:"threes"`
 	Fours      rainbowStatsPIT `json:"fours"`
+	Fourv4     rainbowStatsPIT `json:"4v4"`
 	Overall    rainbowStatsPIT `json:"overall"`
 }
 
@@ -113,6 +117,7 @@ func playerToRainbowPlayerDataPIT(player *domain.PlayerPIT) rainbowPlayerDataPIT
 		Doubles:    gamemodeStatsPITToRainbowStatsPIT(&player.Doubles),
 		Threes:     gamemodeStatsPITToRainbowStatsPIT(&player.Threes),
 		Fours:      gamemodeStatsPITToRainbowStatsPIT(&player.Fours),
+		Fourv4:     gamemodeStatsPITToRainbowStatsPIT(&player.Fourv4),
 		Overall:    gamemodeStatsPITToRainbowStatsPIT(&player.Overall),
 	}
 }

--- a/internal/ports/rainbow_converters_test.go
+++ b/internal/ports/rainbow_converters_test.go
@@ -97,6 +97,18 @@ func TestPlayerToRainbowPlayerPITData(t *testing.T) {
 					Kills:       308,
 					Deaths:      309,
 				},
+				Fourv4: domain.GamemodeStatsPIT{
+					Winstreak:   new(500),
+					GamesPlayed: 501,
+					Wins:        502,
+					Losses:      503,
+					BedsBroken:  504,
+					BedsLost:    505,
+					FinalKills:  506,
+					FinalDeaths: 507,
+					Kills:       508,
+					Deaths:      509,
+				},
 				Overall: domain.GamemodeStatsPIT{
 					Winstreak:   new(400),
 					GamesPlayed: 401,
@@ -163,6 +175,18 @@ func TestPlayerToRainbowPlayerPITData(t *testing.T) {
 					"finalDeaths":  307,
 					"kills":        308,
 					"deaths":       309
+				},
+				"4v4": {
+					"winstreak":    500,
+					"gamesPlayed":  501,
+					"wins":         502,
+					"losses":       503,
+					"bedsBroken":   504,
+					"bedsLost":     505,
+					"finalKills":   506,
+					"finalDeaths":  507,
+					"kills":        508,
+					"deaths":       509
 				},
 				"overall": {
 					"winstreak":    400,
@@ -251,6 +275,18 @@ func TestPlayerToRainbowPlayerPITData(t *testing.T) {
 					"kills":        0,
 					"deaths":       0
 				},
+				"4v4": {
+					"winstreak":    null,
+					"gamesPlayed":  0,
+					"wins":         0,
+					"losses":       0,
+					"bedsBroken":   0,
+					"bedsLost":     0,
+					"finalKills":   0,
+					"finalDeaths":  0,
+					"kills":        0,
+					"deaths":       0
+				},
 				"overall": {
 					"winstreak":    null,
 					"gamesPlayed":  0,
@@ -313,6 +349,18 @@ func TestPlayerToRainbowPlayerPITData(t *testing.T) {
 					"deaths":       0
 				},
 				"fours": {
+					"winstreak":    null,
+					"gamesPlayed":  0,
+					"wins":         0,
+					"losses":       0,
+					"bedsBroken":   0,
+					"bedsLost":     0,
+					"finalKills":   0,
+					"finalDeaths":  0,
+					"kills":        0,
+					"deaths":       0
+				},
+				"4v4": {
 					"winstreak":    null,
 					"gamesPlayed":  0,
 					"wins":         0,
@@ -466,6 +514,18 @@ func TestPlayerToRainbowPlayerPITData(t *testing.T) {
 					"finalDeaths":  307,
 					"kills":        308,
 					"deaths":       309
+				},
+				"4v4": {
+					"winstreak":    null,
+					"gamesPlayed":  0,
+					"wins":         0,
+					"losses":       0,
+					"bedsBroken":   0,
+					"bedsLost":     0,
+					"finalKills":   0,
+					"finalDeaths":  0,
+					"kills":        0,
+					"deaths":       0
 				},
 				"overall": {
 					"winstreak":    null,
@@ -667,6 +727,18 @@ func TestHistoryToRainbowHistoryData(t *testing.T) {
 						"kills":        308,
 						"deaths":       309
 					},
+					"4v4": {
+						"winstreak":    null,
+						"gamesPlayed":  0,
+						"wins":         0,
+						"losses":       0,
+						"bedsBroken":   0,
+						"bedsLost":     0,
+						"finalKills":   0,
+						"finalDeaths":  0,
+						"kills":        0,
+						"deaths":       0
+					},
 					"overall": {
 						"winstreak":    null,
 						"gamesPlayed":  401,
@@ -721,6 +793,18 @@ func TestHistoryToRainbowHistoryData(t *testing.T) {
 						"deaths":       0
 					},
 					"fours": {
+						"winstreak":    null,
+						"gamesPlayed":  0,
+						"wins":         0,
+						"losses":       0,
+						"bedsBroken":   0,
+						"bedsLost":     0,
+						"finalKills":   0,
+						"finalDeaths":  0,
+						"kills":        0,
+						"deaths":       0
+					},
+					"4v4": {
 						"winstreak":    null,
 						"gamesPlayed":  0,
 						"wins":         0,
@@ -937,6 +1021,18 @@ func TestSessionsToRainbowSessionsData(t *testing.T) {
 						"kills":        308,
 						"deaths":       309
 					},
+					"4v4": {
+						"winstreak":    null,
+						"gamesPlayed":  0,
+						"wins":         0,
+						"losses":       0,
+						"bedsBroken":   0,
+						"bedsLost":     0,
+						"finalKills":   0,
+						"finalDeaths":  0,
+						"kills":        0,
+						"deaths":       0
+					},
 					"overall": {
 						"winstreak":    null,
 						"gamesPlayed":  401,
@@ -991,6 +1087,18 @@ func TestSessionsToRainbowSessionsData(t *testing.T) {
 						"deaths":       0
 					},
 					"fours": {
+						"winstreak":    null,
+						"gamesPlayed":  0,
+						"wins":         0,
+						"losses":       0,
+						"bedsBroken":   0,
+						"bedsLost":     0,
+						"finalKills":   0,
+						"finalDeaths":  0,
+						"kills":        0,
+						"deaths":       0
+					},
+					"4v4": {
 						"winstreak":    null,
 						"gamesPlayed":  0,
 						"wins":         0,

--- a/internal/ports/testdata/expected_hypixel_style_responses/175f84462e8a478d90489fa202d75024_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/175f84462e8a478d90489fa202d75024_2024_02_25.json
@@ -52,7 +52,14 @@
         "four_four_final_kills_bedwars": 5,
         "four_four_final_deaths_bedwars": 120,
         "four_four_kills_bedwars": 70,
-        "four_four_deaths_bedwars": 295
+        "four_four_deaths_bedwars": 295,
+        "two_four_winstreak": 0,
+        "two_four_games_played_bedwars": 2,
+        "two_four_wins_bedwars": 1,
+        "two_four_losses_bedwars": 1,
+        "two_four_beds_lost_bedwars": 1,
+        "two_four_final_deaths_bedwars": 1,
+        "two_four_deaths_bedwars": 7
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/1v4_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/1v4_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 2646,
         "four_four_final_deaths_bedwars": 541,
         "four_four_kills_bedwars": 3040,
-        "four_four_deaths_bedwars": 4170
+        "four_four_deaths_bedwars": 4170,
+        "two_four_games_played_bedwars": 132,
+        "two_four_wins_bedwars": 115,
+        "two_four_losses_bedwars": 11,
+        "two_four_beds_broken_bedwars": 36,
+        "two_four_beds_lost_bedwars": 17,
+        "two_four_final_kills_bedwars": 119,
+        "two_four_final_deaths_bedwars": 14,
+        "two_four_kills_bedwars": 113,
+        "two_four_deaths_bedwars": 184
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/ActuallyRacist_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/ActuallyRacist_2024_02_25.json
@@ -56,7 +56,16 @@
         "four_four_final_kills_bedwars": 1,
         "four_four_final_deaths_bedwars": 7,
         "four_four_kills_bedwars": 18,
-        "four_four_deaths_bedwars": 18
+        "four_four_deaths_bedwars": 18,
+        "two_four_winstreak": 3,
+        "two_four_games_played_bedwars": 5,
+        "two_four_wins_bedwars": 4,
+        "two_four_losses_bedwars": 1,
+        "two_four_beds_lost_bedwars": 1,
+        "two_four_final_kills_bedwars": 3,
+        "two_four_final_deaths_bedwars": 1,
+        "two_four_kills_bedwars": 1,
+        "two_four_deaths_bedwars": 5
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Andorite_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Andorite_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 46615,
         "four_four_final_deaths_bedwars": 2144,
         "four_four_kills_bedwars": 27735,
-        "four_four_deaths_bedwars": 58400
+        "four_four_deaths_bedwars": 58400,
+        "two_four_games_played_bedwars": 309,
+        "two_four_wins_bedwars": 294,
+        "two_four_losses_bedwars": 11,
+        "two_four_beds_broken_bedwars": 99,
+        "two_four_beds_lost_bedwars": 13,
+        "two_four_final_kills_bedwars": 286,
+        "two_four_final_deaths_bedwars": 12,
+        "two_four_kills_bedwars": 254,
+        "two_four_deaths_bedwars": 350
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Arnav_The_Great_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Arnav_The_Great_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 1222,
         "four_four_final_deaths_bedwars": 711,
         "four_four_kills_bedwars": 1407,
-        "four_four_deaths_bedwars": 3320
+        "four_four_deaths_bedwars": 3320,
+        "two_four_winstreak": 6,
+        "two_four_games_played_bedwars": 66,
+        "two_four_wins_bedwars": 48,
+        "two_four_losses_bedwars": 17,
+        "two_four_beds_broken_bedwars": 28,
+        "two_four_beds_lost_bedwars": 20,
+        "two_four_final_kills_bedwars": 62,
+        "two_four_final_deaths_bedwars": 18,
+        "two_four_kills_bedwars": 143,
+        "two_four_deaths_bedwars": 162
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Aspectable_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Aspectable_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 599,
         "four_four_final_deaths_bedwars": 373,
         "four_four_kills_bedwars": 1471,
-        "four_four_deaths_bedwars": 2104
+        "four_four_deaths_bedwars": 2104,
+        "two_four_winstreak": 5,
+        "two_four_games_played_bedwars": 21,
+        "two_four_wins_bedwars": 15,
+        "two_four_losses_bedwars": 4,
+        "two_four_beds_broken_bedwars": 3,
+        "two_four_beds_lost_bedwars": 4,
+        "two_four_final_kills_bedwars": 8,
+        "two_four_final_deaths_bedwars": 3,
+        "two_four_kills_bedwars": 21,
+        "two_four_deaths_bedwars": 46
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/AustrisB_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/AustrisB_2024_02_25.json
@@ -55,7 +55,16 @@
         "four_four_final_kills_bedwars": 1,
         "four_four_final_deaths_bedwars": 9,
         "four_four_kills_bedwars": 7,
-        "four_four_deaths_bedwars": 6
+        "four_four_deaths_bedwars": 6,
+        "two_four_winstreak": 0,
+        "two_four_games_played_bedwars": 6,
+        "two_four_wins_bedwars": 2,
+        "two_four_losses_bedwars": 4,
+        "two_four_beds_lost_bedwars": 4,
+        "two_four_final_kills_bedwars": 1,
+        "two_four_final_deaths_bedwars": 4,
+        "two_four_kills_bedwars": 22,
+        "two_four_deaths_bedwars": 15
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Bloomingly_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Bloomingly_2024_02_25.json
@@ -55,7 +55,17 @@
         "four_four_final_kills_bedwars": 37601,
         "four_four_final_deaths_bedwars": 1734,
         "four_four_kills_bedwars": 22227,
-        "four_four_deaths_bedwars": 37868
+        "four_four_deaths_bedwars": 37868,
+        "two_four_winstreak": 33,
+        "two_four_games_played_bedwars": 351,
+        "two_four_wins_bedwars": 300,
+        "two_four_losses_bedwars": 47,
+        "two_four_beds_broken_bedwars": 107,
+        "two_four_beds_lost_bedwars": 61,
+        "two_four_final_kills_bedwars": 268,
+        "two_four_final_deaths_bedwars": 47,
+        "two_four_kills_bedwars": 423,
+        "two_four_deaths_bedwars": 694
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/BritishPoggers_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/BritishPoggers_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 1488,
         "four_four_final_deaths_bedwars": 190,
         "four_four_kills_bedwars": 1852,
-        "four_four_deaths_bedwars": 4657
+        "four_four_deaths_bedwars": 4657,
+        "two_four_winstreak": 4,
+        "two_four_games_played_bedwars": 44,
+        "two_four_wins_bedwars": 38,
+        "two_four_losses_bedwars": 5,
+        "two_four_beds_broken_bedwars": 6,
+        "two_four_beds_lost_bedwars": 5,
+        "two_four_final_kills_bedwars": 32,
+        "two_four_final_deaths_bedwars": 4,
+        "two_four_kills_bedwars": 61,
+        "two_four_deaths_bedwars": 108
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Buhzai_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Buhzai_2024_02_25.json
@@ -52,7 +52,16 @@
         "four_four_final_kills_bedwars": 2831,
         "four_four_final_deaths_bedwars": 108,
         "four_four_kills_bedwars": 1821,
-        "four_four_deaths_bedwars": 3090
+        "four_four_deaths_bedwars": 3090,
+        "two_four_games_played_bedwars": 29,
+        "two_four_wins_bedwars": 19,
+        "two_four_losses_bedwars": 9,
+        "two_four_beds_broken_bedwars": 9,
+        "two_four_beds_lost_bedwars": 12,
+        "two_four_final_kills_bedwars": 19,
+        "two_four_final_deaths_bedwars": 10,
+        "two_four_kills_bedwars": 20,
+        "two_four_deaths_bedwars": 49
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/CantTalkMewingRn_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/CantTalkMewingRn_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 3044,
         "four_four_final_deaths_bedwars": 1239,
         "four_four_kills_bedwars": 4803,
-        "four_four_deaths_bedwars": 6286
+        "four_four_deaths_bedwars": 6286,
+        "two_four_winstreak": 0,
+        "two_four_games_played_bedwars": 2,
+        "two_four_wins_bedwars": 1,
+        "two_four_losses_bedwars": 1,
+        "two_four_beds_broken_bedwars": 1,
+        "two_four_beds_lost_bedwars": 1,
+        "two_four_final_kills_bedwars": 1,
+        "two_four_final_deaths_bedwars": 1,
+        "two_four_kills_bedwars": 8,
+        "two_four_deaths_bedwars": 1
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Chapeey_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Chapeey_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 25847,
         "four_four_final_deaths_bedwars": 1558,
         "four_four_kills_bedwars": 19198,
-        "four_four_deaths_bedwars": 31535
+        "four_four_deaths_bedwars": 31535,
+        "two_four_games_played_bedwars": 1074,
+        "two_four_wins_bedwars": 1035,
+        "two_four_losses_bedwars": 23,
+        "two_four_beds_broken_bedwars": 352,
+        "two_four_beds_lost_bedwars": 39,
+        "two_four_final_kills_bedwars": 891,
+        "two_four_final_deaths_bedwars": 26,
+        "two_four_kills_bedwars": 678,
+        "two_four_deaths_bedwars": 1262
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Cliendence_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Cliendence_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 247,
         "four_four_final_deaths_bedwars": 512,
         "four_four_kills_bedwars": 949,
-        "four_four_deaths_bedwars": 1875
+        "four_four_deaths_bedwars": 1875,
+        "two_four_winstreak": 16,
+        "two_four_games_played_bedwars": 57,
+        "two_four_wins_bedwars": 35,
+        "two_four_losses_bedwars": 21,
+        "two_four_beds_broken_bedwars": 20,
+        "two_four_beds_lost_bedwars": 19,
+        "two_four_final_kills_bedwars": 59,
+        "two_four_final_deaths_bedwars": 21,
+        "two_four_kills_bedwars": 120,
+        "two_four_deaths_bedwars": 146
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Cold_Showers_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Cold_Showers_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 59,
         "four_four_final_deaths_bedwars": 128,
         "four_four_kills_bedwars": 316,
-        "four_four_deaths_bedwars": 252
+        "four_four_deaths_bedwars": 252,
+        "two_four_winstreak": 0,
+        "two_four_games_played_bedwars": 36,
+        "two_four_wins_bedwars": 14,
+        "two_four_losses_bedwars": 22,
+        "two_four_beds_broken_bedwars": 2,
+        "two_four_beds_lost_bedwars": 20,
+        "two_four_final_kills_bedwars": 6,
+        "two_four_final_deaths_bedwars": 19,
+        "two_four_kills_bedwars": 71,
+        "two_four_deaths_bedwars": 81
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Crawdead_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Crawdead_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 3621,
         "four_four_final_deaths_bedwars": 2410,
         "four_four_kills_bedwars": 8387,
-        "four_four_deaths_bedwars": 10430
+        "four_four_deaths_bedwars": 10430,
+        "two_four_games_played_bedwars": 95,
+        "two_four_wins_bedwars": 68,
+        "two_four_losses_bedwars": 23,
+        "two_four_beds_broken_bedwars": 21,
+        "two_four_beds_lost_bedwars": 21,
+        "two_four_final_kills_bedwars": 68,
+        "two_four_final_deaths_bedwars": 21,
+        "two_four_kills_bedwars": 94,
+        "two_four_deaths_bedwars": 137
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/DaddyToeFungus_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/DaddyToeFungus_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 11413,
         "four_four_final_deaths_bedwars": 959,
         "four_four_kills_bedwars": 17096,
-        "four_four_deaths_bedwars": 18528
+        "four_four_deaths_bedwars": 18528,
+        "two_four_games_played_bedwars": 29,
+        "two_four_wins_bedwars": 27,
+        "two_four_losses_bedwars": 2,
+        "two_four_beds_broken_bedwars": 12,
+        "two_four_beds_lost_bedwars": 3,
+        "two_four_final_kills_bedwars": 31,
+        "two_four_final_deaths_bedwars": 2,
+        "two_four_kills_bedwars": 62,
+        "two_four_deaths_bedwars": 56
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/DeathDorito_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/DeathDorito_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 440,
         "four_four_final_deaths_bedwars": 285,
         "four_four_kills_bedwars": 1254,
-        "four_four_deaths_bedwars": 1977
+        "four_four_deaths_bedwars": 1977,
+        "two_four_winstreak": 0,
+        "two_four_games_played_bedwars": 36,
+        "two_four_wins_bedwars": 20,
+        "two_four_losses_bedwars": 16,
+        "two_four_beds_broken_bedwars": 12,
+        "two_four_beds_lost_bedwars": 17,
+        "two_four_final_kills_bedwars": 31,
+        "two_four_final_deaths_bedwars": 16,
+        "two_four_kills_bedwars": 82,
+        "two_four_deaths_bedwars": 115
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/DefiantTech_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/DefiantTech_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 33924,
         "four_four_final_deaths_bedwars": 1961,
         "four_four_kills_bedwars": 25138,
-        "four_four_deaths_bedwars": 42009
+        "four_four_deaths_bedwars": 42009,
+        "two_four_games_played_bedwars": 198,
+        "two_four_wins_bedwars": 192,
+        "two_four_losses_bedwars": 1,
+        "two_four_beds_broken_bedwars": 60,
+        "two_four_beds_lost_bedwars": 2,
+        "two_four_final_kills_bedwars": 142,
+        "two_four_final_deaths_bedwars": 2,
+        "two_four_kills_bedwars": 81,
+        "two_four_deaths_bedwars": 207
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Defone_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Defone_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 50692,
         "four_four_final_deaths_bedwars": 340,
         "four_four_kills_bedwars": 24179,
-        "four_four_deaths_bedwars": 24439
+        "four_four_deaths_bedwars": 24439,
+        "two_four_games_played_bedwars": 1509,
+        "two_four_wins_bedwars": 1501,
+        "two_four_losses_bedwars": 1,
+        "two_four_beds_broken_bedwars": 529,
+        "two_four_beds_lost_bedwars": 4,
+        "two_four_final_kills_bedwars": 2585,
+        "two_four_final_deaths_bedwars": 1,
+        "two_four_kills_bedwars": 1683,
+        "two_four_deaths_bedwars": 884
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Dir3d_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Dir3d_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 16860,
         "four_four_final_deaths_bedwars": 834,
         "four_four_kills_bedwars": 15021,
-        "four_four_deaths_bedwars": 21488
+        "four_four_deaths_bedwars": 21488,
+        "two_four_games_played_bedwars": 147,
+        "two_four_wins_bedwars": 136,
+        "two_four_losses_bedwars": 9,
+        "two_four_beds_broken_bedwars": 43,
+        "two_four_beds_lost_bedwars": 14,
+        "two_four_final_kills_bedwars": 118,
+        "two_four_final_deaths_bedwars": 12,
+        "two_four_kills_bedwars": 139,
+        "two_four_deaths_bedwars": 186
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/DucktheShuk_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/DucktheShuk_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 87,
         "four_four_final_deaths_bedwars": 61,
         "four_four_kills_bedwars": 157,
-        "four_four_deaths_bedwars": 315
+        "four_four_deaths_bedwars": 315,
+        "two_four_winstreak": 12,
+        "two_four_games_played_bedwars": 17,
+        "two_four_wins_bedwars": 14,
+        "two_four_losses_bedwars": 2,
+        "two_four_beds_broken_bedwars": 3,
+        "two_four_beds_lost_bedwars": 4,
+        "two_four_final_kills_bedwars": 9,
+        "two_four_final_deaths_bedwars": 2,
+        "two_four_kills_bedwars": 5,
+        "two_four_deaths_bedwars": 27
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Dxante_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Dxante_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 7243,
         "four_four_final_deaths_bedwars": 518,
         "four_four_kills_bedwars": 5731,
-        "four_four_deaths_bedwars": 11569
+        "four_four_deaths_bedwars": 11569,
+        "two_four_games_played_bedwars": 451,
+        "two_four_wins_bedwars": 256,
+        "two_four_losses_bedwars": 191,
+        "two_four_beds_broken_bedwars": 86,
+        "two_four_beds_lost_bedwars": 199,
+        "two_four_final_kills_bedwars": 248,
+        "two_four_final_deaths_bedwars": 184,
+        "two_four_kills_bedwars": 1316,
+        "two_four_deaths_bedwars": 1432
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/ETGX_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/ETGX_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 311,
         "four_four_final_deaths_bedwars": 93,
         "four_four_kills_bedwars": 468,
-        "four_four_deaths_bedwars": 505
+        "four_four_deaths_bedwars": 505,
+        "two_four_winstreak": 1,
+        "two_four_games_played_bedwars": 308,
+        "two_four_wins_bedwars": 215,
+        "two_four_losses_bedwars": 92,
+        "two_four_beds_broken_bedwars": 123,
+        "two_four_beds_lost_bedwars": 103,
+        "two_four_final_kills_bedwars": 441,
+        "two_four_final_deaths_bedwars": 99,
+        "two_four_kills_bedwars": 871,
+        "two_four_deaths_bedwars": 849
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/EX38_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/EX38_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 643,
         "four_four_final_deaths_bedwars": 866,
         "four_four_kills_bedwars": 2191,
-        "four_four_deaths_bedwars": 2356
+        "four_four_deaths_bedwars": 2356,
+        "two_four_winstreak": 0,
+        "two_four_games_played_bedwars": 67,
+        "two_four_wins_bedwars": 37,
+        "two_four_losses_bedwars": 29,
+        "two_four_beds_broken_bedwars": 9,
+        "two_four_beds_lost_bedwars": 22,
+        "two_four_final_kills_bedwars": 40,
+        "two_four_final_deaths_bedwars": 31,
+        "two_four_kills_bedwars": 120,
+        "two_four_deaths_bedwars": 187
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Ehyu_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Ehyu_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 1204,
         "four_four_final_deaths_bedwars": 315,
         "four_four_kills_bedwars": 1551,
-        "four_four_deaths_bedwars": 2339
+        "four_four_deaths_bedwars": 2339,
+        "two_four_games_played_bedwars": 32,
+        "two_four_wins_bedwars": 22,
+        "two_four_losses_bedwars": 8,
+        "two_four_beds_broken_bedwars": 11,
+        "two_four_beds_lost_bedwars": 8,
+        "two_four_final_kills_bedwars": 22,
+        "two_four_final_deaths_bedwars": 7,
+        "two_four_kills_bedwars": 22,
+        "two_four_deaths_bedwars": 60
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Eyr_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Eyr_2024_02_25.json
@@ -52,7 +52,16 @@
         "four_four_final_kills_bedwars": 1244,
         "four_four_final_deaths_bedwars": 160,
         "four_four_kills_bedwars": 1483,
-        "four_four_deaths_bedwars": 2240
+        "four_four_deaths_bedwars": 2240,
+        "two_four_games_played_bedwars": 40,
+        "two_four_wins_bedwars": 36,
+        "two_four_losses_bedwars": 2,
+        "two_four_beds_broken_bedwars": 4,
+        "two_four_beds_lost_bedwars": 2,
+        "two_four_final_kills_bedwars": 29,
+        "two_four_final_deaths_bedwars": 2,
+        "two_four_kills_bedwars": 54,
+        "two_four_deaths_bedwars": 79
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/FavoAsian_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/FavoAsian_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 175,
         "four_four_final_deaths_bedwars": 185,
         "four_four_kills_bedwars": 585,
-        "four_four_deaths_bedwars": 716
+        "four_four_deaths_bedwars": 716,
+        "two_four_winstreak": 3,
+        "two_four_games_played_bedwars": 9,
+        "two_four_wins_bedwars": 5,
+        "two_four_losses_bedwars": 2,
+        "two_four_beds_broken_bedwars": 1,
+        "two_four_beds_lost_bedwars": 4,
+        "two_four_final_kills_bedwars": 6,
+        "two_four_final_deaths_bedwars": 3,
+        "two_four_kills_bedwars": 13,
+        "two_four_deaths_bedwars": 26
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Galnox_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Galnox_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 118,
         "four_four_final_deaths_bedwars": 357,
         "four_four_kills_bedwars": 560,
-        "four_four_deaths_bedwars": 1304
+        "four_four_deaths_bedwars": 1304,
+        "two_four_winstreak": 1,
+        "two_four_games_played_bedwars": 102,
+        "two_four_wins_bedwars": 45,
+        "two_four_losses_bedwars": 55,
+        "two_four_beds_broken_bedwars": 6,
+        "two_four_beds_lost_bedwars": 50,
+        "two_four_final_kills_bedwars": 35,
+        "two_four_final_deaths_bedwars": 59,
+        "two_four_kills_bedwars": 181,
+        "two_four_deaths_bedwars": 404
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Gatore_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Gatore_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 5687,
         "four_four_final_deaths_bedwars": 674,
         "four_four_kills_bedwars": 6879,
-        "four_four_deaths_bedwars": 10230
+        "four_four_deaths_bedwars": 10230,
+        "two_four_games_played_bedwars": 151,
+        "two_four_wins_bedwars": 114,
+        "two_four_losses_bedwars": 33,
+        "two_four_beds_broken_bedwars": 65,
+        "two_four_beds_lost_bedwars": 39,
+        "two_four_final_kills_bedwars": 162,
+        "two_four_final_deaths_bedwars": 33,
+        "two_four_kills_bedwars": 370,
+        "two_four_deaths_bedwars": 328
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Gauss_TW_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Gauss_TW_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 2948,
         "four_four_final_deaths_bedwars": 174,
         "four_four_kills_bedwars": 2561,
-        "four_four_deaths_bedwars": 3767
+        "four_four_deaths_bedwars": 3767,
+        "two_four_games_played_bedwars": 259,
+        "two_four_wins_bedwars": 199,
+        "two_four_losses_bedwars": 52,
+        "two_four_beds_broken_bedwars": 86,
+        "two_four_beds_lost_bedwars": 53,
+        "two_four_final_kills_bedwars": 243,
+        "two_four_final_deaths_bedwars": 40,
+        "two_four_kills_bedwars": 345,
+        "two_four_deaths_bedwars": 562
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/GawCHINKK_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/GawCHINKK_2024_02_25.json
@@ -55,7 +55,14 @@
         "four_four_final_kills_bedwars": 789,
         "four_four_final_deaths_bedwars": 14,
         "four_four_kills_bedwars": 436,
-        "four_four_deaths_bedwars": 674
+        "four_four_deaths_bedwars": 674,
+        "two_four_winstreak": 13,
+        "two_four_games_played_bedwars": 13,
+        "two_four_wins_bedwars": 13,
+        "two_four_beds_broken_bedwars": 3,
+        "two_four_final_kills_bedwars": 15,
+        "two_four_kills_bedwars": 12,
+        "two_four_deaths_bedwars": 10
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Golzdom_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Golzdom_2024_02_25.json
@@ -55,7 +55,16 @@
         "four_four_final_kills_bedwars": 82,
         "four_four_final_deaths_bedwars": 221,
         "four_four_kills_bedwars": 642,
-        "four_four_deaths_bedwars": 892
+        "four_four_deaths_bedwars": 892,
+        "two_four_winstreak": 0,
+        "two_four_games_played_bedwars": 21,
+        "two_four_wins_bedwars": 5,
+        "two_four_losses_bedwars": 16,
+        "two_four_beds_lost_bedwars": 14,
+        "two_four_final_kills_bedwars": 2,
+        "two_four_final_deaths_bedwars": 14,
+        "two_four_kills_bedwars": 14,
+        "two_four_deaths_bedwars": 13
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Grampslikefood_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Grampslikefood_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 440,
         "four_four_final_deaths_bedwars": 420,
         "four_four_kills_bedwars": 1569,
-        "four_four_deaths_bedwars": 1473
+        "four_four_deaths_bedwars": 1473,
+        "two_four_winstreak": 0,
+        "two_four_games_played_bedwars": 101,
+        "two_four_wins_bedwars": 61,
+        "two_four_losses_bedwars": 39,
+        "two_four_beds_broken_bedwars": 31,
+        "two_four_beds_lost_bedwars": 38,
+        "two_four_final_kills_bedwars": 89,
+        "two_four_final_deaths_bedwars": 37,
+        "two_four_kills_bedwars": 169,
+        "two_four_deaths_bedwars": 278
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/GreenJedia04_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/GreenJedia04_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 24468,
         "four_four_final_deaths_bedwars": 2186,
         "four_four_kills_bedwars": 18019,
-        "four_four_deaths_bedwars": 31895
+        "four_four_deaths_bedwars": 31895,
+        "two_four_games_played_bedwars": 2740,
+        "two_four_wins_bedwars": 2650,
+        "two_four_losses_bedwars": 27,
+        "two_four_beds_broken_bedwars": 715,
+        "two_four_beds_lost_bedwars": 63,
+        "two_four_final_kills_bedwars": 2146,
+        "two_four_final_deaths_bedwars": 33,
+        "two_four_kills_bedwars": 1798,
+        "two_four_deaths_bedwars": 3161
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/GreenSheepi_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/GreenSheepi_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 33819,
         "four_four_final_deaths_bedwars": 966,
         "four_four_kills_bedwars": 18873,
-        "four_four_deaths_bedwars": 25801
+        "four_four_deaths_bedwars": 25801,
+        "two_four_games_played_bedwars": 771,
+        "two_four_wins_bedwars": 744,
+        "two_four_losses_bedwars": 12,
+        "two_four_beds_broken_bedwars": 196,
+        "two_four_beds_lost_bedwars": 18,
+        "two_four_final_kills_bedwars": 755,
+        "two_four_final_deaths_bedwars": 12,
+        "two_four_kills_bedwars": 530,
+        "two_four_deaths_bedwars": 818
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Hfoxlord_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Hfoxlord_2024_02_25.json
@@ -53,7 +53,17 @@
         "four_four_final_kills_bedwars": 17,
         "four_four_final_deaths_bedwars": 59,
         "four_four_kills_bedwars": 39,
-        "four_four_deaths_bedwars": 134
+        "four_four_deaths_bedwars": 134,
+        "two_four_winstreak": 0,
+        "two_four_games_played_bedwars": 12,
+        "two_four_wins_bedwars": 5,
+        "two_four_losses_bedwars": 7,
+        "two_four_beds_broken_bedwars": 3,
+        "two_four_beds_lost_bedwars": 7,
+        "two_four_final_kills_bedwars": 8,
+        "two_four_final_deaths_bedwars": 7,
+        "two_four_kills_bedwars": 8,
+        "two_four_deaths_bedwars": 31
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/ImRegretWhatIDid_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/ImRegretWhatIDid_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 14517,
         "four_four_final_deaths_bedwars": 1277,
         "four_four_kills_bedwars": 12104,
-        "four_four_deaths_bedwars": 22181
+        "four_four_deaths_bedwars": 22181,
+        "two_four_games_played_bedwars": 2896,
+        "two_four_wins_bedwars": 2815,
+        "two_four_losses_bedwars": 45,
+        "two_four_beds_broken_bedwars": 1034,
+        "two_four_beds_lost_bedwars": 97,
+        "two_four_final_kills_bedwars": 1829,
+        "two_four_final_deaths_bedwars": 60,
+        "two_four_kills_bedwars": 988,
+        "two_four_deaths_bedwars": 2996
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Its_The_Guy_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Its_The_Guy_2024_02_25.json
@@ -52,7 +52,17 @@
         "four_four_final_kills_bedwars": 1,
         "four_four_final_deaths_bedwars": 11,
         "four_four_kills_bedwars": 32,
-        "four_four_deaths_bedwars": 35
+        "four_four_deaths_bedwars": 35,
+        "two_four_winstreak": 2,
+        "two_four_games_played_bedwars": 116,
+        "two_four_wins_bedwars": 59,
+        "two_four_losses_bedwars": 55,
+        "two_four_beds_broken_bedwars": 8,
+        "two_four_beds_lost_bedwars": 52,
+        "two_four_final_kills_bedwars": 39,
+        "two_four_final_deaths_bedwars": 55,
+        "two_four_kills_bedwars": 241,
+        "two_four_deaths_bedwars": 267
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Itz_Theo_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Itz_Theo_2024_02_25.json
@@ -56,7 +56,17 @@
         "four_four_final_kills_bedwars": 57,
         "four_four_final_deaths_bedwars": 69,
         "four_four_kills_bedwars": 190,
-        "four_four_deaths_bedwars": 387
+        "four_four_deaths_bedwars": 387,
+        "two_four_winstreak": 1,
+        "two_four_games_played_bedwars": 15,
+        "two_four_wins_bedwars": 5,
+        "two_four_losses_bedwars": 10,
+        "two_four_beds_broken_bedwars": 4,
+        "two_four_beds_lost_bedwars": 9,
+        "two_four_final_kills_bedwars": 5,
+        "two_four_final_deaths_bedwars": 10,
+        "two_four_kills_bedwars": 28,
+        "two_four_deaths_bedwars": 52
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Jedv_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Jedv_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 238,
         "four_four_final_deaths_bedwars": 77,
         "four_four_kills_bedwars": 575,
-        "four_four_deaths_bedwars": 511
+        "four_four_deaths_bedwars": 511,
+        "two_four_winstreak": 3,
+        "two_four_games_played_bedwars": 75,
+        "two_four_wins_bedwars": 62,
+        "two_four_losses_bedwars": 12,
+        "two_four_beds_broken_bedwars": 13,
+        "two_four_beds_lost_bedwars": 11,
+        "two_four_final_kills_bedwars": 55,
+        "two_four_final_deaths_bedwars": 10,
+        "two_four_kills_bedwars": 118,
+        "two_four_deaths_bedwars": 141
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Jifc_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Jifc_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 71,
         "four_four_final_deaths_bedwars": 32,
         "four_four_kills_bedwars": 216,
-        "four_four_deaths_bedwars": 154
+        "four_four_deaths_bedwars": 154,
+        "two_four_winstreak": 1,
+        "two_four_games_played_bedwars": 2,
+        "two_four_wins_bedwars": 1,
+        "two_four_losses_bedwars": 1,
+        "two_four_beds_broken_bedwars": 1,
+        "two_four_beds_lost_bedwars": 1,
+        "two_four_final_kills_bedwars": 1,
+        "two_four_final_deaths_bedwars": 1,
+        "two_four_kills_bedwars": 6,
+        "two_four_deaths_bedwars": 4
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Jqsie_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Jqsie_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 44160,
         "four_four_final_deaths_bedwars": 1139,
         "four_four_kills_bedwars": 29440,
-        "four_four_deaths_bedwars": 37811
+        "four_four_deaths_bedwars": 37811,
+        "two_four_games_played_bedwars": 397,
+        "two_four_wins_bedwars": 390,
+        "two_four_losses_bedwars": 4,
+        "two_four_beds_broken_bedwars": 86,
+        "two_four_beds_lost_bedwars": 7,
+        "two_four_final_kills_bedwars": 328,
+        "two_four_final_deaths_bedwars": 4,
+        "two_four_kills_bedwars": 352,
+        "two_four_deaths_bedwars": 450
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Juaaann_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Juaaann_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 15686,
         "four_four_final_deaths_bedwars": 1703,
         "four_four_kills_bedwars": 14488,
-        "four_four_deaths_bedwars": 26835
+        "four_four_deaths_bedwars": 26835,
+        "two_four_games_played_bedwars": 331,
+        "two_four_wins_bedwars": 261,
+        "two_four_losses_bedwars": 64,
+        "two_four_beds_broken_bedwars": 106,
+        "two_four_beds_lost_bedwars": 68,
+        "two_four_final_kills_bedwars": 242,
+        "two_four_final_deaths_bedwars": 53,
+        "two_four_kills_bedwars": 473,
+        "two_four_deaths_bedwars": 689
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/JuiiceWRLD_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/JuiiceWRLD_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 2623,
         "four_four_final_deaths_bedwars": 1164,
         "four_four_kills_bedwars": 4245,
-        "four_four_deaths_bedwars": 5714
+        "four_four_deaths_bedwars": 5714,
+        "two_four_games_played_bedwars": 574,
+        "two_four_wins_bedwars": 336,
+        "two_four_losses_bedwars": 238,
+        "two_four_beds_broken_bedwars": 109,
+        "two_four_beds_lost_bedwars": 258,
+        "two_four_final_kills_bedwars": 364,
+        "two_four_final_deaths_bedwars": 254,
+        "two_four_kills_bedwars": 1247,
+        "two_four_deaths_bedwars": 1487
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/JustACasualDay_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/JustACasualDay_2024_02_25.json
@@ -57,7 +57,15 @@
         "four_four_final_kills_bedwars": 288,
         "four_four_final_deaths_bedwars": 43,
         "four_four_kills_bedwars": 448,
-        "four_four_deaths_bedwars": 597
+        "four_four_deaths_bedwars": 597,
+        "two_four_winstreak": 3,
+        "two_four_games_played_bedwars": 3,
+        "two_four_wins_bedwars": 3,
+        "two_four_beds_broken_bedwars": 2,
+        "two_four_beds_lost_bedwars": 1,
+        "two_four_final_kills_bedwars": 7,
+        "two_four_kills_bedwars": 7,
+        "two_four_deaths_bedwars": 10
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Kelsov_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Kelsov_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 7404,
         "four_four_final_deaths_bedwars": 429,
         "four_four_kills_bedwars": 6760,
-        "four_four_deaths_bedwars": 8951
+        "four_four_deaths_bedwars": 8951,
+        "two_four_games_played_bedwars": 250,
+        "two_four_wins_bedwars": 178,
+        "two_four_losses_bedwars": 55,
+        "two_four_beds_broken_bedwars": 94,
+        "two_four_beds_lost_bedwars": 60,
+        "two_four_final_kills_bedwars": 214,
+        "two_four_final_deaths_bedwars": 50,
+        "two_four_kills_bedwars": 483,
+        "two_four_deaths_bedwars": 532
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Kubcn_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Kubcn_2024_02_25.json
@@ -55,7 +55,17 @@
         "four_four_final_kills_bedwars": 23220,
         "four_four_final_deaths_bedwars": 501,
         "four_four_kills_bedwars": 10724,
-        "four_four_deaths_bedwars": 21179
+        "four_four_deaths_bedwars": 21179,
+        "two_four_winstreak": 49,
+        "two_four_games_played_bedwars": 222,
+        "two_four_wins_bedwars": 210,
+        "two_four_losses_bedwars": 8,
+        "two_four_beds_broken_bedwars": 52,
+        "two_four_beds_lost_bedwars": 11,
+        "two_four_final_kills_bedwars": 174,
+        "two_four_final_deaths_bedwars": 9,
+        "two_four_kills_bedwars": 164,
+        "two_four_deaths_bedwars": 294
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Leopardiston_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Leopardiston_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 26988,
         "four_four_final_deaths_bedwars": 2836,
         "four_four_kills_bedwars": 39058,
-        "four_four_deaths_bedwars": 36584
+        "four_four_deaths_bedwars": 36584,
+        "two_four_winstreak": 16,
+        "two_four_games_played_bedwars": 26,
+        "two_four_wins_bedwars": 22,
+        "two_four_losses_bedwars": 2,
+        "two_four_beds_broken_bedwars": 7,
+        "two_four_beds_lost_bedwars": 2,
+        "two_four_final_kills_bedwars": 15,
+        "two_four_final_deaths_bedwars": 2,
+        "two_four_kills_bedwars": 25,
+        "two_four_deaths_bedwars": 35
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Lintels_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Lintels_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 38978,
         "four_four_final_deaths_bedwars": 4333,
         "four_four_kills_bedwars": 26954,
-        "four_four_deaths_bedwars": 50367
+        "four_four_deaths_bedwars": 50367,
+        "two_four_games_played_bedwars": 3648,
+        "two_four_wins_bedwars": 3522,
+        "two_four_losses_bedwars": 47,
+        "two_four_beds_broken_bedwars": 622,
+        "two_four_beds_lost_bedwars": 91,
+        "two_four_final_kills_bedwars": 2874,
+        "two_four_final_deaths_bedwars": 56,
+        "two_four_kills_bedwars": 1640,
+        "two_four_deaths_bedwars": 2854
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/LlamaFan54_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/LlamaFan54_2024_02_25.json
@@ -57,7 +57,16 @@
         "four_four_final_kills_bedwars": 6,
         "four_four_final_deaths_bedwars": 11,
         "four_four_kills_bedwars": 21,
-        "four_four_deaths_bedwars": 57
+        "four_four_deaths_bedwars": 57,
+        "two_four_winstreak": 0,
+        "two_four_games_played_bedwars": 5,
+        "two_four_wins_bedwars": 2,
+        "two_four_losses_bedwars": 3,
+        "two_four_beds_lost_bedwars": 4,
+        "two_four_final_kills_bedwars": 3,
+        "two_four_final_deaths_bedwars": 4,
+        "two_four_kills_bedwars": 7,
+        "two_four_deaths_bedwars": 14
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Luify_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Luify_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 3913,
         "four_four_final_deaths_bedwars": 650,
         "four_four_kills_bedwars": 5492,
-        "four_four_deaths_bedwars": 5298
+        "four_four_deaths_bedwars": 5298,
+        "two_four_games_played_bedwars": 77,
+        "two_four_wins_bedwars": 53,
+        "two_four_losses_bedwars": 22,
+        "two_four_beds_broken_bedwars": 20,
+        "two_four_beds_lost_bedwars": 26,
+        "two_four_final_kills_bedwars": 64,
+        "two_four_final_deaths_bedwars": 22,
+        "two_four_kills_bedwars": 158,
+        "two_four_deaths_bedwars": 164
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Lyndonz_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Lyndonz_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 31278,
         "four_four_final_deaths_bedwars": 1057,
         "four_four_kills_bedwars": 22106,
-        "four_four_deaths_bedwars": 34615
+        "four_four_deaths_bedwars": 34615,
+        "two_four_games_played_bedwars": 139,
+        "two_four_wins_bedwars": 128,
+        "two_four_losses_bedwars": 6,
+        "two_four_beds_broken_bedwars": 45,
+        "two_four_beds_lost_bedwars": 9,
+        "two_four_final_kills_bedwars": 99,
+        "two_four_final_deaths_bedwars": 5,
+        "two_four_kills_bedwars": 128,
+        "two_four_deaths_bedwars": 199
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/M0KKY__2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/M0KKY__2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 19898,
         "four_four_final_deaths_bedwars": 236,
         "four_four_kills_bedwars": 7192,
-        "four_four_deaths_bedwars": 10729
+        "four_four_deaths_bedwars": 10729,
+        "two_four_games_played_bedwars": 624,
+        "two_four_wins_bedwars": 610,
+        "two_four_losses_bedwars": 9,
+        "two_four_beds_broken_bedwars": 229,
+        "two_four_beds_lost_bedwars": 21,
+        "two_four_final_kills_bedwars": 733,
+        "two_four_final_deaths_bedwars": 9,
+        "two_four_kills_bedwars": 401,
+        "two_four_deaths_bedwars": 553
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/MAHMOUD_GAMEING_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/MAHMOUD_GAMEING_2024_02_25.json
@@ -55,7 +55,17 @@
         "four_four_final_kills_bedwars": 38587,
         "four_four_final_deaths_bedwars": 737,
         "four_four_kills_bedwars": 25274,
-        "four_four_deaths_bedwars": 28997
+        "four_four_deaths_bedwars": 28997,
+        "two_four_winstreak": 28,
+        "two_four_games_played_bedwars": 2578,
+        "two_four_wins_bedwars": 2550,
+        "two_four_losses_bedwars": 11,
+        "two_four_beds_broken_bedwars": 1033,
+        "two_four_beds_lost_bedwars": 22,
+        "two_four_final_kills_bedwars": 3760,
+        "two_four_final_deaths_bedwars": 11,
+        "two_four_kills_bedwars": 2651,
+        "two_four_deaths_bedwars": 2397
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/MEEMAWSUS_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/MEEMAWSUS_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 900,
         "four_four_final_deaths_bedwars": 416,
         "four_four_kills_bedwars": 1889,
-        "four_four_deaths_bedwars": 3554
+        "four_four_deaths_bedwars": 3554,
+        "two_four_winstreak": 0,
+        "two_four_games_played_bedwars": 127,
+        "two_four_wins_bedwars": 70,
+        "two_four_losses_bedwars": 52,
+        "two_four_beds_broken_bedwars": 23,
+        "two_four_beds_lost_bedwars": 47,
+        "two_four_final_kills_bedwars": 62,
+        "two_four_final_deaths_bedwars": 48,
+        "two_four_kills_bedwars": 212,
+        "two_four_deaths_bedwars": 382
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/MR_money_bags777_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/MR_money_bags777_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 144,
         "four_four_final_deaths_bedwars": 647,
         "four_four_kills_bedwars": 927,
-        "four_four_deaths_bedwars": 547
+        "four_four_deaths_bedwars": 547,
+        "two_four_winstreak": 0,
+        "two_four_games_played_bedwars": 626,
+        "two_four_wins_bedwars": 289,
+        "two_four_losses_bedwars": 331,
+        "two_four_beds_broken_bedwars": 48,
+        "two_four_beds_lost_bedwars": 314,
+        "two_four_final_kills_bedwars": 254,
+        "two_four_final_deaths_bedwars": 343,
+        "two_four_kills_bedwars": 1172,
+        "two_four_deaths_bedwars": 808
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Manhal_IQ__2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Manhal_IQ__2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 37709,
         "four_four_final_deaths_bedwars": 1597,
         "four_four_kills_bedwars": 31230,
-        "four_four_deaths_bedwars": 44553
+        "four_four_deaths_bedwars": 44553,
+        "two_four_games_played_bedwars": 3947,
+        "two_four_wins_bedwars": 3810,
+        "two_four_losses_bedwars": 54,
+        "two_four_beds_broken_bedwars": 1192,
+        "two_four_beds_lost_bedwars": 103,
+        "two_four_final_kills_bedwars": 4094,
+        "two_four_final_deaths_bedwars": 57,
+        "two_four_kills_bedwars": 2813,
+        "two_four_deaths_bedwars": 3244
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/MaxBuilder4X_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/MaxBuilder4X_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 236,
         "four_four_final_deaths_bedwars": 74,
         "four_four_kills_bedwars": 418,
-        "four_four_deaths_bedwars": 508
+        "four_four_deaths_bedwars": 508,
+        "two_four_winstreak": 10,
+        "two_four_games_played_bedwars": 25,
+        "two_four_wins_bedwars": 21,
+        "two_four_losses_bedwars": 4,
+        "two_four_beds_broken_bedwars": 7,
+        "two_four_beds_lost_bedwars": 8,
+        "two_four_final_kills_bedwars": 27,
+        "two_four_final_deaths_bedwars": 6,
+        "two_four_kills_bedwars": 26,
+        "two_four_deaths_bedwars": 42
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/MonsterGG_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/MonsterGG_2024_02_25.json
@@ -55,7 +55,16 @@
         "four_four_final_kills_bedwars": 40632,
         "four_four_final_deaths_bedwars": 1620,
         "four_four_kills_bedwars": 15628,
-        "four_four_deaths_bedwars": 34343
+        "four_four_deaths_bedwars": 34343,
+        "two_four_winstreak": 256,
+        "two_four_games_played_bedwars": 265,
+        "two_four_wins_bedwars": 263,
+        "two_four_beds_broken_bedwars": 75,
+        "two_four_beds_lost_bedwars": 2,
+        "two_four_final_kills_bedwars": 250,
+        "two_four_final_deaths_bedwars": 1,
+        "two_four_kills_bedwars": 140,
+        "two_four_deaths_bedwars": 239
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/MrPoluxX_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/MrPoluxX_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 73,
         "four_four_final_deaths_bedwars": 69,
         "four_four_kills_bedwars": 183,
-        "four_four_deaths_bedwars": 375
+        "four_four_deaths_bedwars": 375,
+        "two_four_winstreak": 0,
+        "two_four_games_played_bedwars": 409,
+        "two_four_wins_bedwars": 155,
+        "two_four_losses_bedwars": 251,
+        "two_four_beds_broken_bedwars": 55,
+        "two_four_beds_lost_bedwars": 255,
+        "two_four_final_kills_bedwars": 180,
+        "two_four_final_deaths_bedwars": 255,
+        "two_four_kills_bedwars": 927,
+        "two_four_deaths_bedwars": 1459
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/NoSDaemon_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/NoSDaemon_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 57980,
         "four_four_final_deaths_bedwars": 1437,
         "four_four_kills_bedwars": 29471,
-        "four_four_deaths_bedwars": 33252
+        "four_four_deaths_bedwars": 33252,
+        "two_four_games_played_bedwars": 147,
+        "two_four_wins_bedwars": 144,
+        "two_four_losses_bedwars": 2,
+        "two_four_beds_broken_bedwars": 61,
+        "two_four_beds_lost_bedwars": 7,
+        "two_four_final_kills_bedwars": 169,
+        "two_four_final_deaths_bedwars": 4,
+        "two_four_kills_bedwars": 83,
+        "two_four_deaths_bedwars": 120
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/OSound_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/OSound_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 142,
         "four_four_final_deaths_bedwars": 216,
         "four_four_kills_bedwars": 466,
-        "four_four_deaths_bedwars": 783
+        "four_four_deaths_bedwars": 783,
+        "two_four_winstreak": 0,
+        "two_four_games_played_bedwars": 359,
+        "two_four_wins_bedwars": 139,
+        "two_four_losses_bedwars": 219,
+        "two_four_beds_broken_bedwars": 15,
+        "two_four_beds_lost_bedwars": 182,
+        "two_four_final_kills_bedwars": 94,
+        "two_four_final_deaths_bedwars": 220,
+        "two_four_kills_bedwars": 603,
+        "two_four_deaths_bedwars": 972
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Ohfound_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Ohfound_2024_02_25.json
@@ -50,7 +50,13 @@
         "four_four_final_kills_bedwars": 3119,
         "four_four_final_deaths_bedwars": 77,
         "four_four_kills_bedwars": 2844,
-        "four_four_deaths_bedwars": 3421
+        "four_four_deaths_bedwars": 3421,
+        "two_four_games_played_bedwars": 4,
+        "two_four_wins_bedwars": 4,
+        "two_four_beds_broken_bedwars": 2,
+        "two_four_final_kills_bedwars": 6,
+        "two_four_kills_bedwars": 6,
+        "two_four_deaths_bedwars": 8
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Ohhhduck_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Ohhhduck_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 119,
         "four_four_final_deaths_bedwars": 44,
         "four_four_kills_bedwars": 230,
-        "four_four_deaths_bedwars": 265
+        "four_four_deaths_bedwars": 265,
+        "two_four_games_played_bedwars": 192,
+        "two_four_wins_bedwars": 140,
+        "two_four_losses_bedwars": 51,
+        "two_four_beds_broken_bedwars": 59,
+        "two_four_beds_lost_bedwars": 57,
+        "two_four_final_kills_bedwars": 189,
+        "two_four_final_deaths_bedwars": 53,
+        "two_four_kills_bedwars": 533,
+        "two_four_deaths_bedwars": 428
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/OkayShawny_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/OkayShawny_2024_02_25.json
@@ -55,7 +55,14 @@
         "four_four_final_kills_bedwars": 61,
         "four_four_final_deaths_bedwars": 27,
         "four_four_kills_bedwars": 146,
-        "four_four_deaths_bedwars": 98
+        "four_four_deaths_bedwars": 98,
+        "two_four_winstreak": 1,
+        "two_four_games_played_bedwars": 1,
+        "two_four_wins_bedwars": 1,
+        "two_four_beds_broken_bedwars": 1,
+        "two_four_final_kills_bedwars": 3,
+        "two_four_kills_bedwars": 1,
+        "two_four_deaths_bedwars": 3
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/OpGoDnEsSs_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/OpGoDnEsSs_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 53577,
         "four_four_final_deaths_bedwars": 2751,
         "four_four_kills_bedwars": 34793,
-        "four_four_deaths_bedwars": 63672
+        "four_four_deaths_bedwars": 63672,
+        "two_four_games_played_bedwars": 434,
+        "two_four_wins_bedwars": 387,
+        "two_four_losses_bedwars": 6,
+        "two_four_beds_broken_bedwars": 112,
+        "two_four_beds_lost_bedwars": 6,
+        "two_four_final_kills_bedwars": 311,
+        "two_four_final_deaths_bedwars": 3,
+        "two_four_kills_bedwars": 244,
+        "two_four_deaths_bedwars": 404
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/PRO10MIXALIS_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/PRO10MIXALIS_2024_02_25.json
@@ -56,7 +56,16 @@
         "four_four_final_kills_bedwars": 6,
         "four_four_final_deaths_bedwars": 11,
         "four_four_kills_bedwars": 39,
-        "four_four_deaths_bedwars": 52
+        "four_four_deaths_bedwars": 52,
+        "two_four_winstreak": 0,
+        "two_four_games_played_bedwars": 3,
+        "two_four_wins_bedwars": 1,
+        "two_four_losses_bedwars": 2,
+        "two_four_beds_lost_bedwars": 1,
+        "two_four_final_kills_bedwars": 1,
+        "two_four_final_deaths_bedwars": 2,
+        "two_four_kills_bedwars": 10,
+        "two_four_deaths_bedwars": 12
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/ParCrayDragon1_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/ParCrayDragon1_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 208,
         "four_four_final_deaths_bedwars": 209,
         "four_four_kills_bedwars": 792,
-        "four_four_deaths_bedwars": 993
+        "four_four_deaths_bedwars": 993,
+        "two_four_winstreak": 0,
+        "two_four_games_played_bedwars": 863,
+        "two_four_wins_bedwars": 429,
+        "two_four_losses_bedwars": 425,
+        "two_four_beds_broken_bedwars": 74,
+        "two_four_beds_lost_bedwars": 334,
+        "two_four_final_kills_bedwars": 417,
+        "two_four_final_deaths_bedwars": 450,
+        "two_four_kills_bedwars": 2638,
+        "two_four_deaths_bedwars": 3130
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Pheenus_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Pheenus_2024_02_25.json
@@ -57,7 +57,16 @@
         "four_four_final_kills_bedwars": 1122,
         "four_four_final_deaths_bedwars": 975,
         "four_four_kills_bedwars": 3664,
-        "four_four_deaths_bedwars": 3528
+        "four_four_deaths_bedwars": 3528,
+        "two_four_winstreak": 0,
+        "two_four_games_played_bedwars": 17,
+        "two_four_wins_bedwars": 3,
+        "two_four_losses_bedwars": 14,
+        "two_four_beds_lost_bedwars": 13,
+        "two_four_final_kills_bedwars": 2,
+        "two_four_final_deaths_bedwars": 13,
+        "two_four_kills_bedwars": 31,
+        "two_four_deaths_bedwars": 39
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/PlzFightMe_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/PlzFightMe_2024_02_25.json
@@ -52,7 +52,16 @@
         "four_four_final_kills_bedwars": 66266,
         "four_four_final_deaths_bedwars": 1826,
         "four_four_kills_bedwars": 48159,
-        "four_four_deaths_bedwars": 52228
+        "four_four_deaths_bedwars": 52228,
+        "two_four_games_played_bedwars": 1293,
+        "two_four_wins_bedwars": 1266,
+        "two_four_losses_bedwars": 13,
+        "two_four_beds_broken_bedwars": 412,
+        "two_four_beds_lost_bedwars": 20,
+        "two_four_final_kills_bedwars": 1583,
+        "two_four_final_deaths_bedwars": 15,
+        "two_four_kills_bedwars": 1025,
+        "two_four_deaths_bedwars": 1114
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Popcornfroid_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Popcornfroid_2024_02_25.json
@@ -56,7 +56,17 @@
         "four_four_final_kills_bedwars": 3,
         "four_four_final_deaths_bedwars": 15,
         "four_four_kills_bedwars": 15,
-        "four_four_deaths_bedwars": 58
+        "four_four_deaths_bedwars": 58,
+        "two_four_winstreak": 0,
+        "two_four_games_played_bedwars": 38,
+        "two_four_wins_bedwars": 14,
+        "two_four_losses_bedwars": 24,
+        "two_four_beds_broken_bedwars": 1,
+        "two_four_beds_lost_bedwars": 21,
+        "two_four_final_kills_bedwars": 5,
+        "two_four_final_deaths_bedwars": 25,
+        "two_four_kills_bedwars": 24,
+        "two_four_deaths_bedwars": 103
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Quagalicious_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Quagalicious_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 161,
         "four_four_final_deaths_bedwars": 176,
         "four_four_kills_bedwars": 505,
-        "four_four_deaths_bedwars": 814
+        "four_four_deaths_bedwars": 814,
+        "two_four_winstreak": 1,
+        "two_four_games_played_bedwars": 47,
+        "two_four_wins_bedwars": 21,
+        "two_four_losses_bedwars": 26,
+        "two_four_beds_broken_bedwars": 5,
+        "two_four_beds_lost_bedwars": 27,
+        "two_four_final_kills_bedwars": 19,
+        "two_four_final_deaths_bedwars": 27,
+        "two_four_kills_bedwars": 75,
+        "two_four_deaths_bedwars": 95
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Quan10_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Quan10_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 601,
         "four_four_final_deaths_bedwars": 1057,
         "four_four_kills_bedwars": 3160,
-        "four_four_deaths_bedwars": 4280
+        "four_four_deaths_bedwars": 4280,
+        "two_four_winstreak": 1,
+        "two_four_games_played_bedwars": 104,
+        "two_four_wins_bedwars": 45,
+        "two_four_losses_bedwars": 55,
+        "two_four_beds_broken_bedwars": 16,
+        "two_four_beds_lost_bedwars": 57,
+        "two_four_final_kills_bedwars": 49,
+        "two_four_final_deaths_bedwars": 55,
+        "two_four_kills_bedwars": 282,
+        "two_four_deaths_bedwars": 324
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/RRG__2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/RRG__2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 17125,
         "four_four_final_deaths_bedwars": 1557,
         "four_four_kills_bedwars": 15657,
-        "four_four_deaths_bedwars": 27911
+        "four_four_deaths_bedwars": 27911,
+        "two_four_games_played_bedwars": 994,
+        "two_four_wins_bedwars": 920,
+        "two_four_losses_bedwars": 51,
+        "two_four_beds_broken_bedwars": 248,
+        "two_four_beds_lost_bedwars": 79,
+        "two_four_final_kills_bedwars": 843,
+        "two_four_final_deaths_bedwars": 64,
+        "two_four_kills_bedwars": 759,
+        "two_four_deaths_bedwars": 1528
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Red_Dolphin34_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Red_Dolphin34_2024_02_25.json
@@ -53,7 +53,14 @@
         "four_four_final_kills_bedwars": 112,
         "four_four_final_deaths_bedwars": 288,
         "four_four_kills_bedwars": 530,
-        "four_four_deaths_bedwars": 1249
+        "four_four_deaths_bedwars": 1249,
+        "two_four_winstreak": 0,
+        "two_four_games_played_bedwars": 2,
+        "two_four_losses_bedwars": 2,
+        "two_four_beds_lost_bedwars": 1,
+        "two_four_final_deaths_bedwars": 2,
+        "two_four_kills_bedwars": 15,
+        "two_four_deaths_bedwars": 10
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Rizzone_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Rizzone_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 53,
         "four_four_final_deaths_bedwars": 127,
         "four_four_kills_bedwars": 193,
-        "four_four_deaths_bedwars": 654
+        "four_four_deaths_bedwars": 654,
+        "two_four_winstreak": 4,
+        "two_four_games_played_bedwars": 6,
+        "two_four_wins_bedwars": 5,
+        "two_four_losses_bedwars": 1,
+        "two_four_beds_broken_bedwars": 2,
+        "two_four_beds_lost_bedwars": 4,
+        "two_four_final_kills_bedwars": 3,
+        "two_four_final_deaths_bedwars": 2,
+        "two_four_kills_bedwars": 6,
+        "two_four_deaths_bedwars": 17
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Sharmoy_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Sharmoy_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 772,
         "four_four_final_deaths_bedwars": 452,
         "four_four_kills_bedwars": 2340,
-        "four_four_deaths_bedwars": 2620
+        "four_four_deaths_bedwars": 2620,
+        "two_four_winstreak": 0,
+        "two_four_games_played_bedwars": 14,
+        "two_four_wins_bedwars": 11,
+        "two_four_losses_bedwars": 3,
+        "two_four_beds_broken_bedwars": 2,
+        "two_four_beds_lost_bedwars": 4,
+        "two_four_final_kills_bedwars": 9,
+        "two_four_final_deaths_bedwars": 3,
+        "two_four_kills_bedwars": 17,
+        "two_four_deaths_bedwars": 21
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/SixtoTheGreat_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/SixtoTheGreat_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 20592,
         "four_four_final_deaths_bedwars": 1028,
         "four_four_kills_bedwars": 9774,
-        "four_four_deaths_bedwars": 22493
+        "four_four_deaths_bedwars": 22493,
+        "two_four_games_played_bedwars": 544,
+        "two_four_wins_bedwars": 512,
+        "two_four_losses_bedwars": 22,
+        "two_four_beds_broken_bedwars": 143,
+        "two_four_beds_lost_bedwars": 40,
+        "two_four_final_kills_bedwars": 452,
+        "two_four_final_deaths_bedwars": 27,
+        "two_four_kills_bedwars": 322,
+        "two_four_deaths_bedwars": 634
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Sixx_0_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Sixx_0_2024_02_25.json
@@ -56,7 +56,17 @@
         "four_four_final_kills_bedwars": 19,
         "four_four_final_deaths_bedwars": 31,
         "four_four_kills_bedwars": 107,
-        "four_four_deaths_bedwars": 101
+        "four_four_deaths_bedwars": 101,
+        "two_four_winstreak": 2,
+        "two_four_games_played_bedwars": 7,
+        "two_four_wins_bedwars": 4,
+        "two_four_losses_bedwars": 3,
+        "two_four_beds_broken_bedwars": 1,
+        "two_four_beds_lost_bedwars": 2,
+        "two_four_final_kills_bedwars": 2,
+        "two_four_final_deaths_bedwars": 3,
+        "two_four_kills_bedwars": 10,
+        "two_four_deaths_bedwars": 25
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Skydeaf_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Skydeaf_2024_02_25.json
@@ -52,7 +52,13 @@
         "four_four_final_kills_bedwars": 1367,
         "four_four_final_deaths_bedwars": 104,
         "four_four_kills_bedwars": 1256,
-        "four_four_deaths_bedwars": 1740
+        "four_four_deaths_bedwars": 1740,
+        "two_four_games_played_bedwars": 5,
+        "two_four_wins_bedwars": 5,
+        "two_four_beds_broken_bedwars": 2,
+        "two_four_final_kills_bedwars": 11,
+        "two_four_kills_bedwars": 9,
+        "two_four_deaths_bedwars": 14
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Skydeath_2021_01_07.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Skydeath_2021_01_07.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 1872,
         "four_four_final_deaths_bedwars": 224,
         "four_four_kills_bedwars": 2370,
-        "four_four_deaths_bedwars": 3576
+        "four_four_deaths_bedwars": 3576,
+        "two_four_winstreak": 0,
+        "two_four_games_played_bedwars": 67,
+        "two_four_wins_bedwars": 39,
+        "two_four_losses_bedwars": 26,
+        "two_four_beds_broken_bedwars": 33,
+        "two_four_beds_lost_bedwars": 33,
+        "two_four_final_kills_bedwars": 66,
+        "two_four_final_deaths_bedwars": 26,
+        "two_four_kills_bedwars": 215,
+        "two_four_deaths_bedwars": 186
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Skydeath_2024_02_03.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Skydeath_2024_02_03.json
@@ -52,7 +52,16 @@
         "four_four_final_kills_bedwars": 5839,
         "four_four_final_deaths_bedwars": 342,
         "four_four_kills_bedwars": 5864,
-        "four_four_deaths_bedwars": 8750
+        "four_four_deaths_bedwars": 8750,
+        "two_four_games_played_bedwars": 72,
+        "two_four_wins_bedwars": 44,
+        "two_four_losses_bedwars": 26,
+        "two_four_beds_broken_bedwars": 33,
+        "two_four_beds_lost_bedwars": 33,
+        "two_four_final_kills_bedwars": 73,
+        "two_four_final_deaths_bedwars": 26,
+        "two_four_kills_bedwars": 220,
+        "two_four_deaths_bedwars": 196
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Skydeath_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Skydeath_2024_02_25.json
@@ -52,7 +52,16 @@
         "four_four_final_kills_bedwars": 5839,
         "four_four_final_deaths_bedwars": 342,
         "four_four_kills_bedwars": 5864,
-        "four_four_deaths_bedwars": 8750
+        "four_four_deaths_bedwars": 8750,
+        "two_four_games_played_bedwars": 72,
+        "two_four_wins_bedwars": 44,
+        "two_four_losses_bedwars": 26,
+        "two_four_beds_broken_bedwars": 33,
+        "two_four_beds_lost_bedwars": 33,
+        "two_four_final_kills_bedwars": 73,
+        "two_four_final_deaths_bedwars": 26,
+        "two_four_kills_bedwars": 220,
+        "two_four_deaths_bedwars": 196
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/SuperAlexNoob_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/SuperAlexNoob_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 8470,
         "four_four_final_deaths_bedwars": 1024,
         "four_four_kills_bedwars": 7484,
-        "four_four_deaths_bedwars": 12741
+        "four_four_deaths_bedwars": 12741,
+        "two_four_games_played_bedwars": 333,
+        "two_four_wins_bedwars": 312,
+        "two_four_losses_bedwars": 13,
+        "two_four_beds_broken_bedwars": 97,
+        "two_four_beds_lost_bedwars": 21,
+        "two_four_final_kills_bedwars": 280,
+        "two_four_final_deaths_bedwars": 13,
+        "two_four_kills_bedwars": 228,
+        "two_four_deaths_bedwars": 419
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/TeamLuxGlez_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/TeamLuxGlez_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 16710,
         "four_four_final_deaths_bedwars": 326,
         "four_four_kills_bedwars": 11570,
-        "four_four_deaths_bedwars": 17182
+        "four_four_deaths_bedwars": 17182,
+        "two_four_games_played_bedwars": 12,
+        "two_four_wins_bedwars": 11,
+        "two_four_losses_bedwars": 1,
+        "two_four_beds_broken_bedwars": 5,
+        "two_four_beds_lost_bedwars": 2,
+        "two_four_final_kills_bedwars": 17,
+        "two_four_final_deaths_bedwars": 2,
+        "two_four_kills_bedwars": 11,
+        "two_four_deaths_bedwars": 3
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/TheCleb_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/TheCleb_2024_02_25.json
@@ -55,7 +55,17 @@
         "four_four_final_kills_bedwars": 51098,
         "four_four_final_deaths_bedwars": 3683,
         "four_four_kills_bedwars": 33884,
-        "four_four_deaths_bedwars": 72105
+        "four_four_deaths_bedwars": 72105,
+        "two_four_winstreak": 3,
+        "two_four_games_played_bedwars": 5,
+        "two_four_wins_bedwars": 4,
+        "two_four_losses_bedwars": 1,
+        "two_four_beds_broken_bedwars": 2,
+        "two_four_beds_lost_bedwars": 2,
+        "two_four_final_kills_bedwars": 1,
+        "two_four_final_deaths_bedwars": 1,
+        "two_four_kills_bedwars": 11,
+        "two_four_deaths_bedwars": 11
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/TigerboyBob_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/TigerboyBob_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 132,
         "four_four_final_deaths_bedwars": 712,
         "four_four_kills_bedwars": 736,
-        "four_four_deaths_bedwars": 1914
+        "four_four_deaths_bedwars": 1914,
+        "two_four_winstreak": 1,
+        "two_four_games_played_bedwars": 813,
+        "two_four_wins_bedwars": 312,
+        "two_four_losses_bedwars": 497,
+        "two_four_beds_broken_bedwars": 99,
+        "two_four_beds_lost_bedwars": 391,
+        "two_four_final_kills_bedwars": 263,
+        "two_four_final_deaths_bedwars": 519,
+        "two_four_kills_bedwars": 928,
+        "two_four_deaths_bedwars": 2206
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Tolered_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Tolered_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 70,
         "four_four_final_deaths_bedwars": 432,
         "four_four_kills_bedwars": 455,
-        "four_four_deaths_bedwars": 1033
+        "four_four_deaths_bedwars": 1033,
+        "two_four_winstreak": 2,
+        "two_four_games_played_bedwars": 426,
+        "two_four_wins_bedwars": 143,
+        "two_four_losses_bedwars": 283,
+        "two_four_beds_broken_bedwars": 21,
+        "two_four_beds_lost_bedwars": 280,
+        "two_four_final_kills_bedwars": 89,
+        "two_four_final_deaths_bedwars": 294,
+        "two_four_kills_bedwars": 648,
+        "two_four_deaths_bedwars": 1041
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/U5BB_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/U5BB_2024_02_25.json
@@ -43,7 +43,15 @@
         "four_four_final_kills_bedwars": 581,
         "four_four_final_deaths_bedwars": 135,
         "four_four_kills_bedwars": 544,
-        "four_four_deaths_bedwars": 509
+        "four_four_deaths_bedwars": 509,
+        "two_four_games_played_bedwars": 9,
+        "two_four_wins_bedwars": 5,
+        "two_four_losses_bedwars": 2,
+        "two_four_beds_lost_bedwars": 2,
+        "two_four_final_kills_bedwars": 4,
+        "two_four_final_deaths_bedwars": 2,
+        "two_four_kills_bedwars": 7,
+        "two_four_deaths_bedwars": 1
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/USBB_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/USBB_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 22908,
         "four_four_final_deaths_bedwars": 1765,
         "four_four_kills_bedwars": 21442,
-        "four_four_deaths_bedwars": 29878
+        "four_four_deaths_bedwars": 29878,
+        "two_four_games_played_bedwars": 438,
+        "two_four_wins_bedwars": 329,
+        "two_four_losses_bedwars": 96,
+        "two_four_beds_broken_bedwars": 182,
+        "two_four_beds_lost_bedwars": 106,
+        "two_four_final_kills_bedwars": 392,
+        "two_four_final_deaths_bedwars": 97,
+        "two_four_kills_bedwars": 901,
+        "two_four_deaths_bedwars": 1177
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/VEZYxVOLTEYxEROS_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/VEZYxVOLTEYxEROS_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 46092,
         "four_four_final_deaths_bedwars": 9420,
         "four_four_kills_bedwars": 70910,
-        "four_four_deaths_bedwars": 76790
+        "four_four_deaths_bedwars": 76790,
+        "two_four_games_played_bedwars": 122,
+        "two_four_wins_bedwars": 118,
+        "two_four_losses_bedwars": 1,
+        "two_four_beds_broken_bedwars": 5,
+        "two_four_beds_lost_bedwars": 4,
+        "two_four_final_kills_bedwars": 61,
+        "two_four_final_deaths_bedwars": 1,
+        "two_four_kills_bedwars": 51,
+        "two_four_deaths_bedwars": 62
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/WarOG_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/WarOG_2024_02_25.json
@@ -52,7 +52,16 @@
         "four_four_final_kills_bedwars": 71147,
         "four_four_final_deaths_bedwars": 3862,
         "four_four_kills_bedwars": 78325,
-        "four_four_deaths_bedwars": 66455
+        "four_four_deaths_bedwars": 66455,
+        "two_four_games_played_bedwars": 1541,
+        "two_four_wins_bedwars": 1473,
+        "two_four_losses_bedwars": 35,
+        "two_four_beds_broken_bedwars": 638,
+        "two_four_beds_lost_bedwars": 72,
+        "two_four_final_kills_bedwars": 1711,
+        "two_four_final_deaths_bedwars": 41,
+        "two_four_kills_bedwars": 1606,
+        "two_four_deaths_bedwars": 1838
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Wizarro_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Wizarro_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 45905,
         "four_four_final_deaths_bedwars": 3648,
         "four_four_kills_bedwars": 29354,
-        "four_four_deaths_bedwars": 50252
+        "four_four_deaths_bedwars": 50252,
+        "two_four_games_played_bedwars": 685,
+        "two_four_wins_bedwars": 666,
+        "two_four_losses_bedwars": 6,
+        "two_four_beds_broken_bedwars": 183,
+        "two_four_beds_lost_bedwars": 13,
+        "two_four_final_kills_bedwars": 531,
+        "two_four_final_deaths_bedwars": 5,
+        "two_four_kills_bedwars": 498,
+        "two_four_deaths_bedwars": 713
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Wlnks_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Wlnks_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 20607,
         "four_four_final_deaths_bedwars": 739,
         "four_four_kills_bedwars": 12590,
-        "four_four_deaths_bedwars": 23729
+        "four_four_deaths_bedwars": 23729,
+        "two_four_games_played_bedwars": 41,
+        "two_four_wins_bedwars": 32,
+        "two_four_losses_bedwars": 8,
+        "two_four_beds_broken_bedwars": 12,
+        "two_four_beds_lost_bedwars": 7,
+        "two_four_final_kills_bedwars": 43,
+        "two_four_final_deaths_bedwars": 7,
+        "two_four_kills_bedwars": 64,
+        "two_four_deaths_bedwars": 100
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Wonkky_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Wonkky_2024_02_25.json
@@ -52,7 +52,16 @@
         "four_four_final_kills_bedwars": 8998,
         "four_four_final_deaths_bedwars": 1848,
         "four_four_kills_bedwars": 14914,
-        "four_four_deaths_bedwars": 22389
+        "four_four_deaths_bedwars": 22389,
+        "two_four_games_played_bedwars": 91,
+        "two_four_wins_bedwars": 76,
+        "two_four_losses_bedwars": 11,
+        "two_four_beds_broken_bedwars": 31,
+        "two_four_beds_lost_bedwars": 17,
+        "two_four_final_kills_bedwars": 68,
+        "two_four_final_deaths_bedwars": 13,
+        "two_four_kills_bedwars": 154,
+        "two_four_deaths_bedwars": 210
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Yaomi_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Yaomi_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 8378,
         "four_four_final_deaths_bedwars": 1336,
         "four_four_kills_bedwars": 11456,
-        "four_four_deaths_bedwars": 13952
+        "four_four_deaths_bedwars": 13952,
+        "two_four_games_played_bedwars": 196,
+        "two_four_wins_bedwars": 188,
+        "two_four_losses_bedwars": 7,
+        "two_four_beds_broken_bedwars": 42,
+        "two_four_beds_lost_bedwars": 10,
+        "two_four_final_kills_bedwars": 194,
+        "two_four_final_deaths_bedwars": 10,
+        "two_four_kills_bedwars": 166,
+        "two_four_deaths_bedwars": 223
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/Zeit_Gaming_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/Zeit_Gaming_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 13196,
         "four_four_final_deaths_bedwars": 473,
         "four_four_kills_bedwars": 7383,
-        "four_four_deaths_bedwars": 8708
+        "four_four_deaths_bedwars": 8708,
+        "two_four_games_played_bedwars": 78,
+        "two_four_wins_bedwars": 59,
+        "two_four_losses_bedwars": 19,
+        "two_four_beds_broken_bedwars": 37,
+        "two_four_beds_lost_bedwars": 23,
+        "two_four_final_kills_bedwars": 80,
+        "two_four_final_deaths_bedwars": 19,
+        "two_four_kills_bedwars": 157,
+        "two_four_deaths_bedwars": 161
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/_JBC__2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/_JBC__2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 4014,
         "four_four_final_deaths_bedwars": 591,
         "four_four_kills_bedwars": 2789,
-        "four_four_deaths_bedwars": 4474
+        "four_four_deaths_bedwars": 4474,
+        "two_four_games_played_bedwars": 179,
+        "two_four_wins_bedwars": 101,
+        "two_four_losses_bedwars": 77,
+        "two_four_beds_broken_bedwars": 63,
+        "two_four_beds_lost_bedwars": 85,
+        "two_four_final_kills_bedwars": 107,
+        "two_four_final_deaths_bedwars": 78,
+        "two_four_kills_bedwars": 294,
+        "two_four_deaths_bedwars": 559
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/____WaFFlz______2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/____WaFFlz______2024_02_25.json
@@ -54,7 +54,16 @@
         "four_four_final_kills_bedwars": 18,
         "four_four_final_deaths_bedwars": 83,
         "four_four_kills_bedwars": 93,
-        "four_four_deaths_bedwars": 249
+        "four_four_deaths_bedwars": 249,
+        "two_four_winstreak": 0,
+        "two_four_games_played_bedwars": 15,
+        "two_four_wins_bedwars": 2,
+        "two_four_losses_bedwars": 13,
+        "two_four_beds_lost_bedwars": 12,
+        "two_four_final_kills_bedwars": 4,
+        "two_four_final_deaths_bedwars": 13,
+        "two_four_kills_bedwars": 17,
+        "two_four_deaths_bedwars": 21
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/_lazor_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/_lazor_2024_02_25.json
@@ -56,7 +56,17 @@
         "four_four_final_kills_bedwars": 67,
         "four_four_final_deaths_bedwars": 511,
         "four_four_kills_bedwars": 515,
-        "four_four_deaths_bedwars": 2408
+        "four_four_deaths_bedwars": 2408,
+        "two_four_winstreak": 0,
+        "two_four_games_played_bedwars": 133,
+        "two_four_wins_bedwars": 50,
+        "two_four_losses_bedwars": 76,
+        "two_four_beds_broken_bedwars": 2,
+        "two_four_beds_lost_bedwars": 77,
+        "two_four_final_kills_bedwars": 15,
+        "two_four_final_deaths_bedwars": 76,
+        "two_four_kills_bedwars": 114,
+        "two_four_deaths_bedwars": 399
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/acehubs_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/acehubs_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 65,
         "four_four_final_deaths_bedwars": 130,
         "four_four_kills_bedwars": 220,
-        "four_four_deaths_bedwars": 407
+        "four_four_deaths_bedwars": 407,
+        "two_four_winstreak": 3,
+        "two_four_games_played_bedwars": 146,
+        "two_four_wins_bedwars": 71,
+        "two_four_losses_bedwars": 75,
+        "two_four_beds_broken_bedwars": 35,
+        "two_four_beds_lost_bedwars": 79,
+        "two_four_final_kills_bedwars": 81,
+        "two_four_final_deaths_bedwars": 79,
+        "two_four_kills_bedwars": 302,
+        "two_four_deaths_bedwars": 433
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/baller_NY_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/baller_NY_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 1994,
         "four_four_final_deaths_bedwars": 490,
         "four_four_kills_bedwars": 2696,
-        "four_four_deaths_bedwars": 5195
+        "four_four_deaths_bedwars": 5195,
+        "two_four_games_played_bedwars": 97,
+        "two_four_wins_bedwars": 90,
+        "two_four_losses_bedwars": 7,
+        "two_four_beds_broken_bedwars": 28,
+        "two_four_beds_lost_bedwars": 10,
+        "two_four_final_kills_bedwars": 98,
+        "two_four_final_deaths_bedwars": 8,
+        "two_four_kills_bedwars": 148,
+        "two_four_deaths_bedwars": 203
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/bigboicarrot_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/bigboicarrot_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 170,
         "four_four_final_deaths_bedwars": 99,
         "four_four_kills_bedwars": 405,
-        "four_four_deaths_bedwars": 680
+        "four_four_deaths_bedwars": 680,
+        "two_four_winstreak": 8,
+        "two_four_games_played_bedwars": 132,
+        "two_four_wins_bedwars": 67,
+        "two_four_losses_bedwars": 61,
+        "two_four_beds_broken_bedwars": 27,
+        "two_four_beds_lost_bedwars": 58,
+        "two_four_final_kills_bedwars": 64,
+        "two_four_final_deaths_bedwars": 61,
+        "two_four_kills_bedwars": 381,
+        "two_four_deaths_bedwars": 524
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/blazing_lord_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/blazing_lord_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 34838,
         "four_four_final_deaths_bedwars": 1874,
         "four_four_kills_bedwars": 20800,
-        "four_four_deaths_bedwars": 37985
+        "four_four_deaths_bedwars": 37985,
+        "two_four_games_played_bedwars": 2095,
+        "two_four_wins_bedwars": 2036,
+        "two_four_losses_bedwars": 44,
+        "two_four_beds_broken_bedwars": 636,
+        "two_four_beds_lost_bedwars": 74,
+        "two_four_final_kills_bedwars": 2060,
+        "two_four_final_deaths_bedwars": 45,
+        "two_four_kills_bedwars": 1076,
+        "two_four_deaths_bedwars": 1649
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/bulizhnik3012_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/bulizhnik3012_2024_02_25.json
@@ -56,7 +56,15 @@
         "four_four_final_kills_bedwars": 10,
         "four_four_final_deaths_bedwars": 32,
         "four_four_kills_bedwars": 85,
-        "four_four_deaths_bedwars": 82
+        "four_four_deaths_bedwars": 82,
+        "two_four_winstreak": 1,
+        "two_four_games_played_bedwars": 7,
+        "two_four_wins_bedwars": 3,
+        "two_four_losses_bedwars": 4,
+        "two_four_beds_lost_bedwars": 4,
+        "two_four_final_deaths_bedwars": 4,
+        "two_four_kills_bedwars": 11,
+        "two_four_deaths_bedwars": 11
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/calceta_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/calceta_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 15201,
         "four_four_final_deaths_bedwars": 2814,
         "four_four_kills_bedwars": 18467,
-        "four_four_deaths_bedwars": 23814
+        "four_four_deaths_bedwars": 23814,
+        "two_four_games_played_bedwars": 45,
+        "two_four_wins_bedwars": 42,
+        "two_four_losses_bedwars": 2,
+        "two_four_beds_broken_bedwars": 13,
+        "two_four_beds_lost_bedwars": 2,
+        "two_four_final_kills_bedwars": 28,
+        "two_four_final_deaths_bedwars": 3,
+        "two_four_kills_bedwars": 39,
+        "two_four_deaths_bedwars": 55
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/cocoasann_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/cocoasann_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 45703,
         "four_four_final_deaths_bedwars": 4004,
         "four_four_kills_bedwars": 36666,
-        "four_four_deaths_bedwars": 49589
+        "four_four_deaths_bedwars": 49589,
+        "two_four_games_played_bedwars": 7665,
+        "two_four_wins_bedwars": 7625,
+        "two_four_losses_bedwars": 23,
+        "two_four_beds_broken_bedwars": 2016,
+        "two_four_beds_lost_bedwars": 46,
+        "two_four_final_kills_bedwars": 7300,
+        "two_four_final_deaths_bedwars": 21,
+        "two_four_kills_bedwars": 3882,
+        "two_four_deaths_bedwars": 5661
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/comfywick_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/comfywick_2024_02_25.json
@@ -52,7 +52,16 @@
         "four_four_final_kills_bedwars": 5444,
         "four_four_final_deaths_bedwars": 655,
         "four_four_kills_bedwars": 5989,
-        "four_four_deaths_bedwars": 8697
+        "four_four_deaths_bedwars": 8697,
+        "two_four_games_played_bedwars": 89,
+        "two_four_wins_bedwars": 72,
+        "two_four_losses_bedwars": 16,
+        "two_four_beds_broken_bedwars": 27,
+        "two_four_beds_lost_bedwars": 16,
+        "two_four_final_kills_bedwars": 81,
+        "two_four_final_deaths_bedwars": 15,
+        "two_four_kills_bedwars": 117,
+        "two_four_deaths_bedwars": 173
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/dsbmlover_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/dsbmlover_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 3529,
         "four_four_final_deaths_bedwars": 218,
         "four_four_kills_bedwars": 3108,
-        "four_four_deaths_bedwars": 3586
+        "four_four_deaths_bedwars": 3586,
+        "two_four_games_played_bedwars": 694,
+        "two_four_wins_bedwars": 396,
+        "two_four_losses_bedwars": 278,
+        "two_four_beds_broken_bedwars": 162,
+        "two_four_beds_lost_bedwars": 287,
+        "two_four_final_kills_bedwars": 505,
+        "two_four_final_deaths_bedwars": 274,
+        "two_four_kills_bedwars": 2118,
+        "two_four_deaths_bedwars": 1635
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/egg4999953332egg_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/egg4999953332egg_2024_02_25.json
@@ -50,7 +50,13 @@
         "four_four_final_kills_bedwars": 12917,
         "four_four_final_deaths_bedwars": 383,
         "four_four_kills_bedwars": 7932,
-        "four_four_deaths_bedwars": 9406
+        "four_four_deaths_bedwars": 9406,
+        "two_four_games_played_bedwars": 112,
+        "two_four_wins_bedwars": 111,
+        "two_four_beds_broken_bedwars": 22,
+        "two_four_final_kills_bedwars": 115,
+        "two_four_kills_bedwars": 50,
+        "two_four_deaths_bedwars": 112
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/eggyu_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/eggyu_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 1580,
         "four_four_final_deaths_bedwars": 1317,
         "four_four_kills_bedwars": 3817,
-        "four_four_deaths_bedwars": 8101
+        "four_four_deaths_bedwars": 8101,
+        "two_four_winstreak": 5,
+        "two_four_games_played_bedwars": 211,
+        "two_four_wins_bedwars": 151,
+        "two_four_losses_bedwars": 58,
+        "two_four_beds_broken_bedwars": 40,
+        "two_four_beds_lost_bedwars": 63,
+        "two_four_final_kills_bedwars": 87,
+        "two_four_final_deaths_bedwars": 59,
+        "two_four_kills_bedwars": 295,
+        "two_four_deaths_bedwars": 601
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/f69ba2c027c8472ab9514a9e6795c64f_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/f69ba2c027c8472ab9514a9e6795c64f_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 52,
         "four_four_final_deaths_bedwars": 86,
         "four_four_kills_bedwars": 140,
-        "four_four_deaths_bedwars": 329
+        "four_four_deaths_bedwars": 329,
+        "two_four_winstreak": 0,
+        "two_four_games_played_bedwars": 212,
+        "two_four_wins_bedwars": 86,
+        "two_four_losses_bedwars": 125,
+        "two_four_beds_broken_bedwars": 36,
+        "two_four_beds_lost_bedwars": 117,
+        "two_four_final_kills_bedwars": 82,
+        "two_four_final_deaths_bedwars": 130,
+        "two_four_kills_bedwars": 264,
+        "two_four_deaths_bedwars": 637
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/fart_da_ass_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/fart_da_ass_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 446,
         "four_four_final_deaths_bedwars": 290,
         "four_four_kills_bedwars": 1511,
-        "four_four_deaths_bedwars": 1318
+        "four_four_deaths_bedwars": 1318,
+        "two_four_winstreak": 3,
+        "two_four_games_played_bedwars": 14,
+        "two_four_wins_bedwars": 9,
+        "two_four_losses_bedwars": 5,
+        "two_four_beds_broken_bedwars": 4,
+        "two_four_beds_lost_bedwars": 7,
+        "two_four_final_kills_bedwars": 15,
+        "two_four_final_deaths_bedwars": 5,
+        "two_four_kills_bedwars": 33,
+        "two_four_deaths_bedwars": 33
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/gamerboy80_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/gamerboy80_2024_02_25.json
@@ -55,7 +55,17 @@
         "four_four_final_kills_bedwars": 28257,
         "four_four_final_deaths_bedwars": 617,
         "four_four_kills_bedwars": 14093,
-        "four_four_deaths_bedwars": 21087
+        "four_four_deaths_bedwars": 21087,
+        "two_four_winstreak": 3,
+        "two_four_games_played_bedwars": 42,
+        "two_four_wins_bedwars": 35,
+        "two_four_losses_bedwars": 7,
+        "two_four_beds_broken_bedwars": 23,
+        "two_four_beds_lost_bedwars": 9,
+        "two_four_final_kills_bedwars": 55,
+        "two_four_final_deaths_bedwars": 7,
+        "two_four_kills_bedwars": 82,
+        "two_four_deaths_bedwars": 85
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/hotmami_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/hotmami_2024_02_25.json
@@ -50,7 +50,14 @@
         "four_four_final_kills_bedwars": 3094,
         "four_four_final_deaths_bedwars": 216,
         "four_four_kills_bedwars": 2371,
-        "four_four_deaths_bedwars": 4565
+        "four_four_deaths_bedwars": 4565,
+        "two_four_games_played_bedwars": 129,
+        "two_four_wins_bedwars": 129,
+        "two_four_beds_broken_bedwars": 28,
+        "two_four_beds_lost_bedwars": 1,
+        "two_four_final_kills_bedwars": 102,
+        "two_four_kills_bedwars": 68,
+        "two_four_deaths_bedwars": 133
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/hubbabubba3_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/hubbabubba3_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 315,
         "four_four_final_deaths_bedwars": 73,
         "four_four_kills_bedwars": 404,
-        "four_four_deaths_bedwars": 490
+        "four_four_deaths_bedwars": 490,
+        "two_four_games_played_bedwars": 153,
+        "two_four_wins_bedwars": 138,
+        "two_four_losses_bedwars": 15,
+        "two_four_beds_broken_bedwars": 83,
+        "two_four_beds_lost_bedwars": 18,
+        "two_four_final_kills_bedwars": 260,
+        "two_four_final_deaths_bedwars": 16,
+        "two_four_kills_bedwars": 320,
+        "two_four_deaths_bedwars": 274
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/iCiara_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/iCiara_2024_02_25.json
@@ -52,7 +52,16 @@
         "four_four_final_kills_bedwars": 4443,
         "four_four_final_deaths_bedwars": 512,
         "four_four_kills_bedwars": 4085,
-        "four_four_deaths_bedwars": 10725
+        "four_four_deaths_bedwars": 10725,
+        "two_four_games_played_bedwars": 11,
+        "two_four_wins_bedwars": 6,
+        "two_four_losses_bedwars": 5,
+        "two_four_beds_broken_bedwars": 2,
+        "two_four_beds_lost_bedwars": 5,
+        "two_four_final_kills_bedwars": 4,
+        "two_four_final_deaths_bedwars": 6,
+        "two_four_kills_bedwars": 10,
+        "two_four_deaths_bedwars": 19
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/iElephant_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/iElephant_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 68341,
         "four_four_final_deaths_bedwars": 2041,
         "four_four_kills_bedwars": 42113,
-        "four_four_deaths_bedwars": 72205
+        "four_four_deaths_bedwars": 72205,
+        "two_four_games_played_bedwars": 4115,
+        "two_four_wins_bedwars": 4048,
+        "two_four_losses_bedwars": 30,
+        "two_four_beds_broken_bedwars": 866,
+        "two_four_beds_lost_bedwars": 61,
+        "two_four_final_kills_bedwars": 3557,
+        "two_four_final_deaths_bedwars": 32,
+        "two_four_kills_bedwars": 2091,
+        "two_four_deaths_bedwars": 3970
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/insecuregf_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/insecuregf_2024_02_25.json
@@ -57,7 +57,16 @@
         "four_four_final_kills_bedwars": 436,
         "four_four_final_deaths_bedwars": 449,
         "four_four_kills_bedwars": 766,
-        "four_four_deaths_bedwars": 1084
+        "four_four_deaths_bedwars": 1084,
+        "two_four_winstreak": 5,
+        "two_four_games_played_bedwars": 46,
+        "two_four_wins_bedwars": 42,
+        "two_four_losses_bedwars": 4,
+        "two_four_beds_broken_bedwars": 10,
+        "two_four_final_kills_bedwars": 16,
+        "two_four_final_deaths_bedwars": 5,
+        "two_four_kills_bedwars": 9,
+        "two_four_deaths_bedwars": 22
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/ipwningnoobs_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/ipwningnoobs_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 14,
         "four_four_final_deaths_bedwars": 26,
         "four_four_kills_bedwars": 47,
-        "four_four_deaths_bedwars": 84
+        "four_four_deaths_bedwars": 84,
+        "two_four_winstreak": 0,
+        "two_four_games_played_bedwars": 54,
+        "two_four_wins_bedwars": 24,
+        "two_four_losses_bedwars": 30,
+        "two_four_beds_broken_bedwars": 13,
+        "two_four_beds_lost_bedwars": 30,
+        "two_four_final_kills_bedwars": 48,
+        "two_four_final_deaths_bedwars": 30,
+        "two_four_kills_bedwars": 240,
+        "two_four_deaths_bedwars": 212
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/j0kic_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/j0kic_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 125,
         "four_four_final_deaths_bedwars": 37,
         "four_four_kills_bedwars": 198,
-        "four_four_deaths_bedwars": 313
+        "four_four_deaths_bedwars": 313,
+        "two_four_winstreak": 14,
+        "two_four_games_played_bedwars": 279,
+        "two_four_wins_bedwars": 193,
+        "two_four_losses_bedwars": 86,
+        "two_four_beds_broken_bedwars": 81,
+        "two_four_beds_lost_bedwars": 94,
+        "two_four_final_kills_bedwars": 265,
+        "two_four_final_deaths_bedwars": 86,
+        "two_four_kills_bedwars": 721,
+        "two_four_deaths_bedwars": 759
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/jfaf_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/jfaf_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 33,
         "four_four_final_deaths_bedwars": 33,
         "four_four_kills_bedwars": 97,
-        "four_four_deaths_bedwars": 156
+        "four_four_deaths_bedwars": 156,
+        "two_four_winstreak": 0,
+        "two_four_games_played_bedwars": 32,
+        "two_four_wins_bedwars": 24,
+        "two_four_losses_bedwars": 8,
+        "two_four_beds_broken_bedwars": 3,
+        "two_four_beds_lost_bedwars": 7,
+        "two_four_final_kills_bedwars": 18,
+        "two_four_final_deaths_bedwars": 7,
+        "two_four_kills_bedwars": 70,
+        "two_four_deaths_bedwars": 86
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/jonzus_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/jonzus_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 30,
         "four_four_final_deaths_bedwars": 59,
         "four_four_kills_bedwars": 163,
-        "four_four_deaths_bedwars": 148
+        "four_four_deaths_bedwars": 148,
+        "two_four_winstreak": 1,
+        "two_four_games_played_bedwars": 28,
+        "two_four_wins_bedwars": 12,
+        "two_four_losses_bedwars": 15,
+        "two_four_beds_broken_bedwars": 2,
+        "two_four_beds_lost_bedwars": 12,
+        "two_four_final_kills_bedwars": 16,
+        "two_four_final_deaths_bedwars": 13,
+        "two_four_kills_bedwars": 45,
+        "two_four_deaths_bedwars": 50
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/kippi_games_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/kippi_games_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 53,
         "four_four_final_deaths_bedwars": 362,
         "four_four_kills_bedwars": 324,
-        "four_four_deaths_bedwars": 1328
+        "four_four_deaths_bedwars": 1328,
+        "two_four_winstreak": 1,
+        "two_four_games_played_bedwars": 298,
+        "two_four_wins_bedwars": 100,
+        "two_four_losses_bedwars": 195,
+        "two_four_beds_broken_bedwars": 11,
+        "two_four_beds_lost_bedwars": 185,
+        "two_four_final_kills_bedwars": 52,
+        "two_four_final_deaths_bedwars": 204,
+        "two_four_kills_bedwars": 357,
+        "two_four_deaths_bedwars": 936
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/kittycatopmine_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/kittycatopmine_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 32187,
         "four_four_final_deaths_bedwars": 1282,
         "four_four_kills_bedwars": 22035,
-        "four_four_deaths_bedwars": 32981
+        "four_four_deaths_bedwars": 32981,
+        "two_four_winstreak": 27,
+        "two_four_games_played_bedwars": 7131,
+        "two_four_wins_bedwars": 6943,
+        "two_four_losses_bedwars": 62,
+        "two_four_beds_broken_bedwars": 1637,
+        "two_four_beds_lost_bedwars": 142,
+        "two_four_final_kills_bedwars": 5100,
+        "two_four_final_deaths_bedwars": 67,
+        "two_four_kills_bedwars": 3771,
+        "two_four_deaths_bedwars": 5664
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/kittycatzenshi_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/kittycatzenshi_2024_02_25.json
@@ -52,7 +52,16 @@
         "four_four_final_kills_bedwars": 23919,
         "four_four_final_deaths_bedwars": 2681,
         "four_four_kills_bedwars": 27338,
-        "four_four_deaths_bedwars": 28980
+        "four_four_deaths_bedwars": 28980,
+        "two_four_games_played_bedwars": 33,
+        "two_four_wins_bedwars": 31,
+        "two_four_losses_bedwars": 2,
+        "two_four_beds_broken_bedwars": 10,
+        "two_four_beds_lost_bedwars": 2,
+        "two_four_final_kills_bedwars": 25,
+        "two_four_final_deaths_bedwars": 2,
+        "two_four_kills_bedwars": 62,
+        "two_four_deaths_bedwars": 39
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/kkbwf123_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/kkbwf123_2024_02_25.json
@@ -44,7 +44,12 @@
         "four_four_final_kills_bedwars": 133,
         "four_four_final_deaths_bedwars": 96,
         "four_four_kills_bedwars": 294,
-        "four_four_deaths_bedwars": 429
+        "four_four_deaths_bedwars": 429,
+        "two_four_winstreak": 1,
+        "two_four_games_played_bedwars": 1,
+        "two_four_wins_bedwars": 1,
+        "two_four_final_kills_bedwars": 3,
+        "two_four_deaths_bedwars": 1
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/l_PoopJuice_l_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/l_PoopJuice_l_2024_02_25.json
@@ -55,7 +55,16 @@
         "four_four_final_kills_bedwars": 55,
         "four_four_final_deaths_bedwars": 196,
         "four_four_kills_bedwars": 347,
-        "four_four_deaths_bedwars": 458
+        "four_four_deaths_bedwars": 458,
+        "two_four_winstreak": 6,
+        "two_four_games_played_bedwars": 91,
+        "two_four_wins_bedwars": 36,
+        "two_four_losses_bedwars": 55,
+        "two_four_beds_lost_bedwars": 57,
+        "two_four_final_kills_bedwars": 7,
+        "two_four_final_deaths_bedwars": 59,
+        "two_four_kills_bedwars": 177,
+        "two_four_deaths_bedwars": 141
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/mineplayz2020_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/mineplayz2020_2024_02_25.json
@@ -57,7 +57,17 @@
         "four_four_final_kills_bedwars": 901,
         "four_four_final_deaths_bedwars": 603,
         "four_four_kills_bedwars": 1703,
-        "four_four_deaths_bedwars": 3837
+        "four_four_deaths_bedwars": 3837,
+        "two_four_winstreak": 0,
+        "two_four_games_played_bedwars": 640,
+        "two_four_wins_bedwars": 324,
+        "two_four_losses_bedwars": 307,
+        "two_four_beds_broken_bedwars": 91,
+        "two_four_beds_lost_bedwars": 297,
+        "two_four_final_kills_bedwars": 298,
+        "two_four_final_deaths_bedwars": 303,
+        "two_four_kills_bedwars": 965,
+        "two_four_deaths_bedwars": 2075
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/naxsps17_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/naxsps17_2024_02_25.json
@@ -55,7 +55,17 @@
         "four_four_final_kills_bedwars": 635,
         "four_four_final_deaths_bedwars": 1733,
         "four_four_kills_bedwars": 2354,
-        "four_four_deaths_bedwars": 5980
+        "four_four_deaths_bedwars": 5980,
+        "two_four_winstreak": 0,
+        "two_four_games_played_bedwars": 1080,
+        "two_four_wins_bedwars": 455,
+        "two_four_losses_bedwars": 618,
+        "two_four_beds_broken_bedwars": 117,
+        "two_four_beds_lost_bedwars": 637,
+        "two_four_final_kills_bedwars": 322,
+        "two_four_final_deaths_bedwars": 651,
+        "two_four_kills_bedwars": 1223,
+        "two_four_deaths_bedwars": 3470
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/nobmo_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/nobmo_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 51842,
         "four_four_final_deaths_bedwars": 4218,
         "four_four_kills_bedwars": 37855,
-        "four_four_deaths_bedwars": 60961
+        "four_four_deaths_bedwars": 60961,
+        "two_four_games_played_bedwars": 2840,
+        "two_four_wins_bedwars": 2700,
+        "two_four_losses_bedwars": 73,
+        "two_four_beds_broken_bedwars": 826,
+        "two_four_beds_lost_bedwars": 142,
+        "two_four_final_kills_bedwars": 2207,
+        "two_four_final_deaths_bedwars": 88,
+        "two_four_kills_bedwars": 2011,
+        "two_four_deaths_bedwars": 3428
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/noneleft_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/noneleft_2024_02_25.json
@@ -50,7 +50,15 @@
         "four_four_final_kills_bedwars": 27954,
         "four_four_final_deaths_bedwars": 1185,
         "four_four_kills_bedwars": 16745,
-        "four_four_deaths_bedwars": 31484
+        "four_four_deaths_bedwars": 31484,
+        "two_four_games_played_bedwars": 12,
+        "two_four_wins_bedwars": 3,
+        "two_four_losses_bedwars": 8,
+        "two_four_beds_broken_bedwars": 1,
+        "two_four_beds_lost_bedwars": 7,
+        "two_four_final_deaths_bedwars": 7,
+        "two_four_kills_bedwars": 17,
+        "two_four_deaths_bedwars": 12
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/oCheddar_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/oCheddar_2024_02_25.json
@@ -52,7 +52,16 @@
         "four_four_final_kills_bedwars": 125,
         "four_four_final_deaths_bedwars": 11,
         "four_four_kills_bedwars": 169,
-        "four_four_deaths_bedwars": 218
+        "four_four_deaths_bedwars": 218,
+        "two_four_games_played_bedwars": 13,
+        "two_four_wins_bedwars": 12,
+        "two_four_losses_bedwars": 1,
+        "two_four_beds_broken_bedwars": 6,
+        "two_four_beds_lost_bedwars": 2,
+        "two_four_final_kills_bedwars": 21,
+        "two_four_final_deaths_bedwars": 1,
+        "two_four_kills_bedwars": 37,
+        "two_four_deaths_bedwars": 33
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/oFlab_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/oFlab_2024_02_25.json
@@ -47,7 +47,17 @@
         "four_four_final_kills_bedwars": 115,
         "four_four_final_deaths_bedwars": 20,
         "four_four_kills_bedwars": 203,
-        "four_four_deaths_bedwars": 215
+        "four_four_deaths_bedwars": 215,
+        "two_four_winstreak": 0,
+        "two_four_games_played_bedwars": 12,
+        "two_four_wins_bedwars": 11,
+        "two_four_losses_bedwars": 1,
+        "two_four_beds_broken_bedwars": 4,
+        "two_four_beds_lost_bedwars": 1,
+        "two_four_final_kills_bedwars": 11,
+        "two_four_final_deaths_bedwars": 1,
+        "two_four_kills_bedwars": 9,
+        "two_four_deaths_bedwars": 27
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/ohDevil_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/ohDevil_2024_02_25.json
@@ -55,7 +55,17 @@
         "four_four_final_kills_bedwars": 16008,
         "four_four_final_deaths_bedwars": 340,
         "four_four_kills_bedwars": 10712,
-        "four_four_deaths_bedwars": 19197
+        "four_four_deaths_bedwars": 19197,
+        "two_four_winstreak": 38,
+        "two_four_games_played_bedwars": 568,
+        "two_four_wins_bedwars": 547,
+        "two_four_losses_bedwars": 15,
+        "two_four_beds_broken_bedwars": 170,
+        "two_four_beds_lost_bedwars": 28,
+        "two_four_final_kills_bedwars": 458,
+        "two_four_final_deaths_bedwars": 16,
+        "two_four_kills_bedwars": 473,
+        "two_four_deaths_bedwars": 696
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/poopoosnake75_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/poopoosnake75_2024_02_25.json
@@ -52,7 +52,16 @@
         "four_four_final_kills_bedwars": 91692,
         "four_four_final_deaths_bedwars": 6586,
         "four_four_kills_bedwars": 53671,
-        "four_four_deaths_bedwars": 69155
+        "four_four_deaths_bedwars": 69155,
+        "two_four_games_played_bedwars": 578,
+        "two_four_wins_bedwars": 467,
+        "two_four_losses_bedwars": 93,
+        "two_four_beds_broken_bedwars": 215,
+        "two_four_beds_lost_bedwars": 125,
+        "two_four_final_kills_bedwars": 621,
+        "two_four_final_deaths_bedwars": 98,
+        "two_four_kills_bedwars": 1050,
+        "two_four_deaths_bedwars": 1170
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/rvdes_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/rvdes_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 33713,
         "four_four_final_deaths_bedwars": 3135,
         "four_four_kills_bedwars": 38409,
-        "four_four_deaths_bedwars": 42367
+        "four_four_deaths_bedwars": 42367,
+        "two_four_games_played_bedwars": 603,
+        "two_four_wins_bedwars": 566,
+        "two_four_losses_bedwars": 22,
+        "two_four_beds_broken_bedwars": 124,
+        "two_four_beds_lost_bedwars": 45,
+        "two_four_final_kills_bedwars": 505,
+        "two_four_final_deaths_bedwars": 26,
+        "two_four_kills_bedwars": 569,
+        "two_four_deaths_bedwars": 732
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/schmorr84_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/schmorr84_2024_02_25.json
@@ -54,7 +54,17 @@
         "four_four_beds_lost_bedwars": 8,
         "four_four_final_deaths_bedwars": 9,
         "four_four_kills_bedwars": 6,
-        "four_four_deaths_bedwars": 33
+        "four_four_deaths_bedwars": 33,
+        "two_four_winstreak": 1,
+        "two_four_games_played_bedwars": 113,
+        "two_four_wins_bedwars": 56,
+        "two_four_losses_bedwars": 55,
+        "two_four_beds_broken_bedwars": 6,
+        "two_four_beds_lost_bedwars": 55,
+        "two_four_final_kills_bedwars": 23,
+        "two_four_final_deaths_bedwars": 57,
+        "two_four_kills_bedwars": 110,
+        "two_four_deaths_bedwars": 291
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/slimy55_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/slimy55_2024_02_25.json
@@ -57,7 +57,13 @@
         "four_four_final_kills_bedwars": 67,
         "four_four_final_deaths_bedwars": 370,
         "four_four_kills_bedwars": 438,
-        "four_four_deaths_bedwars": 765
+        "four_four_deaths_bedwars": 765,
+        "two_four_winstreak": 1,
+        "two_four_games_played_bedwars": 2,
+        "two_four_wins_bedwars": 1,
+        "two_four_losses_bedwars": 1,
+        "two_four_kills_bedwars": 1,
+        "two_four_deaths_bedwars": 5
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/stephen0726_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/stephen0726_2024_02_25.json
@@ -55,7 +55,17 @@
         "four_four_final_kills_bedwars": 34,
         "four_four_final_deaths_bedwars": 224,
         "four_four_kills_bedwars": 263,
-        "four_four_deaths_bedwars": 888
+        "four_four_deaths_bedwars": 888,
+        "two_four_winstreak": 0,
+        "two_four_games_played_bedwars": 552,
+        "two_four_wins_bedwars": 184,
+        "two_four_losses_bedwars": 360,
+        "two_four_beds_broken_bedwars": 11,
+        "two_four_beds_lost_bedwars": 318,
+        "two_four_final_kills_bedwars": 88,
+        "two_four_final_deaths_bedwars": 367,
+        "two_four_kills_bedwars": 753,
+        "two_four_deaths_bedwars": 1754
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/technoblade_2022_06_10.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/technoblade_2022_06_10.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 12990,
         "four_four_final_deaths_bedwars": 36,
         "four_four_kills_bedwars": 3489,
-        "four_four_deaths_bedwars": 4483
+        "four_four_deaths_bedwars": 4483,
+        "two_four_games_played_bedwars": 11,
+        "two_four_wins_bedwars": 10,
+        "two_four_losses_bedwars": 1,
+        "two_four_beds_broken_bedwars": 5,
+        "two_four_beds_lost_bedwars": 1,
+        "two_four_final_kills_bedwars": 10,
+        "two_four_final_deaths_bedwars": 1,
+        "two_four_kills_bedwars": 15,
+        "two_four_deaths_bedwars": 14
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/tiltings_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/tiltings_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 29202,
         "four_four_final_deaths_bedwars": 1877,
         "four_four_kills_bedwars": 25005,
-        "four_four_deaths_bedwars": 32819
+        "four_four_deaths_bedwars": 32819,
+        "two_four_games_played_bedwars": 1152,
+        "two_four_wins_bedwars": 1102,
+        "two_four_losses_bedwars": 34,
+        "two_four_beds_broken_bedwars": 312,
+        "two_four_beds_lost_bedwars": 62,
+        "two_four_final_kills_bedwars": 1073,
+        "two_four_final_deaths_bedwars": 39,
+        "two_four_kills_bedwars": 1112,
+        "two_four_deaths_bedwars": 1929
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/tiltingsson_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/tiltingsson_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 19999,
         "four_four_final_deaths_bedwars": 903,
         "four_four_kills_bedwars": 15663,
-        "four_four_deaths_bedwars": 17373
+        "four_four_deaths_bedwars": 17373,
+        "two_four_games_played_bedwars": 2655,
+        "two_four_wins_bedwars": 2624,
+        "two_four_losses_bedwars": 18,
+        "two_four_beds_broken_bedwars": 857,
+        "two_four_beds_lost_bedwars": 31,
+        "two_four_final_kills_bedwars": 2781,
+        "two_four_final_deaths_bedwars": 18,
+        "two_four_kills_bedwars": 1666,
+        "two_four_deaths_bedwars": 1974
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/tqrm_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/tqrm_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 12685,
         "four_four_final_deaths_bedwars": 810,
         "four_four_kills_bedwars": 9830,
-        "four_four_deaths_bedwars": 11635
+        "four_four_deaths_bedwars": 11635,
+        "two_four_games_played_bedwars": 1122,
+        "two_four_wins_bedwars": 1081,
+        "two_four_losses_bedwars": 21,
+        "two_four_beds_broken_bedwars": 308,
+        "two_four_beds_lost_bedwars": 34,
+        "two_four_final_kills_bedwars": 1054,
+        "two_four_final_deaths_bedwars": 21,
+        "two_four_kills_bedwars": 591,
+        "two_four_deaths_bedwars": 1076
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/undefiedd_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/undefiedd_2024_02_25.json
@@ -52,7 +52,16 @@
         "four_four_final_kills_bedwars": 4276,
         "four_four_final_deaths_bedwars": 231,
         "four_four_kills_bedwars": 4635,
-        "four_four_deaths_bedwars": 5873
+        "four_four_deaths_bedwars": 5873,
+        "two_four_games_played_bedwars": 41,
+        "two_four_wins_bedwars": 37,
+        "two_four_losses_bedwars": 3,
+        "two_four_beds_broken_bedwars": 19,
+        "two_four_beds_lost_bedwars": 4,
+        "two_four_final_kills_bedwars": 52,
+        "two_four_final_deaths_bedwars": 3,
+        "two_four_kills_bedwars": 70,
+        "two_four_deaths_bedwars": 97
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/wact_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/wact_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 17442,
         "four_four_final_deaths_bedwars": 767,
         "four_four_kills_bedwars": 12023,
-        "four_four_deaths_bedwars": 17803
+        "four_four_deaths_bedwars": 17803,
+        "two_four_games_played_bedwars": 1236,
+        "two_four_wins_bedwars": 1205,
+        "two_four_losses_bedwars": 4,
+        "two_four_beds_broken_bedwars": 381,
+        "two_four_beds_lost_bedwars": 8,
+        "two_four_final_kills_bedwars": 1437,
+        "two_four_final_deaths_bedwars": 4,
+        "two_four_kills_bedwars": 938,
+        "two_four_deaths_bedwars": 896
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/xLectroLiqhtnin_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/xLectroLiqhtnin_2024_02_25.json
@@ -50,7 +50,16 @@
         "four_four_final_kills_bedwars": 85058,
         "four_four_final_deaths_bedwars": 5493,
         "four_four_kills_bedwars": 45290,
-        "four_four_deaths_bedwars": 117853
+        "four_four_deaths_bedwars": 117853,
+        "two_four_games_played_bedwars": 54,
+        "two_four_wins_bedwars": 51,
+        "two_four_losses_bedwars": 2,
+        "two_four_beds_broken_bedwars": 28,
+        "two_four_beds_lost_bedwars": 3,
+        "two_four_final_kills_bedwars": 44,
+        "two_four_final_deaths_bedwars": 2,
+        "two_four_kills_bedwars": 36,
+        "two_four_deaths_bedwars": 70
       }
     }
   }

--- a/internal/ports/testdata/expected_hypixel_style_responses/yippeyay_2024_02_25.json
+++ b/internal/ports/testdata/expected_hypixel_style_responses/yippeyay_2024_02_25.json
@@ -55,7 +55,17 @@
         "four_four_final_kills_bedwars": 1743,
         "four_four_final_deaths_bedwars": 605,
         "four_four_kills_bedwars": 2222,
-        "four_four_deaths_bedwars": 3469
+        "four_four_deaths_bedwars": 3469,
+        "two_four_winstreak": 0,
+        "two_four_games_played_bedwars": 1811,
+        "two_four_wins_bedwars": 1118,
+        "two_four_losses_bedwars": 682,
+        "two_four_beds_broken_bedwars": 452,
+        "two_four_beds_lost_bedwars": 681,
+        "two_four_final_kills_bedwars": 1356,
+        "two_four_final_deaths_bedwars": 691,
+        "two_four_kills_bedwars": 2855,
+        "two_four_deaths_bedwars": 4356
       }
     }
   }

--- a/internal/ports/wrapped.go
+++ b/internal/ports/wrapped.go
@@ -132,6 +132,7 @@ type winstreakStats struct {
 	Doubles *gamemodeWinstreak `json:"doubles,omitempty"`
 	Threes  *gamemodeWinstreak `json:"threes,omitempty"`
 	Fours   *gamemodeWinstreak `json:"fours,omitempty"`
+	Fourv4  *gamemodeWinstreak `json:"4v4,omitempty"`
 }
 
 type gamemodeWinstreak struct {
@@ -145,6 +146,7 @@ type finalKillStreakStats struct {
 	Doubles *gamemodeFinalKillStreak `json:"doubles,omitempty"`
 	Threes  *gamemodeFinalKillStreak `json:"threes,omitempty"`
 	Fours   *gamemodeFinalKillStreak `json:"fours,omitempty"`
+	Fourv4  *gamemodeFinalKillStreak `json:"4v4,omitempty"`
 }
 
 type gamemodeFinalKillStreak struct {
@@ -608,6 +610,7 @@ func computeWinstreaks(ctx context.Context, playerPITs []domain.PlayerPIT) winst
 	result.Doubles = computeGamemodeWinstreak(func(p *domain.PlayerPIT) domain.GamemodeStatsPIT { return p.Doubles })
 	result.Threes = computeGamemodeWinstreak(func(p *domain.PlayerPIT) domain.GamemodeStatsPIT { return p.Threes })
 	result.Fours = computeGamemodeWinstreak(func(p *domain.PlayerPIT) domain.GamemodeStatsPIT { return p.Fours })
+	result.Fourv4 = computeGamemodeWinstreak(func(p *domain.PlayerPIT) domain.GamemodeStatsPIT { return p.Fourv4 })
 
 	return result
 }
@@ -671,6 +674,7 @@ func computeFinalKillStreaks(ctx context.Context, playerPITs []domain.PlayerPIT)
 	result.Doubles = computeGamemodeFKStreak(func(p *domain.PlayerPIT) domain.GamemodeStatsPIT { return p.Doubles })
 	result.Threes = computeGamemodeFKStreak(func(p *domain.PlayerPIT) domain.GamemodeStatsPIT { return p.Threes })
 	result.Fours = computeGamemodeFKStreak(func(p *domain.PlayerPIT) domain.GamemodeStatsPIT { return p.Fours })
+	result.Fourv4 = computeGamemodeFKStreak(func(p *domain.PlayerPIT) domain.GamemodeStatsPIT { return p.Fourv4 })
 
 	return result
 }

--- a/internal/ports/wrapped_test.go
+++ b/internal/ports/wrapped_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Amund211/flashlight/internal/app"
 	"github.com/Amund211/flashlight/internal/domain"
+	"github.com/Amund211/flashlight/internal/domaintest"
 	"github.com/Amund211/flashlight/internal/ports"
 )
 
@@ -88,6 +89,52 @@ func TestMakeGetWrappedHandler(t *testing.T) {
 		require.Equal(t, true, response["success"])
 		require.Equal(t, uuid, response["uuid"])
 		require.Equal(t, float64(2023), response["year"])
+	})
+
+	t.Run("4v4 win and final kill streaks", func(t *testing.T) {
+		t.Parallel()
+
+		base := time.Date(2023, time.June, 1, 12, 0, 0, 0, time.UTC)
+		pb := domaintest.NewPlayerBuilder(uuid).FromDB().Fourv4()
+		playerPITs := []domain.PlayerPIT{
+			pb.Build(base),
+			pb.WithGamesPlayed(2).WithWins(2).WithFinalKills(3).Build(base.Add(20 * time.Minute)),
+			pb.WithGamesPlayed(3).WithWins(3).WithFinalKills(5).Build(base.Add(40 * time.Minute)),
+			pb.WithGamesPlayed(4).WithLosses(1).WithFinalDeaths(1).Build(base.Add(60 * time.Minute)),
+		}
+		getPlayerPITsFunc, called := makeGetPlayerPITs(t, uuid, playerPITs, nil)
+		handler := makeGetWrappedHandler(getPlayerPITsFunc)
+
+		req := makeRequest(uuid, "2023")
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		require.True(t, *called)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		require.Equal(t, true, response["success"])
+
+		sessionStats, ok := response["sessionStats"].(map[string]interface{})
+		require.True(t, ok)
+
+		winstreaks, ok := sessionStats["winstreaks"].(map[string]interface{})
+		require.True(t, ok)
+		fourv4Winstreak, ok := winstreaks["4v4"].(map[string]interface{})
+		require.True(t, ok)
+		require.Equal(t, float64(3), fourv4Winstreak["highest"])
+		require.Equal(t, "2023-06-01T12:40:00Z", fourv4Winstreak["when"])
+
+		finalKillStreaks, ok := sessionStats["finalKillStreaks"].(map[string]interface{})
+		require.True(t, ok)
+		fourv4FKStreak, ok := finalKillStreaks["4v4"].(map[string]interface{})
+		require.True(t, ok)
+		require.Equal(t, float64(5), fourv4FKStreak["highest"])
+		require.Equal(t, "2023-06-01T12:40:00Z", fourv4FKStreak["when"])
 	})
 
 	t.Run("empty sessions", func(t *testing.T) {


### PR DESCRIPTION
Implements steps F1–F4 of `plans/2026-07-06-4v4-full-support.md` (in the overlay meta-repo): expose the 4v4 gamemode (Hypixel internal `two_four`) on every API surface, now that all stats rows carry a `4v4` block (backfill `docs/2026-07-01-4v4-stats-backfill.md`).

All changes are additive JSON — deployed rainbow ignores unknown keys and prism reads only overall keys, so this is safe to deploy before any frontend change.

## Changes

- **F1a** — `domain.GamemodeFourv4` constant; `domaintest` player builder gains a `Fourv4()` stats builder (overall reconciliation, winstreak handling).
- **F1b** — `buildGameSegment` attributes 4v4 games. Fixes a live bug: a 4v4 game previously hit the "unreachable" default branch and fired a spurious `"overall games played advanced by 1 but no mode did"` report.
- **F2** — rainbow-facing PITs (`/v1/history`, `/v1/sessions`, `/v1/session-at`, `/v1/wrapped`) include a `"4v4"` stats block; session-at game segments can serialize `"gamemode": "4v4"`.
- **F3** — prism-style playerdata (`/v1/playerdata`, deprecated `/playerdata`) includes the `two_four_*` keys (all `omitempty`); golden fixtures regenerated. The unrelated stale-golden churn in `internal/adapters/playerprovider/testdata/` (`"DBID": null`) was left out.
- **F4** — `/v1/wrapped` `winstreaks` / `finalKillStreaks` maps gain an `omitempty` `"4v4"` entry, plus a handler test covering 4v4 win/final-kill streak computation.

## Verification

- `go build ./...` clean, `go test -short -count=1 ./...` green after every commit (pre-commit hook also ran build/lint/test per commit).
- New subtests: `TestBuildGetSessionAt/game_result_computation_per_gamemode/4v4/{win,loss,draw}`, `TestMakeGetWrappedHandler/4v4_win_and_final_kill_streaks`.

Merging this (F5) gates the rainbow-side changes (R1/R2); a rainbow built with 4v4 support crashes on responses lacking the `"4v4"` block, so this must deploy first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
