### PR TITLE
feat: Add well-known provider mode

### DIFF
--- a/internal/adapters/playerrepository/interface.go
+++ b/internal/adapters/playerrepository/interface.go
@@ -12,6 +12,8 @@ type PlayerRepository interface {
 	// GetPlayer returns the most recently stored PlayerPIT for the given UUID.
 	// Returns domain.ErrPlayerNotFound if no stats are stored for the UUID.
 	GetPlayer(ctx context.Context, playerUUID string) (*domain.PlayerPIT, error)
+	// CountStats returns the number of stored stat records for the given UUID.
+	CountStats(ctx context.Context, playerUUID string) (int, error)
 	GetHistory(ctx context.Context, playerUUID string, start, end time.Time, limit int) ([]domain.PlayerPIT, error)
 	GetPlayerPITs(ctx context.Context, playerUUID string, start, end time.Time) ([]domain.PlayerPIT, error)
 	FindMilestoneAchievements(ctx context.Context, playerUUID string, gamemode domain.Gamemode, stat domain.Stat, milestones []int64) ([]domain.MilestoneAchievement, error)

--- a/internal/adapters/playerrepository/repository.go
+++ b/internal/adapters/playerrepository/repository.go
@@ -354,6 +354,52 @@ func (p *PostgresPlayerRepository) GetPlayer(ctx context.Context, playerUUID str
 	return player, nil
 }
 
+func (p *PostgresPlayerRepository) CountStats(ctx context.Context, playerUUID string) (int, error) {
+	ctx, span := p.tracer.Start(ctx, "PostgresPlayerRepository.CountStats")
+	defer span.End()
+
+	if !strutils.UUIDIsNormalized(playerUUID) {
+		err := fmt.Errorf("uuid is not normalized")
+		reporting.Report(ctx, err, map[string]string{
+			"uuid": playerUUID,
+		})
+		return 0, err
+	}
+
+	conn, err := p.db.Connx(ctx)
+	if err != nil {
+		err := fmt.Errorf("failed to get connection: %w", err)
+		reporting.Report(ctx, err)
+		return 0, err
+	}
+	defer conn.Close()
+
+	_, err = conn.ExecContext(ctx, fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(p.schema)))
+	if err != nil {
+		err := fmt.Errorf("failed to set search path: %w", err)
+		reporting.Report(ctx, err, map[string]string{
+			"schema": p.schema,
+		})
+		return 0, err
+	}
+
+	var count int
+	err = conn.GetContext(
+		ctx,
+		&count,
+		`select count(*) from stats where player_uuid = $1`,
+		playerUUID)
+	if err != nil {
+		err := fmt.Errorf("failed to count stats: %w", err)
+		reporting.Report(ctx, err, map[string]string{
+			"uuid": playerUUID,
+		})
+		return 0, err
+	}
+
+	return count, nil
+}
+
 func (p *PostgresPlayerRepository) GetHistory(ctx context.Context, playerUUID string, start, end time.Time, limit int) ([]domain.PlayerPIT, error) {
 	ctx, span := p.tracer.Start(ctx, "PostgresPlayerRepository.GetHistory")
 	defer span.End()
@@ -775,6 +821,10 @@ func (p *StubPlayerRepository) StorePlayer(ctx context.Context, player *domain.P
 
 func (p *StubPlayerRepository) GetPlayer(ctx context.Context, playerUUID string) (*domain.PlayerPIT, error) {
 	return nil, domain.ErrPlayerNotFound
+}
+
+func (p *StubPlayerRepository) CountStats(ctx context.Context, playerUUID string) (int, error) {
+	return 0, nil
 }
 
 func (p *StubPlayerRepository) GetHistory(ctx context.Context, playerUUID string, start, end time.Time, limit int) ([]domain.PlayerPIT, error) {

--- a/internal/adapters/playerrepository/repository_test.go
+++ b/internal/adapters/playerrepository/repository_test.go
@@ -427,6 +427,65 @@ func TestPostgresPlayerRepository(t *testing.T) {
 		})
 	})
 
