### PR TITLE
Set provider modes per call site

### DIFF
--- a/internal/app/get_and_persist.go
+++ b/internal/app/get_and_persist.go
@@ -257,7 +257,7 @@ func BuildUpdatePlayerInInterval(
 		}
 
 		// This is a current interval -> fetch new data and persist it to the repository
-		_, err := getAndPersistPlayerWithCache(ctx, uuid, ProviderModeFallback)
+		_, err := getAndPersistPlayerWithCache(ctx, uuid, ProviderModeAlways)
 		if err != nil {
 			// NOTE: GetAndPersistPlayerWithCache implementations handle their own error reporting
 			return fmt.Errorf("failed to get updated player data: %w", err)

--- a/internal/app/get_and_persist_test.go
+++ b/internal/app/get_and_persist_test.go
@@ -205,7 +205,7 @@ func TestUpdatePlayerInInterval(t *testing.T) {
 			getAndPersist := func(ctx context.Context, uuid string, providerMode ProviderMode) (*domain.PlayerPIT, error) {
 				t.Helper()
 				require.Equal(t, testUUID, uuid)
-				require.Equal(t, ProviderModeFallback, providerMode)
+				require.Equal(t, ProviderModeAlways, providerMode)
 				updated = true
 				return nil, nil
 			}
@@ -232,7 +232,7 @@ func TestUpdatePlayerInInterval(t *testing.T) {
 		getAndPersist := func(ctx context.Context, uuid string, providerMode ProviderMode) (*domain.PlayerPIT, error) {
 			t.Helper()
 			require.Equal(t, testUUID, uuid)
-			require.Equal(t, ProviderModeFallback, providerMode)
+			require.Equal(t, ProviderModeAlways, providerMode)
 			called = true
 			return nil, assert.AnError
 		}

--- a/internal/app/milestone.go
+++ b/internal/app/milestone.go
@@ -30,7 +30,7 @@ func BuildFindMilestoneAchievements(
 
 		// Ensure the repository is updated with the latest data
 		// NOTE: GetAndPersistPlayerWithCache implementations handle their own error reporting
-		_, _ = getAndPersistPlayerWithCache(ctx, playerUUID, ProviderModeFallback)
+		_, _ = getAndPersistPlayerWithCache(ctx, playerUUID, ProviderModeAlways)
 
 		// Convert star milestones to experience milestones
 		var convertedMilestones []int64

--- a/internal/app/milestone_test.go
+++ b/internal/app/milestone_test.go
@@ -38,7 +38,7 @@ func TestFindMilestoneAchievements(t *testing.T) {
 		return func(ctx context.Context, playerUUIDArg string, providerMode app.ProviderMode) (*domain.PlayerPIT, error) {
 			t.Helper()
 			require.Equal(t, playerUUID, playerUUIDArg)
-			require.Equal(t, app.ProviderModeFallback, providerMode)
+			require.Equal(t, app.ProviderModeAlways, providerMode)
 			return nil, nil
 		}
 	}

--- a/internal/ports/player_data.go
+++ b/internal/ports/player_data.go
@@ -126,7 +126,7 @@ func MakeGetPlayerDataHandler(
 			},
 		)
 
-		player, err := getAndPersistPlayerWithCache(ctx, uuid, app.ProviderModeFallback)
+		player, err := getAndPersistPlayerWithCache(ctx, uuid, app.ProviderModeNever)
 		if errors.Is(err, domain.ErrPlayerNotFound) {
 			hypixelAPIResponseData, err := PlayerToPrismPlayerDataResponseData(nil)
 			if err != nil {


### PR DESCRIPTION
## Summary
Sets the provider mode explicitly at each call site of `GetAndPersistPlayerWithCache`:

- **playerdata endpoint** (`internal/ports/player_data.go`) → `ProviderModeNever` — never query the provider; serve stored stats only.
- **interval updater** (`internal/app/get_and_persist.go`) → `ProviderModeAlways` — always fetch fresh data for current intervals.
- **milestone finder** (`internal/app/milestone.go`) → `ProviderModeAlways` — always fetch fresh data before computing achievements.

Test assertions for the interval updater and milestone finder are updated to match.

## Test plan
- `go build ./...`
- `go test ./internal/app/ ./internal/ports/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)