### PR TITLE
Log stored stats count in well-known provider mode

### DIFF
--- a/internal/app/get_and_persist.go
+++ b/internal/app/get_and_persist.go
@@ -224,6 +224,7 @@ func BuildGetAndPersistPlayerWithCache(
 					// NOTE: PlayerRepository implementations handle their own error reporting
 					return nil, fmt.Errorf("failed to count stored player stats: %w", err)
 				}
+				logging.FromContext(ctx).InfoContext(ctx, "Counted stored player stats for well-known provider mode", "statsCount", count)
 				if count >= wellKnownStatsThreshold {
 					// Well-known player -> behave like ProviderModeAlways.
 					return getAndPersistPlayerWithoutCache(ctx, provider, repo, uuid)


### PR DESCRIPTION
## Summary

Adds a structured log line recording the `CountStats` result whenever the well-known provider mode decides how to route a request. The count is emitted as a `statsCount` structured field so it can be queried/aggregated in log tooling.

This gives visibility into how `ProviderModeWellKnown` routes requests — i.e. how many players cross the well-known threshold (≥10 stored stat records) and get fresh provider queries versus being served stored-only.

## Changes

- `internal/app/get_and_persist.go`: `InfoContext` log with `statsCount` field in the `ProviderModeWellKnown` branch, right after the count is fetched.

## Testing

- `go build ./...`
- `go vet ./internal/app/`
- `go test ./internal/app/`
- pre-commit hooks (golangci-lint, go-build, go-test, go-mod-tidy) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)