### PR TITLE
feat: Add providerMode to get-and-persist player

### DIFF
--- a/internal/adapters/playerrepository/interface.go
+++ b/internal/adapters/playerrepository/interface.go
@@ -9,6 +9,9 @@ import (
 
 type PlayerRepository interface {
 	StorePlayer(ctx context.Context, player *domain.PlayerPIT) error
+	// GetPlayer returns the most recently stored PlayerPIT for the given UUID.
+	// Returns domain.ErrPlayerNotFound if no stats are stored for the UUID.
+	GetPlayer(ctx context.Context, playerUUID string) (*domain.PlayerPIT, error)
 	GetHistory(ctx context.Context, playerUUID string, start, end time.Time, limit int) ([]domain.PlayerPIT, error)
 	GetPlayerPITs(ctx context.Context, playerUUID string, start, end time.Time) ([]domain.PlayerPIT, error)
 	FindMilestoneAchievements(ctx context.Context, playerUUID string, gamemode domain.Gamemode, stat domain.Stat, milestones []int64) ([]domain.MilestoneAchievement, error)

--- a/internal/adapters/playerrepository/repository.go
+++ b/internal/adapters/playerrepository/repository.go
@@ -291,6 +291,69 @@ func (p *PostgresPlayerRepository) StorePlayer(ctx context.Context, player *doma
 	return nil
 }
 
+func (p *PostgresPlayerRepository) GetPlayer(ctx context.Context, playerUUID string) (*domain.PlayerPIT, error) {
+	ctx, span := p.tracer.Start(ctx, "PostgresPlayerRepository.GetPlayer")
+	defer span.End()
+
+	if !strutils.UUIDIsNormalized(playerUUID) {
+		err := fmt.Errorf("uuid is not normalized")
+		reporting.Report(ctx, err, map[string]string{
+			"uuid": playerUUID,
+		})
+		return nil, err
+	}
+
+	conn, err := p.db.Connx(ctx)
+	if err != nil {
+		err := fmt.Errorf("failed to get connection: %w", err)
+		reporting.Report(ctx, err)
+		return nil, err
+	}
+	defer conn.Close()
+
+	_, err = conn.ExecContext(ctx, fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(p.schema)))
+	if err != nil {
+		err := fmt.Errorf("failed to set search path: %w", err)
+		reporting.Report(ctx, err, map[string]string{
+			"schema": p.schema,
+		})
+		return nil, err
+	}
+
+	var stat dbStat
+	err = conn.GetContext(
+		ctx,
+		&stat,
+		`select
+			id, data_format_version, player_uuid, queried_at, player_data
+		from stats
+		where player_uuid = $1
+		order by queried_at desc
+		limit 1`,
+		playerUUID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, domain.ErrPlayerNotFound
+	}
+	if err != nil {
+		err := fmt.Errorf("failed to select most recent stat: %w", err)
+		reporting.Report(ctx, err, map[string]string{
+			"uuid": playerUUID,
+		})
+		return nil, err
+	}
+
+	player, err := dbStatToPlayerPIT(stat)
+	if err != nil {
+		err := fmt.Errorf("failed to convert db stat to playerpit: %w", err)
+		reporting.Report(ctx, err, map[string]string{
+			"statID": stat.ID,
+		})
+		return nil, err
+	}
+
+	return player, nil
+}
+
 func (p *PostgresPlayerRepository) GetHistory(ctx context.Context, playerUUID string, start, end time.Time, limit int) ([]domain.PlayerPIT, error) {
 	ctx, span := p.tracer.Start(ctx, "PostgresPlayerRepository.GetHistory")
 	defer span.End()
@@ -708,6 +771,10 @@ type StubPlayerRepository struct{}
 
 func (p *StubPlayerRepository) StorePlayer(ctx context.Context, player *domain.PlayerPIT) error {
 	return nil
+}
+
+func (p *StubPlayerRepository) GetPlayer(ctx context.Context, playerUUID string) (*domain.PlayerPIT, error) {
+	return nil, domain.ErrPlayerNotFound
 }
 
 func (p *StubPlayerRepository) GetHistory(ctx context.Context, playerUUID string, start, end time.Time, limit int) ([]domain.PlayerPIT, error) {

--- a/internal/adapters/playerrepository/repository_test.go
+++ b/internal/adapters/playerrepository/repository_test.go
@@ -383,6 +383,50 @@ func TestPostgresPlayerRepository(t *testing.T) {
 		})
 	})
 
