### PR TITLE
ports: stop sending user-input errors to Sentry

### DIFF
--- a/internal/ports/history.go
+++ b/internal/ports/history.go
@@ -90,9 +90,7 @@ func MakeGetHistoryHandler(
 		}{}
 		err = json.Unmarshal(body, &request)
 		if err != nil {
-			reporting.Report(ctx, fmt.Errorf("failed to parse request body: %w", err), map[string]string{
-				"body": string(body),
-			})
+			logging.FromContext(ctx).WarnContext(ctx, "Failed to parse request body", "error", err, "body", string(body))
 			http.Error(w, "Failed to parse request body", http.StatusBadRequest)
 			return
 		}
@@ -105,9 +103,7 @@ func MakeGetHistoryHandler(
 
 		uuid, err := strutils.NormalizeUUID(request.UUID)
 		if err != nil {
-			reporting.Report(ctx, fmt.Errorf("failed to normalize UUID: %w", err), map[string]string{
-				"rawUUID": request.UUID,
-			})
+			logging.FromContext(ctx).WarnContext(ctx, "Failed to normalize UUID", "error", err, "rawUUID", request.UUID)
 			http.Error(w, "invalid uuid", http.StatusBadRequest)
 			return
 		}
@@ -123,7 +119,7 @@ func MakeGetHistoryHandler(
 		)
 
 		if request.Start.After(request.End) {
-			reporting.Report(ctx, fmt.Errorf("start time is after end time"))
+			logging.FromContext(ctx).WarnContext(ctx, "Start time is after end time")
 			http.Error(w, "Start time cannot be after end time", http.StatusBadRequest)
 			return
 		}

--- a/internal/ports/session_at.go
+++ b/internal/ports/session_at.go
@@ -111,7 +111,7 @@ func MakeGetSessionAtHandler(
 		}{}
 		err = json.Unmarshal(body, &request)
 		if err != nil {
-			reporting.Report(ctx, fmt.Errorf("failed to parse request body: %w", err))
+			logging.FromContext(ctx).WarnContext(ctx, "Failed to parse request body", "error", err)
 			http.Error(w, "Failed to parse request body", http.StatusBadRequest)
 			return
 		}
@@ -122,9 +122,7 @@ func MakeGetSessionAtHandler(
 
 		uuid, err := strutils.NormalizeUUID(request.UUID)
 		if err != nil {
-			reporting.Report(ctx, fmt.Errorf("failed to normalize uuid: %w", err), map[string]string{
-				"rawUUID": request.UUID,
-			})
+			logging.FromContext(ctx).WarnContext(ctx, "Failed to normalize uuid", "error", err, "rawUUID", request.UUID)
 			http.Error(w, "invalid uuid", http.StatusBadRequest)
 			return
 		}

--- a/internal/ports/sessions.go
+++ b/internal/ports/sessions.go
@@ -90,7 +90,7 @@ func MakeGetSessionsHandler(
 		}{}
 		err = json.Unmarshal(body, &request)
 		if err != nil {
-			reporting.Report(ctx, fmt.Errorf("failed to parse request body: %w", err))
+			logging.FromContext(ctx).WarnContext(ctx, "Failed to parse request body", "error", err)
 			http.Error(w, "Failed to parse request body", http.StatusBadRequest)
 			return
 		}
@@ -102,9 +102,7 @@ func MakeGetSessionsHandler(
 
 		uuid, err := strutils.NormalizeUUID(request.UUID)
 		if err != nil {
-			reporting.Report(ctx, fmt.Errorf("failed to normalize uuid: %w", err), map[string]string{
-				"rawUUID": request.UUID,
-			})
+			logging.FromContext(ctx).WarnContext(ctx, "Failed to normalize uuid", "error", err, "rawUUID", request.UUID)
 			http.Error(w, "invalid uuid", http.StatusBadRequest)
 			return
 		}
@@ -119,7 +117,7 @@ func MakeGetSessionsHandler(
 		)
 
 		if request.Start.After(request.End) {
-			reporting.Report(ctx, fmt.Errorf("start time is after end time"))
+			logging.FromContext(ctx).WarnContext(ctx, "Start time is after end time")
 			http.Error(w, "Start time cannot be after end time", http.StatusBadRequest)
 			return
 		}

--- a/internal/reporting/sentry.go
+++ b/internal/reporting/sentry.go
@@ -20,10 +20,17 @@ var uuidRx = regexp.MustCompile(`[0-9a-f]{8}-?([0-9a-f]{4}-?){3}[0-9a-f]{12}`)
 var hostRx = regexp.MustCompile(`\[:{0,2}([0-9a-f]{0,4}:?){1,8}\]:\d+`)
 var usernameRequestRx = regexp.MustCompile(`("https://api\.mojang\.com/users/profiles/minecraft/)[^\s]+?"`)
 
+// invalidUUIDInputRx matches the errors returned by strutils.NormalizeUUID for
+// bad input, scrubbing the user-supplied value quoted after "input: ". The
+// value is high-cardinality client input, so keeping it out of the fingerprint
+// keeps these grouped together.
+var invalidUUIDInputRx = regexp.MustCompile(`((?:invalid character in UUID|normalized UUID has incorrect length)\. input: ').*'`)
+
 func sanitizeError(err string) string {
 	err = uuidRx.ReplaceAllString(err, "<uuid>")
 	err = hostRx.ReplaceAllString(err, "<host>")
 	err = usernameRequestRx.ReplaceAllString(err, `$1<username>"`)
+	err = invalidUUIDInputRx.ReplaceAllString(err, `${1}<value>'`)
 	return err
 }
 

--- a/internal/reporting/sentry_test.go
+++ b/internal/reporting/sentry_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/Amund211/flashlight/internal/strutils"
 )
 
 func TestSanitizeError(t *testing.T) {
@@ -114,6 +116,57 @@ func TestSanitizeError(t *testing.T) {
 				// Real error - double sanitization
 				error: `failed to send request: Get "https://api.mojang.com/users/profiles/minecraft/user123": read tcp [fddf:1111:ffff:dddd::c123]:34567->[1234:1b3:51:1::27]:443: read: connection reset by peer`,
 				want:  `failed to send request: Get "https://api.mojang.com/users/profiles/minecraft/<username>": read tcp <host>-><host>: read: connection reset by peer`,
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.error, func(t *testing.T) {
+				t.Parallel()
+
+				require.Equal(t, tc.want, sanitizeError(tc.error))
+			})
+		}
+	})
+
+	t.Run("invalid uuid input", func(t *testing.T) {
+		t.Parallel()
+
+		// Generate the real errors from NormalizeUUID so the regex stays in
+		// sync with the actual message format.
+		invalidCharErr := func(input string) string {
+			_, err := strutils.NormalizeUUID(input)
+			require.Error(t, err)
+			return err.Error()
+		}
+
+		cases := []struct {
+			error string
+			want  string
+		}{
+			{
+				// Real error - invalid character
+				error: invalidCharErr("not-a-uuid!"),
+				want:  `invalid character in UUID. input: '<value>'`,
+			},
+			{
+				// Real error - incorrect length
+				error: invalidCharErr("abc"),
+				want:  `normalized UUID has incorrect length. input: '<value>'`,
+			},
+			{
+				// Real error - value containing a single quote
+				error: invalidCharErr("a'b"),
+				want:  `invalid character in UUID. input: '<value>'`,
+			},
+			{
+				// Wrapped error
+				error: fmt.Errorf("failed to normalize uuid: %w", fmt.Errorf("%s", invalidCharErr("bad uuid"))).Error(),
+				want:  `failed to normalize uuid: invalid character in UUID. input: '<value>'`,
+			},
+			{
+				// Constructed - unrelated "input:" text is not scrubbed
+				error: `some other error. input: 'keepme'`,
+				want:  `some other error. input: 'keepme'`,
 			},
 		}
 


### PR DESCRIPTION
User mistakes (malformed request bodies, invalid UUIDs, start-after-end times) return 400 and aren't service faults, so they don't belong in Sentry.

- **ports**: the 8 relevant `reporting.Report` calls in the session/history/session-at handlers now warn-log instead, keeping the same context (raw uuid, body, error). Response marshal/conversion failures, body-read errors, and infra invariants (e.g. missing `X-Forwarded-For`) still report as before.
- **reporting**: scrub the raw input out of the invalid-UUID error fingerprint so any such errors that still reach Sentry (e.g. wrapped from elsewhere) group together instead of one fingerprint per input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)