+	t.Run("CountStats", func(t *testing.T) {
+		t.Parallel()
+		p := newPostgresPlayerRepository(t, db, "count_stats_tests")
+
+		now := time.Now().Truncate(time.Millisecond)
+
+		t.Run("returns the number of stored stats for the player", func(t *testing.T) {
+			t.Parallel()
+
+			playerUUID := domaintest.NewUUID(t)
+
+			// Distinct stats so the store dedup logic keeps each as a separate row.
+			p1 := domaintest.NewPlayerBuilder(playerUUID).Fours().WithGamesPlayed(1).BuildPtr(now.Add(-2 * time.Hour))
+			p2 := domaintest.NewPlayerBuilder(playerUUID).Fours().WithGamesPlayed(2).BuildPtr(now.Add(-1 * time.Hour))
+			p3 := domaintest.NewPlayerBuilder(playerUUID).Fours().WithGamesPlayed(3).BuildPtr(now)
+
+			require.NoError(t, p.StorePlayer(ctx, p1))
+			require.NoError(t, p.StorePlayer(ctx, p2))
+			require.NoError(t, p.StorePlayer(ctx, p3))
+
+			count, err := p.CountStats(ctx, playerUUID)
+			require.NoError(t, err)
+			require.Equal(t, 3, count)
+		})
+
+		t.Run("returns zero when no stats are stored", func(t *testing.T) {
+			t.Parallel()
+
+			playerUUID := domaintest.NewUUID(t)
+
+			count, err := p.CountStats(ctx, playerUUID)
+			require.NoError(t, err)
+			require.Equal(t, 0, count)
+		})
+
+		t.Run("only counts stats for the given player", func(t *testing.T) {
+			t.Parallel()
+
+			playerUUID := domaintest.NewUUID(t)
+			otherUUID := domaintest.NewUUID(t)
+
+			require.NoError(t, p.StorePlayer(ctx, domaintest.NewPlayerBuilder(playerUUID).Fours().WithGamesPlayed(1).BuildPtr(now.Add(-1*time.Hour))))
+			require.NoError(t, p.StorePlayer(ctx, domaintest.NewPlayerBuilder(playerUUID).Fours().WithGamesPlayed(2).BuildPtr(now)))
+
+			require.NoError(t, p.StorePlayer(ctx, domaintest.NewPlayerBuilder(otherUUID).Fours().WithGamesPlayed(1).BuildPtr(now)))
+
+			count, err := p.CountStats(ctx, playerUUID)
+			require.NoError(t, err)
+			require.Equal(t, 2, count)
+		})
+
+		t.Run("errors on un-normalized uuid", func(t *testing.T) {
+			t.Parallel()
+
+			_, err := p.CountStats(ctx, "not-a-uuid")
+			require.Error(t, err)
+		})
+	})
+
 	t.Run("GetPlayerPITs", func(t *testing.T) {
 		t.Parallel()
 		p := newPostgresPlayerRepository(t, db, "get_player_pits_tests")

--- a/internal/app/get_and_persist.go
+++ b/internal/app/get_and_persist.go
@@ -33,11 +33,20 @@ const (
 	// ProviderModeNever never queries the provider. If we have no stored stats
 	// for the player the request fails.
 	ProviderModeNever ProviderMode = "never"
+	// ProviderModeWellKnown behaves like ProviderModeAlways for players we
+	// consider well-known (those with at least wellKnownStatsThreshold stored
+	// stat records) and like ProviderModeNever for everyone else.
+	ProviderModeWellKnown ProviderMode = "well-known"
 )
+
+// wellKnownStatsThreshold is the minimum number of stored stat records a player
+// must have for ProviderModeWellKnown to treat them as well-known and query the
+// provider for fresh data.
+const wellKnownStatsThreshold = 10
 
 func (m ProviderMode) validate() error {
 	switch m {
-	case ProviderModeAlways, ProviderModeFallback, ProviderModeNever:
+	case ProviderModeAlways, ProviderModeFallback, ProviderModeNever, ProviderModeWellKnown:
 		return nil
 	default:
 		return fmt.Errorf("invalid provider mode: %q", string(m))
@@ -151,6 +160,23 @@ func BuildGetAndPersistPlayerWithCache(
 		return &username
 	}
 
+	// getStoredPlayerOrFail returns the most recent stored stats for the player
+	// without ever querying the provider. If we have no stored stats it returns
+	// a generic error (not ErrPlayerNotFound) so the caller responds with a 500
+	// rather than a 404.
+	getStoredPlayerOrFail := func(ctx context.Context, uuid string, providerMode ProviderMode) (*domain.PlayerPIT, error) {
+		repoPlayer, err := repo.GetPlayer(ctx, uuid)
+		if err == nil {
+			repoPlayer.Displayname = resolveDisplayname(ctx, uuid)
+			return repoPlayer, nil
+		}
+		if errors.Is(err, domain.ErrPlayerNotFound) {
+			return nil, fmt.Errorf("player not stored and provider mode is %q", providerMode)
+		}
+		// NOTE: PlayerRepository implementations handle their own error reporting
+		return nil, fmt.Errorf("failed to get player from repository: %w", err)
+	}
+
 	return func(ctx context.Context, uuid string, providerMode ProviderMode) (*domain.PlayerPIT, error) {
 		if err := providerMode.validate(); err != nil {
 			logging.FromContext(ctx).ErrorContext(ctx, "Invalid provider mode", "providerMode", string(providerMode))
@@ -190,19 +216,20 @@ func BuildGetAndPersistPlayerWithCache(
 				// No stored stats (or lookup failed) -> fetch from the provider
 				return getAndPersistPlayerWithoutCache(ctx, provider, repo, uuid)
 			case ProviderModeNever:
-				repoPlayer, err := repo.GetPlayer(ctx, uuid)
-				if err == nil {
-					repoPlayer.Displayname = resolveDisplayname(ctx, uuid)
-					return repoPlayer, nil
+				// Provider mode is never -> we don't query the provider.
+				return getStoredPlayerOrFail(ctx, uuid, providerMode)
+			case ProviderModeWellKnown:
+				count, err := repo.CountStats(ctx, uuid)
+				if err != nil {
+					// NOTE: PlayerRepository implementations handle their own error reporting
+					return nil, fmt.Errorf("failed to count stored player stats: %w", err)
 				}
-				if errors.Is(err, domain.ErrPlayerNotFound) {
-					// Provider mode is never -> we don't query the provider.
-					// Return a generic error (not ErrPlayerNotFound) so the caller
-					// responds with a 500 rather than a 404.
-					return nil, fmt.Errorf("player not stored and provider mode is %q", providerMode)
+				if count >= wellKnownStatsThreshold {
+					// Well-known player -> behave like ProviderModeAlways.
+					return getAndPersistPlayerWithoutCache(ctx, provider, repo, uuid)
 				}
-				// NOTE: PlayerRepository implementations handle their own error reporting
-				return nil, fmt.Errorf("failed to get player from repository: %w", err)
+				// Not well-known -> behave like ProviderModeNever.
+				return getStoredPlayerOrFail(ctx, uuid, providerMode)
 			default:
 				// Unreachable: providerMode was validated above.
 				return nil, fmt.Errorf("invalid provider mode: %q", providerMode)

--- a/internal/app/get_and_persist_test.go
+++ b/internal/app/get_and_persist_test.go
@@ -51,12 +51,14 @@ func (s stubAccountRepositoryByUUID) GetAccountByUUID(ctx context.Context, uuid 
 	return s.account, s.err
 }
 
-// fakePlayerRepository lets tests configure the result of GetPlayer while
-// inheriting the no-op behaviour of the stub repository for everything else.
+// fakePlayerRepository lets tests configure the result of GetPlayer and
+// CountStats while inheriting the no-op behaviour of the stub repository for
+// everything else.
 type fakePlayerRepository struct {
 	*playerrepository.StubPlayerRepository
 	player       *domain.PlayerPIT
 	getPlayerErr error
+	statCount    int
 }
 
 func (f *fakePlayerRepository) GetPlayer(ctx context.Context, uuid string) (*domain.PlayerPIT, error) {
@@ -64,6 +66,10 @@ func (f *fakePlayerRepository) GetPlayer(ctx context.Context, uuid string) (*dom
 		return nil, f.getPlayerErr
 	}
 	return f.player, nil
+}
+
+func (f *fakePlayerRepository) CountStats(ctx context.Context, uuid string) (int, error) {
+	return f.statCount, nil
 }
 
 func TestGetAndPersistPlayer(t *testing.T) {
@@ -367,6 +373,65 @@ func TestGetAndPersistPlayerProviderMode(t *testing.T) {
 		usecase := build(t, &panicPlayerProvider{t: t}, repo, accountRepo, panicGetAccount(t))
 
 		_, err := usecase(t.Context(), UUID, ProviderModeNever)
+		require.Error(t, err)
+		// Must NOT be ErrPlayerNotFound so the port responds with 500, not 404.
+		require.NotErrorIs(t, err, domain.ErrPlayerNotFound)
+	})
+
+	t.Run("well-known queries the provider when the player has enough stored stats", func(t *testing.T) {
+		t.Parallel()
+
+		repo := &fakePlayerRepository{
+			StubPlayerRepository: playerrepository.NewStubPlayerRepository(),
+			// Stored player is stale; well-known should ignore it and query the provider.
+			player:    domaintest.NewPlayerBuilder(UUID).WithExperience(1234).BuildPtr(now),
+			statCount: wellKnownStatsThreshold,
+		}
+		provider := &mockedPlayerProvider{
+			t:      t,
+			player: domaintest.NewPlayerBuilder(UUID).WithExperience(999).BuildPtr(now),
+		}
+		accountRepo := stubAccountRepositoryByUUID{err: domain.ErrUsernameNotFound}
+
+		usecase := build(t, provider, repo, accountRepo, panicGetAccount(t))
+
+		player, err := usecase(t.Context(), UUID, ProviderModeWellKnown)
+		require.NoError(t, err)
+		require.Equal(t, int64(999), player.Experience)
+	})
+
+	t.Run("well-known returns stored player without querying the provider when below threshold", func(t *testing.T) {
+		t.Parallel()
+
+		repo := &fakePlayerRepository{
+			StubPlayerRepository: playerrepository.NewStubPlayerRepository(),
+			player:               domaintest.NewPlayerBuilder(UUID).WithExperience(1234).BuildPtr(now),
+			statCount:            wellKnownStatsThreshold - 1,
+		}
+		accountRepo := stubAccountRepositoryByUUID{account: domain.Account{UUID: UUID, Username: "StoredName"}}
+
+		usecase := build(t, &panicPlayerProvider{t: t}, repo, accountRepo, panicGetAccount(t))
+
+		player, err := usecase(t.Context(), UUID, ProviderModeWellKnown)
+		require.NoError(t, err)
+		require.Equal(t, int64(1234), player.Experience)
+		require.NotNil(t, player.Displayname)
+		require.Equal(t, "StoredName", *player.Displayname)
+	})
+
+	t.Run("well-known fails without querying the provider when below threshold and no stored stats", func(t *testing.T) {
+		t.Parallel()
+
+		repo := &fakePlayerRepository{
+			StubPlayerRepository: playerrepository.NewStubPlayerRepository(),
+			getPlayerErr:         domain.ErrPlayerNotFound,
+			statCount:            0,
+		}
+		accountRepo := stubAccountRepositoryByUUID{err: domain.ErrUsernameNotFound}
+
+		usecase := build(t, &panicPlayerProvider{t: t}, repo, accountRepo, panicGetAccount(t))
+
+		_, err := usecase(t.Context(), UUID, ProviderModeWellKnown)
 		require.Error(t, err)
 		// Must NOT be ErrPlayerNotFound so the port responds with 500, not 404.
 		require.NotErrorIs(t, err, domain.ErrPlayerNotFound)

--- a/internal/ports/player_data.go
+++ b/internal/ports/player_data.go
@@ -126,7 +126,7 @@ func MakeGetPlayerDataHandler(
 			},
 		)
 
-		player, err := getAndPersistPlayerWithCache(ctx, uuid, app.ProviderModeNever)
+		player, err := getAndPersistPlayerWithCache(ctx, uuid, app.ProviderModeWellKnown)
 		if errors.Is(err, domain.ErrPlayerNotFound) {
 			hypixelAPIResponseData, err := PlayerToPrismPlayerDataResponseData(nil)
 			if err != nil {


### PR DESCRIPTION
## Summary

Adds a new `well-known` provider mode and wires it up to the player data endpoint.

`well-known` decides per-player how to source stats based on how much history we already have stored:
- **≥ 10 stored stat records** → behaves like `always` (query the provider for fresh data and persist it).
- **fewer than 10** → behaves like `never` (serve the most recent stored stats only; error if none, so the caller responds 500 rather than 404).

The threshold is a `wellKnownStatsThreshold = 10` constant, easy to tune.

## Changes

- **`playerrepository`**: new `CountStats(ctx, playerUUID) (int, error)` on the interface, implemented for `PostgresPlayerRepository` (`SELECT count(*) FROM stats WHERE player_uuid = $1`) and `StubPlayerRepository`.
- **`app/get_and_persist`**: new `ProviderModeWellKnown` constant + validation + threshold. Extracted the `never` behavior into a shared `getStoredPlayerOrFail` helper reused by both `never` and the below-threshold `well-known` path.
- **`ports/player_data`**: the `playerdata` endpoint now passes `ProviderModeWellKnown` (was `ProviderModeNever`).

## Notes

- The mode is part of the cache key, so `CountStats` only runs on a cache miss, not every request.
- Threshold semantics are "at least 10" (`count >= 10`).

## Testing

- App-level tests for all three `well-known` paths (above threshold → provider; below with stored stats → stored; below with none → non-404 error).
- DB-backed `CountStats` tests (count, zero, per-player filtering, un-normalized UUID) — pass against Postgres.
- Full pre-commit suite (golangci-lint, build, go test, go mod tidy) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)