### PR TITLE
fix: Drop high-cardinality attributes from request metrics

### DIFF
--- a/internal/ports/metrics.go
+++ b/internal/ports/metrics.go
@@ -66,24 +66,45 @@ func init() {
 	}
 }
 
+// knownMethods bounds the cardinality of the "method" metric label. r.Method is
+// client-controlled — Go's HTTP server accepts any valid HTTP token as a method,
+// not just the standard verbs — so anything outside this allow-list is collapsed
+// to "other" to keep handler × method series bounded regardless of input.
+var knownMethods = map[string]struct{}{
+	http.MethodGet:     {},
+	http.MethodHead:    {},
+	http.MethodPost:    {},
+	http.MethodPut:     {},
+	http.MethodPatch:   {},
+	http.MethodDelete:  {},
+	http.MethodConnect: {},
+	http.MethodOptions: {},
+	http.MethodTrace:   {},
+}
+
+func normalizeMethod(method string) string {
+	if _, ok := knownMethods[method]; ok {
+		return method
+	}
+	return "other"
+}
+
 func buildMetricsMiddleware(handler string) func(http.HandlerFunc) http.HandlerFunc {
 	return func(next http.HandlerFunc) http.HandlerFunc {
 		return func(w http.ResponseWriter, r *http.Request) {
 			start := time.Now()
 			ctx := r.Context()
 
-			userAgent := r.UserAgent()
-
-			// NOTE: Potentially high cardinality label
-			ipHash := GetIP(r).Hash()
-
 			next(w, r)
 
+			// NOTE: Only attach bounded attributes here. High-cardinality
+			// values (user agent, IP hash, etc.) would blow past the
+			// OpenTelemetry per-instrument cardinality limit (default 2000)
+			// and collapse into a single otel.metric.overflow series. They
+			// belong in logs/traces, not metric labels.
 			attributes := []attribute.KeyValue{
-				attribute.String("method", r.Method),
+				attribute.String("method", normalizeMethod(r.Method)),
 				attribute.String("handler", handler),
-				attribute.String("user_agent", userAgent),
-				attribute.String("ip_hash", ipHash),
 			}
 
 			attributesOption := metric.WithAttributes(attributes...)

--- a/internal/ports/metrics_internal_test.go
+++ b/internal/ports/metrics_internal_test.go
@@ -1,0 +1,27 @@
+package ports
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestNormalizeMethod(t *testing.T) {
+	cases := map[string]string{
+		http.MethodGet:     "GET",
+		http.MethodPost:    "POST",
+		http.MethodHead:    "HEAD",
+		http.MethodOptions: "OPTIONS",
+		http.MethodDelete:  "DELETE",
+		// Non-standard / attacker-controlled tokens collapse to "other".
+		"FOOBAR":     "other",
+		"get":        "other", // methods are case-sensitive
+		"":           "other",
+		"GET /admin": "other",
+	}
+
+	for method, want := range cases {
+		if got := normalizeMethod(method); got != want {
+			t.Errorf("normalizeMethod(%q) = %q, want %q", method, got, want)
+		}
+	}
+}

--- a/internal/ports/middleware.go
+++ b/internal/ports/middleware.go
@@ -87,10 +87,10 @@ func NewRateLimitMiddleware(rateLimiter ratelimiting.RequestRateLimiter, onLimit
 					slog.String("userId", userID.String()),
 				)
 
-				attributes := []attribute.KeyValue{
-					attribute.String("ip_hash", ipHash),
-				}
-				metrics.ratelimitedRequestCount.Add(ctx, 1, metric.WithAttributes(attributes...))
+				// NOTE: ip_hash is high-cardinality and is captured in the log
+				// above; keep it off the metric to stay under the OpenTelemetry
+				// cardinality limit.
+				metrics.ratelimitedRequestCount.Add(ctx, 1)
 
 				onLimitExceeded(w, r)
 				return


### PR DESCRIPTION
## Problem

A metrics investigation into `prometheus.googleapis.com/ports_request_count_total/counter` found the **largest series had no `handler` label** and was growing at ~5.7/s (vs. `playerdata`'s 0.24/s).

Querying Google Managed Prometheus showed why:

- `count(ports_request_count_total)` was pinned at **exactly 2000**.
- The no-handler series carried **`otel_metric_overflow="true"`**.

That's the OpenTelemetry Go SDK's [default per-instrument cardinality limit of 2000](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric). `buildMetricsMiddleware` attached `user_agent` (the full UA string) and `ip_hash` to `request_count` / `request_duration_seconds`, and `NewRateLimitMiddleware` attached `ip_hash` to `ratelimited_request_count`. These are effectively unbounded, so the instrument saturated the 2000-series cap. Once saturated, every further measurement collapses into a single `otel.metric.overflow=true` point with **all attributes stripped** — surfacing in Managed Prometheus as one giant handler-less series, while starving the real per-handler series of slots and undercounting them (`playerdata` alone already held 1,995 distinct series from UA/IP combinations).

The earlier `f72c718` (`path` → `handler`) change removed one high-cardinality label but left these two, which are worse.

## Change

Attach only **bounded** attributes to these metrics:

| Metric | Before | After |
|---|---|---|
| `ports/request_count` | method, handler, **user_agent, ip_hash** | method, handler |
| `ports/request_duration_seconds` | method, handler, **user_agent, ip_hash** | method, handler |
| `ports/ratelimited_request_count` | **ip_hash** | (none) |

All other metrics already use bounded bool/enum attributes (`status_code`, `source`, tag flags) and are unchanged. The high-cardinality values are still captured in the request logs, so nothing observable is lost.

This drops the metric's cardinality from 2000 (saturated) to roughly `handlers × methods` (~dozens), eliminates the overflow bucket, and makes the per-handler breakdown accurate again.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt` — clean
- `go test ./internal/ports/...` — pass
- No tests assert on metric attributes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
