### PR TITLE
deps: bump Go to 1.26.5 to fix GO-2026-5856

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine AS build
+FROM golang:1.26.5-alpine AS build
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Amund211/flashlight
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/getsentry/sentry-go v0.47.0


### PR DESCRIPTION
The daily `govulncheck` scan fails on `main` with [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856) (Encrypted Client Hello privacy leak in `crypto/tls`), present in the `go1.26.4` stdlib and fixed in `go1.26.5`.

Bumps the `go` directive in `go.mod` and the build image in `Dockerfile` to `1.26.5`. Verified locally: `go tool govulncheck ./...` reports no vulnerabilities.

Fixes the failing scheduled run: https://github.com/Amund211/flashlight/actions/runs/29078421508

🤖 Generated with [Claude Code](https://claude.com/claude-code)
