### PR TITLE
feat: Log input params in each port

### DIFF
--- a/internal/ports/auth_anonymous_login.go
+++ b/internal/ports/auth_anonymous_login.go
@@ -67,6 +67,10 @@ func MakeAnonymousLoginHandler(
 			)
 		}
 
+		logging.FromContext(ctx).InfoContext(ctx, "Handling auth-anonymous-login request",
+			slog.String("bodyUserId", body.UserID),
+		)
+
 		ipHash := GetIP(r).Hash()
 
 		sess, err := login(ctx, body.UserID, ipHash)

--- a/internal/ports/get_account_by_username.go
+++ b/internal/ports/get_account_by_username.go
@@ -73,6 +73,10 @@ func MakeGetAccountByUsernameHandler(
 		ctx := r.Context()
 		username := r.PathValue("username")
 
+		logging.FromContext(ctx).InfoContext(ctx, "Handling get_account_by_username request",
+			slog.String("username", username),
+		)
+
 		handleError := func(ctx context.Context, cause string, statusCode int) {
 			response, err := makeErrorAccountResponseForUsername(ctx, username, cause)
 			if err != nil {

--- a/internal/ports/get_account_by_uuid.go
+++ b/internal/ports/get_account_by_uuid.go
@@ -86,6 +86,10 @@ func MakeGetAccountByUUIDHandler(
 			return
 		}
 
+		logging.FromContext(ctx).InfoContext(ctx, "Handling get_account_by_uuid request",
+			slog.String("uuid", uuid),
+		)
+
 		ctx = logging.AddMetaToContext(ctx,
 			slog.String("uuid", uuid),
 		)

--- a/internal/ports/history.go
+++ b/internal/ports/history.go
@@ -108,6 +108,13 @@ func MakeGetHistoryHandler(
 			return
 		}
 
+		logging.FromContext(ctx).InfoContext(ctx, "Handling history request",
+			slog.String("uuid", uuid),
+			slog.String("start", request.Start.Format(time.RFC3339)),
+			slog.String("end", request.End.Format(time.RFC3339)),
+			slog.Int("limit", request.Limit),
+		)
+
 		ctx = reporting.AddExtrasToContext(ctx, map[string]string{
 			"uuid": uuid,
 		})

--- a/internal/ports/player_data.go
+++ b/internal/ports/player_data.go
@@ -93,6 +93,11 @@ func MakeGetPlayerDataHandler(
 		}
 
 		rawUUID := r.URL.Query().Get("uuid")
+
+		logging.FromContext(ctx).InfoContext(ctx, "Handling playerdata request",
+			slog.String("uuid", rawUUID),
+		)
+
 		ctx = logging.AddMetaToContext(ctx,
 			slog.String("uuid", rawUUID),
 		)

--- a/internal/ports/prestiges.go
+++ b/internal/ports/prestiges.go
@@ -84,6 +84,11 @@ func MakeGetPrestigesHandler(
 		ctx := r.Context()
 
 		rawUUID := r.PathValue("uuid")
+
+		logging.FromContext(ctx).InfoContext(ctx, "Handling prestiges request",
+			slog.String("uuid", rawUUID),
+		)
+
 		ctx = logging.AddMetaToContext(ctx,
 			slog.String("uuid", rawUUID),
 		)

--- a/internal/ports/prism_notices.go
+++ b/internal/ports/prism_notices.go
@@ -113,6 +113,11 @@ func MakePrismNoticesHandler(
 
 		rawSelection := r.URL.Query().Get("includeVersionUpdates")
 
+		logging.FromContext(ctx).InfoContext(ctx, "Handling prism-notices request",
+			slog.String("prismVersion", prismVersion),
+			slog.String("includeVersionUpdates", rawSelection),
+		)
+
 		ctx = logging.AddMetaToContext(ctx,
 			slog.String("prismVersion", prismVersion),
 			slog.String("includeVersionUpdates", rawSelection),

--- a/internal/ports/session_at.go
+++ b/internal/ports/session_at.go
@@ -132,6 +132,11 @@ func MakeGetSessionAtHandler(
 			return
 		}
 
+		logging.FromContext(ctx).InfoContext(ctx, "Handling session-at request",
+			slog.String("uuid", uuid),
+			slog.String("time", request.Time.Format(time.RFC3339)),
+		)
+
 		ctx = reporting.AddExtrasToContext(ctx, map[string]string{
 			"uuid": uuid,
 		})

--- a/internal/ports/sessions.go
+++ b/internal/ports/sessions.go
@@ -107,6 +107,12 @@ func MakeGetSessionsHandler(
 			return
 		}
 
+		logging.FromContext(ctx).InfoContext(ctx, "Handling sessions request",
+			slog.String("uuid", uuid),
+			slog.String("start", request.Start.Format(time.RFC3339)),
+			slog.String("end", request.End.Format(time.RFC3339)),
+		)
+
 		ctx = reporting.AddExtrasToContext(ctx, map[string]string{
 			"uuid": uuid,
 		})

--- a/internal/ports/tags.go
+++ b/internal/ports/tags.go
@@ -110,6 +110,11 @@ func MakeGetTagsHandler(
 			return
 		}
 
+		logging.FromContext(ctx).InfoContext(ctx, "Handling tags request",
+			slog.String("uuid", uuid),
+			slog.Bool("hasUrchinApiKey", urchinAPIKey != nil),
+		)
+
 		ctx = reporting.AddExtrasToContext(ctx,
 			map[string]string{
 				"uuid": uuid,

--- a/internal/ports/wrapped.go
+++ b/internal/ports/wrapped.go
@@ -227,6 +227,13 @@ func MakeGetWrappedHandler(
 
 		rawUUID := r.PathValue("uuid")
 		rawYear := r.PathValue("year")
+
+		logging.FromContext(ctx).InfoContext(ctx, "Handling wrapped request",
+			slog.String("uuid", rawUUID),
+			slog.String("year", rawYear),
+			slog.String("timezone", r.URL.Query().Get("timezone")),
+		)
+
 		ctx = logging.AddMetaToContext(ctx,
 			slog.String("uuid", rawUUID),
 			slog.String("year", rawYear),


### PR DESCRIPTION
## What

Adds an explicit `logging.FromContext(ctx).InfoContext(ctx, "Handling <port> request", ...)` line to every HTTP port in `internal/ports/`, logging that request's non-sensitive input params inline on a single, greppable line.

**Motivation:** make it easy to understand query patterns from the logs — a consistent per-port line with all params as structured fields.

Previously, param logging relied on scattered `AddMetaToContext` enrichment that only surfaced if a handler happened to emit a later log line; some ports / error paths logged nothing, and the middleware's `Finished handling request` line never carries handler-added meta.

## Ports & params

| Port | params logged |
|---|---|
| prism-notices | `prismVersion`, `includeVersionUpdates` |
| playerdata | `uuid` |
| tags | `uuid`, `hasUrchinApiKey` |
| auth-anonymous-login | `bodyUserId` |
| get_account_by_username | `username` |
| get_account_by_uuid | `uuid` |
| history | `uuid`, `start`, `end`, `limit` |
| sessions | `uuid`, `start`, `end` |
| session-at | `uuid`, `time` |
| prestiges | `uuid` |
| wrapped | `uuid`, `year`, `timezone` |

`auth-refresh` is intentionally skipped — its only inputs are the bearer token (sensitive) and the IP (already logged hashed by middleware).

## Sensitive data

- IP stays hashed via existing middleware (never logged raw).
- Bearer/session tokens are never logged.
- The Urchin API key value is never logged — only a `hasUrchinApiKey` boolean.
- Existing `AddMetaToContext` / `reporting.AddExtrasToContext` calls are left untouched.

## Verification

- `go build ./...`, `go test ./internal/ports/...`, golangci-lint all pass (pre-commit hook).
- Drove the tags handler end-to-end with a buffer-backed logger: confirmed the `Handling tags request` line carries `uuid` + `hasUrchinApiKey`, the API key value never appears in any log line, and there are no duplicate JSON keys (params don't collide with the middleware's `.With` fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)