+	t.Run("GetPlayer", func(t *testing.T) {
+		t.Parallel()
+		p := newPostgresPlayerRepository(t, db, "get_player_tests")
+
+		now := time.Now().Truncate(time.Millisecond)
+
+		t.Run("returns the most recently queried stats", func(t *testing.T) {
+			t.Parallel()
+
+			playerUUID := domaintest.NewUUID(t)
+
+			p1 := domaintest.NewPlayerBuilder(playerUUID).Fours().WithGamesPlayed(1).BuildPtr(now.Add(-2 * time.Hour))
+			p2 := domaintest.NewPlayerBuilder(playerUUID).Fours().WithGamesPlayed(2).BuildPtr(now)
+			p3 := domaintest.NewPlayerBuilder(playerUUID).Fours().WithGamesPlayed(3).BuildPtr(now.Add(-1 * time.Hour))
+
+			require.NoError(t, p.StorePlayer(ctx, p1))
+			require.NoError(t, p.StorePlayer(ctx, p2))
+			require.NoError(t, p.StorePlayer(ctx, p3))
+
+			player, err := p.GetPlayer(ctx, playerUUID)
+			require.NoError(t, err)
+			require.Equal(t, playerUUID, player.UUID)
+			require.WithinDuration(t, p2.QueriedAt, player.QueriedAt, 0)
+			require.Equal(t, 2, player.Fours.GamesPlayed)
+			requireValidDBID(t, player.DBID)
+		})
+
+		t.Run("returns ErrPlayerNotFound when no stats are stored", func(t *testing.T) {
+			t.Parallel()
+
+			playerUUID := domaintest.NewUUID(t)
+
+			_, err := p.GetPlayer(ctx, playerUUID)
+			require.ErrorIs(t, err, domain.ErrPlayerNotFound)
+		})
+
+		t.Run("errors on un-normalized uuid", func(t *testing.T) {
+			t.Parallel()
+
+			_, err := p.GetPlayer(ctx, "not-a-uuid")
+			require.Error(t, err)
+		})
+	})
+
 	t.Run("GetPlayerPITs", func(t *testing.T) {
 		t.Parallel()
 		p := newPostgresPlayerRepository(t, db, "get_player_pits_tests")

--- a/internal/app/get_and_persist.go
+++ b/internal/app/get_and_persist.go
@@ -19,7 +19,39 @@ import (
 	"github.com/Amund211/flashlight/internal/strutils"
 )
 
-type GetAndPersistPlayerWithCache func(ctx context.Context, uuid string) (*domain.PlayerPIT, error)
+// ProviderMode controls how GetAndPersistPlayerWithCache sources player data.
+type ProviderMode string
+
+const (
+	// ProviderModeAlways always queries the player provider (Hypixel) for fresh
+	// data and persists it. This is the original behaviour.
+	ProviderModeAlways ProviderMode = "always"
+	// ProviderModeFallback returns the most recent stored stats when we have
+	// them, only querying the provider when we have no stored stats for the
+	// player.
+	ProviderModeFallback ProviderMode = "fallback"
+	// ProviderModeNever never queries the provider. If we have no stored stats
+	// for the player the request fails.
+	ProviderModeNever ProviderMode = "never"
+)
+
+func (m ProviderMode) validate() error {
+	switch m {
+	case ProviderModeAlways, ProviderModeFallback, ProviderModeNever:
+		return nil
+	default:
+		return fmt.Errorf("invalid provider mode: %q", string(m))
+	}
+}
+
+type GetAndPersistPlayerWithCache func(ctx context.Context, uuid string, providerMode ProviderMode) (*domain.PlayerPIT, error)
+
+// displaynameAccountRepository resolves a username from our own account store.
+// The player stats repository does not store usernames, so we resolve them
+// separately when serving stats from the repository.
+type displaynameAccountRepository interface {
+	GetAccountByUUID(ctx context.Context, uuid string) (domain.Account, error)
+}
 
 type getAndPersistPlayerMetricsCollection struct {
 	returnCount metric.Int64Counter
@@ -64,6 +96,8 @@ func BuildGetAndPersistPlayerWithCache(
 	playerCache cache.Cache[*domain.PlayerPIT],
 	provider playerprovider.PlayerProvider,
 	repo playerrepository.PlayerRepository,
+	accountRepo displaynameAccountRepository,
+	getAccountByUUID GetAccountByUUID,
 ) (GetAndPersistPlayerWithCache, error) {
 	const name = "flashlight/app/get_and_persist_player_with_cache"
 
@@ -79,6 +113,7 @@ func BuildGetAndPersistPlayerWithCache(
 		found        bool
 		cached       bool
 		invalidInput bool
+		providerMode ProviderMode
 	}
 
 	track := func(ctx context.Context, info trackingInfo) {
@@ -90,34 +125,101 @@ func BuildGetAndPersistPlayerWithCache(
 				attribute.Bool("found", info.found),
 				attribute.Bool("cached", info.cached),
 				attribute.Bool("invalid_input", info.invalidInput),
+				attribute.String("provider_mode", string(info.providerMode)),
 			),
 		)
 	}
 
-	return func(ctx context.Context, uuid string) (*domain.PlayerPIT, error) {
+	// resolveDisplayname resolves a player's current username. The stats
+	// repository does not store usernames, so when we serve stats from the
+	// repository we resolve the name separately. We check our own account store
+	// first and only query the provider when we don't have it stored.
+	resolveDisplayname := func(ctx context.Context, uuid string) *string {
+		account, err := accountRepo.GetAccountByUUID(ctx, uuid)
+		if err != nil {
+			// Not stored (or lookup failed) -> resolve via the account use case,
+			// which queries the provider and persists the result.
+			// NOTE: accountRepo / getAccountByUUID handle their own error reporting.
+			account, err = getAccountByUUID(ctx, uuid)
+			if err != nil {
+				// The username is non-critical -> return the stats without it.
+				logging.FromContext(ctx).WarnContext(ctx, "Failed to resolve username for repository player", "uuid", uuid, "error", err.Error())
+				return nil
+			}
+		}
+		username := account.Username
+		return &username
+	}
+
+	return func(ctx context.Context, uuid string, providerMode ProviderMode) (*domain.PlayerPIT, error) {
+		if err := providerMode.validate(); err != nil {
+			logging.FromContext(ctx).ErrorContext(ctx, "Invalid provider mode", "providerMode", string(providerMode))
+			reporting.Report(ctx, err, map[string]string{
+				"providerMode": string(providerMode),
+			})
+			track(ctx, trackingInfo{success: false, invalidInput: true, providerMode: "invalid"})
+			return nil, err
+		}
+
 		if !strutils.UUIDIsNormalized(uuid) {
 			logging.FromContext(ctx).ErrorContext(ctx, "UUID is not normalized", "uuid", uuid)
 			err := fmt.Errorf("UUID is not normalized")
 			reporting.Report(ctx, err)
-			track(ctx, trackingInfo{success: false, invalidInput: true})
+			track(ctx, trackingInfo{success: false, invalidInput: true, providerMode: providerMode})
 			return nil, err
 		}
 
-		player, created, err := cache.GetOrCreate(ctx, playerCache, uuid, func() (*domain.PlayerPIT, error) {
-			return getAndPersistPlayerWithoutCache(ctx, provider, repo, uuid)
+		// Include the provider mode in the cache key so requests with different
+		// modes don't serve each other's (differently-sourced) results.
+		cacheKey := string(providerMode) + ":" + uuid
+
+		player, created, err := cache.GetOrCreate(ctx, playerCache, cacheKey, func() (*domain.PlayerPIT, error) {
+			switch providerMode {
+			case ProviderModeAlways:
+				return getAndPersistPlayerWithoutCache(ctx, provider, repo, uuid)
+			case ProviderModeFallback:
+				repoPlayer, err := repo.GetPlayer(ctx, uuid)
+				if err == nil {
+					repoPlayer.Displayname = resolveDisplayname(ctx, uuid)
+					return repoPlayer, nil
+				}
+				if !errors.Is(err, domain.ErrPlayerNotFound) {
+					// NOTE: PlayerRepository implementations handle their own error reporting
+					logging.FromContext(ctx).WarnContext(ctx, "Failed to read player from repository, falling back to provider", "error", err.Error())
+				}
+				// No stored stats (or lookup failed) -> fetch from the provider
+				return getAndPersistPlayerWithoutCache(ctx, provider, repo, uuid)
+			case ProviderModeNever:
+				repoPlayer, err := repo.GetPlayer(ctx, uuid)
+				if err == nil {
+					repoPlayer.Displayname = resolveDisplayname(ctx, uuid)
+					return repoPlayer, nil
+				}
+				if errors.Is(err, domain.ErrPlayerNotFound) {
+					// Provider mode is never -> we don't query the provider.
+					// Return a generic error (not ErrPlayerNotFound) so the caller
+					// responds with a 500 rather than a 404.
+					return nil, fmt.Errorf("player not stored and provider mode is %q", providerMode)
+				}
+				// NOTE: PlayerRepository implementations handle their own error reporting
+				return nil, fmt.Errorf("failed to get player from repository: %w", err)
+			default:
+				// Unreachable: providerMode was validated above.
+				return nil, fmt.Errorf("invalid provider mode: %q", providerMode)
+			}
 		})
 		if err != nil {
 			// NOTE: GetOrCreate only returns an error if create() fails.
-			// getAndPersistPlayerWithoutCache handles its own error reporting
+			// The create functions handle their own error reporting.
 			if errors.Is(err, domain.ErrPlayerNotFound) {
-				track(ctx, trackingInfo{success: true, found: false})
+				track(ctx, trackingInfo{success: true, found: false, providerMode: providerMode})
 			} else {
-				track(ctx, trackingInfo{success: false})
+				track(ctx, trackingInfo{success: false, providerMode: providerMode})
 			}
 			return nil, fmt.Errorf("failed to cache.GetOrCreate player data: %w", err)
 		}
 
-		track(ctx, trackingInfo{success: true, found: true, cached: !created})
+		track(ctx, trackingInfo{success: true, found: true, cached: !created, providerMode: providerMode})
 		return player, nil
 	}, nil
 }
@@ -155,7 +257,7 @@ func BuildUpdatePlayerInInterval(
 		}
 
 		// This is a current interval -> fetch new data and persist it to the repository
-		_, err := getAndPersistPlayerWithCache(ctx, uuid)
+		_, err := getAndPersistPlayerWithCache(ctx, uuid, ProviderModeFallback)
 		if err != nil {
 			// NOTE: GetAndPersistPlayerWithCache implementations handle their own error reporting
 			return fmt.Errorf("failed to get updated player data: %w", err)

--- a/internal/app/get_and_persist_test.go
+++ b/internal/app/get_and_persist_test.go
@@ -42,6 +42,30 @@ func (m *mockedPlayerProvider) GetPlayer(ctx context.Context, uuid string) (*dom
 	return m.player, m.err
 }
 
+type stubAccountRepositoryByUUID struct {
+	account domain.Account
+	err     error
+}
+
+func (s stubAccountRepositoryByUUID) GetAccountByUUID(ctx context.Context, uuid string) (domain.Account, error) {
+	return s.account, s.err
+}
+
+// fakePlayerRepository lets tests configure the result of GetPlayer while
+// inheriting the no-op behaviour of the stub repository for everything else.
+type fakePlayerRepository struct {
+	*playerrepository.StubPlayerRepository
+	player       *domain.PlayerPIT
+	getPlayerErr error
+}
+
+func (f *fakePlayerRepository) GetPlayer(ctx context.Context, uuid string) (*domain.PlayerPIT, error) {
+	if f.getPlayerErr != nil {
+		return nil, f.getPlayerErr
+	}
+	return f.player, nil
+}
+
 func TestGetAndPersistPlayer(t *testing.T) {
 	t.Parallel()
 
@@ -51,8 +75,12 @@ func TestGetAndPersistPlayer(t *testing.T) {
 		t.Helper()
 
 		repo := playerrepository.NewStubPlayerRepository()
+		accountRepo := stubAccountRepositoryByUUID{err: domain.ErrUsernameNotFound}
+		getAccountByUUID := func(ctx context.Context, uuid string) (domain.Account, error) {
+			return domain.Account{}, domain.ErrUsernameNotFound
+		}
 
-		usecase, err := BuildGetAndPersistPlayerWithCache(cache, provider, repo)
+		usecase, err := BuildGetAndPersistPlayerWithCache(cache, provider, repo, accountRepo, getAccountByUUID)
 		require.NoError(t, err)
 
 		return usecase
@@ -69,10 +97,10 @@ func TestGetAndPersistPlayer(t *testing.T) {
 		panicProvider := &panicPlayerProvider{t: t}
 		cache := cache.NewBasicCache[*domain.PlayerPIT]()
 
-		_, err := mustBuildGetAndPersistPlayerWithCache(t, cache, provider)(t.Context(), UUID)
+		_, err := mustBuildGetAndPersistPlayerWithCache(t, cache, provider)(t.Context(), UUID, ProviderModeAlways)
 		require.NoError(t, err)
 
-		_, err = mustBuildGetAndPersistPlayerWithCache(t, cache, panicProvider)(t.Context(), UUID)
+		_, err = mustBuildGetAndPersistPlayerWithCache(t, cache, panicProvider)(t.Context(), UUID, ProviderModeAlways)
 		require.NoError(t, err)
 	})
 
@@ -90,7 +118,7 @@ func TestGetAndPersistPlayer(t *testing.T) {
 			}
 			cache := cache.NewBasicCache[*domain.PlayerPIT]()
 
-			_, err := mustBuildGetAndPersistPlayerWithCache(t, cache, provider)(t.Context(), "01234567-89ab-cdef-0123-456789abcdef")
+			_, err := mustBuildGetAndPersistPlayerWithCache(t, cache, provider)(t.Context(), "01234567-89ab-cdef-0123-456789abcdef", ProviderModeAlways)
 			require.ErrorIs(t, err, providerErr)
 		}
 	})
@@ -114,7 +142,7 @@ func TestGetAndPersistPlayer(t *testing.T) {
 			t.Run(fmt.Sprintf("UUID: '%s'", uuid), func(t *testing.T) {
 				t.Parallel()
 
-				_, err := mustBuildGetAndPersistPlayerWithCache(t, cache, provider)(t.Context(), uuid)
+				_, err := mustBuildGetAndPersistPlayerWithCache(t, cache, provider)(t.Context(), uuid, ProviderModeAlways)
 				require.Error(t, err)
 			})
 		}
@@ -174,9 +202,10 @@ func TestUpdatePlayerInInterval(t *testing.T) {
 			testUUID := "01234567-9999-9999-0123-456789abcdef"
 
 			updated := false
-			getAndPersist := func(ctx context.Context, uuid string) (*domain.PlayerPIT, error) {
+			getAndPersist := func(ctx context.Context, uuid string, providerMode ProviderMode) (*domain.PlayerPIT, error) {
 				t.Helper()
 				require.Equal(t, testUUID, uuid)
+				require.Equal(t, ProviderModeFallback, providerMode)
 				updated = true
 				return nil, nil
 			}
@@ -200,9 +229,10 @@ func TestUpdatePlayerInInterval(t *testing.T) {
 		testUUID := "01234567-0000-9999-0123-456789abcdef"
 
 		called := false
-		getAndPersist := func(ctx context.Context, uuid string) (*domain.PlayerPIT, error) {
+		getAndPersist := func(ctx context.Context, uuid string, providerMode ProviderMode) (*domain.PlayerPIT, error) {
 			t.Helper()
 			require.Equal(t, testUUID, uuid)
+			require.Equal(t, ProviderModeFallback, providerMode)
 			called = true
 			return nil, assert.AnError
 		}
@@ -213,5 +243,144 @@ func TestUpdatePlayerInInterval(t *testing.T) {
 		require.ErrorIs(t, err, assert.AnError)
 
 		require.True(t, called)
+	})
+}
+
+func TestGetAndPersistPlayerProviderMode(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+
+	build := func(
+		t *testing.T,
+		provider playerprovider.PlayerProvider,
+		repo playerrepository.PlayerRepository,
+		accountRepo displaynameAccountRepository,
+		getAccountByUUID GetAccountByUUID,
+	) GetAndPersistPlayerWithCache {
+		t.Helper()
+		usecase, err := BuildGetAndPersistPlayerWithCache(
+			cache.NewBasicCache[*domain.PlayerPIT](),
+			provider,
+			repo,
+			accountRepo,
+			getAccountByUUID,
+		)
+		require.NoError(t, err)
+		return usecase
+	}
+
+	panicGetAccount := func(t *testing.T) GetAccountByUUID {
+		return func(ctx context.Context, uuid string) (domain.Account, error) {
+			t.Helper()
+			t.Fatal("getAccountByUUID should not be called")
+			return domain.Account{}, nil
+		}
+	}
+
+	t.Run("fallback returns stored player without querying the provider", func(t *testing.T) {
+		t.Parallel()
+
+		repo := &fakePlayerRepository{
+			StubPlayerRepository: playerrepository.NewStubPlayerRepository(),
+			player:               domaintest.NewPlayerBuilder(UUID).WithExperience(1234).BuildPtr(now),
+		}
+		accountRepo := stubAccountRepositoryByUUID{account: domain.Account{UUID: UUID, Username: "StoredName"}}
+
+		usecase := build(t, &panicPlayerProvider{t: t}, repo, accountRepo, panicGetAccount(t))
+
+		player, err := usecase(t.Context(), UUID, ProviderModeFallback)
+		require.NoError(t, err)
+		require.NotNil(t, player)
+		require.Equal(t, int64(1234), player.Experience)
+		require.NotNil(t, player.Displayname)
+		require.Equal(t, "StoredName", *player.Displayname)
+	})
+
+	t.Run("fallback resolves username via provider when not in account repo", func(t *testing.T) {
+		t.Parallel()
+
+		repo := &fakePlayerRepository{
+			StubPlayerRepository: playerrepository.NewStubPlayerRepository(),
+			player:               domaintest.NewPlayerBuilder(UUID).WithExperience(1234).BuildPtr(now),
+		}
+		accountRepo := stubAccountRepositoryByUUID{err: domain.ErrUsernameNotFound}
+		getAccountByUUID := func(ctx context.Context, uuid string) (domain.Account, error) {
+			return domain.Account{UUID: UUID, Username: "FetchedName"}, nil
+		}
+
+		usecase := build(t, &panicPlayerProvider{t: t}, repo, accountRepo, getAccountByUUID)
+
+		player, err := usecase(t.Context(), UUID, ProviderModeFallback)
+		require.NoError(t, err)
+		require.NotNil(t, player.Displayname)
+		require.Equal(t, "FetchedName", *player.Displayname)
+	})
+
+	t.Run("fallback queries the provider when there are no stored stats", func(t *testing.T) {
+		t.Parallel()
+
+		repo := &fakePlayerRepository{
+			StubPlayerRepository: playerrepository.NewStubPlayerRepository(),
+			getPlayerErr:         domain.ErrPlayerNotFound,
+		}
+		provider := &mockedPlayerProvider{
+			t:      t,
+			player: domaintest.NewPlayerBuilder(UUID).WithExperience(999).BuildPtr(now),
+		}
+		accountRepo := stubAccountRepositoryByUUID{err: domain.ErrUsernameNotFound}
+
+		usecase := build(t, provider, repo, accountRepo, panicGetAccount(t))
+
+		player, err := usecase(t.Context(), UUID, ProviderModeFallback)
+		require.NoError(t, err)
+		require.Equal(t, int64(999), player.Experience)
+	})
+
+	t.Run("never returns stored player without querying the provider", func(t *testing.T) {
+		t.Parallel()
+
+		repo := &fakePlayerRepository{
+			StubPlayerRepository: playerrepository.NewStubPlayerRepository(),
+			player:               domaintest.NewPlayerBuilder(UUID).WithExperience(1234).BuildPtr(now),
+		}
+		accountRepo := stubAccountRepositoryByUUID{account: domain.Account{UUID: UUID, Username: "StoredName"}}
+
+		usecase := build(t, &panicPlayerProvider{t: t}, repo, accountRepo, panicGetAccount(t))
+
+		player, err := usecase(t.Context(), UUID, ProviderModeNever)
+		require.NoError(t, err)
+		require.Equal(t, int64(1234), player.Experience)
+		require.NotNil(t, player.Displayname)
+		require.Equal(t, "StoredName", *player.Displayname)
+	})
+
+	t.Run("never fails without querying the provider when no stored stats", func(t *testing.T) {
+		t.Parallel()
+
+		repo := &fakePlayerRepository{
+			StubPlayerRepository: playerrepository.NewStubPlayerRepository(),
+			getPlayerErr:         domain.ErrPlayerNotFound,
+		}
+		accountRepo := stubAccountRepositoryByUUID{err: domain.ErrUsernameNotFound}
+
+		usecase := build(t, &panicPlayerProvider{t: t}, repo, accountRepo, panicGetAccount(t))
+
+		_, err := usecase(t.Context(), UUID, ProviderModeNever)
+		require.Error(t, err)
+		// Must NOT be ErrPlayerNotFound so the port responds with 500, not 404.
+		require.NotErrorIs(t, err, domain.ErrPlayerNotFound)
+	})
+
+	t.Run("invalid provider mode errors without querying anything", func(t *testing.T) {
+		t.Parallel()
+
+		repo := &fakePlayerRepository{StubPlayerRepository: playerrepository.NewStubPlayerRepository()}
+		accountRepo := stubAccountRepositoryByUUID{err: domain.ErrUsernameNotFound}
+
+		usecase := build(t, &panicPlayerProvider{t: t}, repo, accountRepo, panicGetAccount(t))
+
+		_, err := usecase(t.Context(), UUID, ProviderMode("bogus"))
+		require.Error(t, err)
 	})
 }

--- a/internal/app/milestone.go
+++ b/internal/app/milestone.go
@@ -30,7 +30,7 @@ func BuildFindMilestoneAchievements(
 
 		// Ensure the repository is updated with the latest data
 		// NOTE: GetAndPersistPlayerWithCache implementations handle their own error reporting
-		_, _ = getAndPersistPlayerWithCache(ctx, playerUUID)
+		_, _ = getAndPersistPlayerWithCache(ctx, playerUUID, ProviderModeFallback)
 
 		// Convert star milestones to experience milestones
 		var convertedMilestones []int64

--- a/internal/app/milestone_test.go
+++ b/internal/app/milestone_test.go
@@ -34,10 +34,11 @@ func TestFindMilestoneAchievements(t *testing.T) {
 	ctx := t.Context()
 	playerUUID := domaintest.NewUUID(t)
 
-	getAndPersistPlayerWithoutCache := func(t *testing.T) func(ctx context.Context, playerUUIDArg string) (*domain.PlayerPIT, error) {
-		return func(ctx context.Context, playerUUIDArg string) (*domain.PlayerPIT, error) {
+	getAndPersistPlayerWithoutCache := func(t *testing.T) func(ctx context.Context, playerUUIDArg string, providerMode app.ProviderMode) (*domain.PlayerPIT, error) {
+		return func(ctx context.Context, playerUUIDArg string, providerMode app.ProviderMode) (*domain.PlayerPIT, error) {
 			t.Helper()
 			require.Equal(t, playerUUID, playerUUIDArg)
+			require.Equal(t, app.ProviderModeFallback, providerMode)
 			return nil, nil
 		}
 	}

--- a/internal/ports/player_data.go
+++ b/internal/ports/player_data.go
@@ -126,7 +126,7 @@ func MakeGetPlayerDataHandler(
 			},
 		)
 
-		player, err := getAndPersistPlayerWithCache(ctx, uuid)
+		player, err := getAndPersistPlayerWithCache(ctx, uuid, app.ProviderModeFallback)
 		if errors.Is(err, domain.ErrPlayerNotFound) {
 			hypixelAPIResponseData, err := PlayerToPrismPlayerDataResponseData(nil)
 			if err != nil {

--- a/internal/ports/player_data_test.go
+++ b/internal/ports/player_data_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/Amund211/flashlight/internal/app"
 	"github.com/Amund211/flashlight/internal/domain"
 	"github.com/Amund211/flashlight/internal/domaintest"
 )
@@ -46,7 +47,7 @@ func TestMakeGetPlayerDataHandler(t *testing.T) {
 
 		player := domaintest.NewPlayerBuilder(UUID).WithExperience(1000).BuildPtr(now)
 
-		getPlayerDataHandler := MakeGetPlayerDataHandler(func(ctx context.Context, uuid string) (*domain.PlayerPIT, error) {
+		getPlayerDataHandler := MakeGetPlayerDataHandler(func(ctx context.Context, uuid string, providerMode app.ProviderMode) (*domain.PlayerPIT, error) {
 			return player, nil
 		}, stubRegisterUserVisit, logger, sentryMiddleware, bearerAuthMiddleware, emptyBlocklistConfig, false)
 
@@ -68,7 +69,7 @@ func TestMakeGetPlayerDataHandler(t *testing.T) {
 	t.Run("client error: invalid uuid", func(t *testing.T) {
 		t.Parallel()
 
-		getPlayerDataHandler := MakeGetPlayerDataHandler(func(ctx context.Context, uuid string) (*domain.PlayerPIT, error) {
+		getPlayerDataHandler := MakeGetPlayerDataHandler(func(ctx context.Context, uuid string, providerMode app.ProviderMode) (*domain.PlayerPIT, error) {
 			t.Helper()
 			t.Fatal("should not be called")
 			return nil, nil
@@ -88,7 +89,7 @@ func TestMakeGetPlayerDataHandler(t *testing.T) {
 	t.Run("player not found", func(t *testing.T) {
 		t.Parallel()
 
-		getPlayerDataHandler := MakeGetPlayerDataHandler(func(ctx context.Context, uuid string) (*domain.PlayerPIT, error) {
+		getPlayerDataHandler := MakeGetPlayerDataHandler(func(ctx context.Context, uuid string, providerMode app.ProviderMode) (*domain.PlayerPIT, error) {
 			return nil, fmt.Errorf("%w: couldn't find him", domain.ErrPlayerNotFound)
 		}, stubRegisterUserVisit, logger, sentryMiddleware, bearerAuthMiddleware, emptyBlocklistConfig, false)
 		w := httptest.NewRecorder()
@@ -105,7 +106,7 @@ func TestMakeGetPlayerDataHandler(t *testing.T) {
 	t.Run("provider temporarily unavailable", func(t *testing.T) {
 		t.Parallel()
 
-		getPlayerDataHandler := MakeGetPlayerDataHandler(func(ctx context.Context, uuid string) (*domain.PlayerPIT, error) {
+		getPlayerDataHandler := MakeGetPlayerDataHandler(func(ctx context.Context, uuid string, providerMode app.ProviderMode) (*domain.PlayerPIT, error) {
 			return nil, fmt.Errorf("error :^(: (%w)", domain.ErrTemporarilyUnavailable)
 		}, stubRegisterUserVisit, logger, sentryMiddleware, bearerAuthMiddleware, emptyBlocklistConfig, false)
 		w := httptest.NewRecorder()
@@ -124,7 +125,7 @@ func TestMakeGetPlayerDataHandler(t *testing.T) {
 
 		player := domaintest.NewPlayerBuilder(UUID).WithExperience(1000).BuildPtr(now)
 
-		getPlayerDataHandler := MakeGetPlayerDataHandler(func(ctx context.Context, uuid string) (*domain.PlayerPIT, error) {
+		getPlayerDataHandler := MakeGetPlayerDataHandler(func(ctx context.Context, uuid string, providerMode app.ProviderMode) (*domain.PlayerPIT, error) {
 			return player, nil
 		}, stubRegisterUserVisit, logger, sentryMiddleware, bearerAuthMiddleware, emptyBlocklistConfig, false)
 

--- a/main.go
+++ b/main.go
@@ -174,12 +174,6 @@ func main() {
 		fail("Failed to initialize allowed origins", "error", err.Error())
 	}
 
-	getAndPersistPlayerWithCache, err := app.BuildGetAndPersistPlayerWithCache(playerCache, playerProvider, playerRepo)
-	if err != nil {
-		fail("Failed to initialize GetAndPersistPlayerWithCache", "error", err.Error())
-	}
-	updatePlayerInInterval := app.BuildUpdatePlayerInInterval(getAndPersistPlayerWithCache, time.Now)
-
 	getAccountByUsernameWithCache, err := app.BuildGetAccountByUsernameWithCache(accountByUsernameCache, accountProvider, accountRepo, time.Now)
 	if err != nil {
 		fail("Failed to initialize GetAccountByUsernameWithCache", "error", err.Error())
@@ -188,6 +182,12 @@ func main() {
 	if err != nil {
 		fail("Failed to initialize GetAccountByUUIDWithCache", "error", err.Error())
 	}
+
+	getAndPersistPlayerWithCache, err := app.BuildGetAndPersistPlayerWithCache(playerCache, playerProvider, playerRepo, accountRepo, getAccountByUUIDWithCache)
+	if err != nil {
+		fail("Failed to initialize GetAndPersistPlayerWithCache", "error", err.Error())
+	}
+	updatePlayerInInterval := app.BuildUpdatePlayerInInterval(getAndPersistPlayerWithCache, time.Now)
 
 	getTags, err := app.BuildGetTagsWithCache(tagsCache, tagProvider)
 	if err != nil {


### PR DESCRIPTION
## Why

We're seeing a lot of bot traffic on the playerdata endpoints, which is burning through our Hypixel API rate limit. This adds a `providerMode` to the get-and-persist player flow so we can serve players from our own stats DB instead of always hitting Hypixel.

## What

Adds a `providerMode` parameter to `GetAndPersistPlayerWithCache` with three allowed values. The value is validated on receipt — an invalid value is reported (Sentry) and returns an error.

- **`always`** — query the provider (Hypixel) for fresh data and persist it. Original behaviour.
- **`fallback`** — return the most recent stored stats when we have them, only querying the provider when we have no stored stats for the player. The stats DB does not store usernames, so the displayname is resolved separately: we check our own account store first and only fetch (Mojang) when it isn't stored.
- **`never`** — never query the provider. If the player isn't stored, the request fails with a 500 (a generic error, not `ErrPlayerNotFound`, so it does not map to 404).

Supporting changes:
- New `PlayerRepository.GetPlayer(ctx, uuid)` returning the most recently stored `PlayerPIT`, or `domain.ErrPlayerNotFound`. Implemented for the Postgres repo and the stub.
- `BuildGetAndPersistPlayerWithCache` now takes the account repo + `GetAccountByUUID` use case for db-first username resolution; `main.go` wiring reordered accordingly.
- The return-count metric gains a low-cardinality `provider_mode` attribute.
- The cache key now includes the mode so different modes don't serve each other's (differently-sourced) results.

**All callers currently pass `fallback`** (playerdata port, milestone/prestiges, and the `updatePlayerInInterval` path used by history/sessions/session-at/wrapped), as requested for the initial rollout.

## Tests

- New app-layer tests covering each mode: fallback served-from-DB (no provider call) with username resolution from the account store and via fetch, fallback-to-provider on cache/DB miss, never served-from-DB, never-fails-without-provider, and invalid-mode.
- New Postgres `GetPlayer` tests (most-recent selection, `ErrPlayerNotFound`, un-normalized UUID).
- Existing tests updated for the new signature. Full suite + `golangci-lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)