### PR TITLE
chore: raise well-known stats threshold to 75

### DIFF
--- a/internal/app/get_and_persist.go
+++ b/internal/app/get_and_persist.go
@@ -42,7 +42,7 @@ const (
 // wellKnownStatsThreshold is the minimum number of stored stat records a player
 // must have for ProviderModeWellKnown to treat them as well-known and query the
 // provider for fresh data.
-const wellKnownStatsThreshold = 10
+const wellKnownStatsThreshold = 75
 
 func (m ProviderMode) validate() error {
 	switch m {


### PR DESCRIPTION
Raise `wellKnownStatsThreshold` from 10 to 75 so `ProviderModeWellKnown` only treats players with at least 75 stored stat records as well-known (querying the provider for fresh data). Everyone below the threshold behaves like `ProviderModeNever`.

## Methodology

Sampled the `statsCount` emitted by the "Counted stored player stats for well-known provider mode" log line via [Cloud Logging Analytics](https://console.cloud.google.com/logs/analytics), and computed the share of requests clearing each candidate threshold over ~1000 samples:

```sql
WITH
  logs AS (
    SELECT * FROM `prism-overlay.global._Default._AllLogs`
    UNION ALL
    SELECT * FROM `prism-overlay.global._Required._AllLogs`
  ),
  stats AS (
    SELECT SAFE_CAST(JSON_VALUE(json_payload.statsCount) AS INT64) AS stats_count
    FROM logs
    WHERE JSON_VALUE(json_payload.statsCount) IS NOT NULL
  )
SELECT
  t AS threshold,
  COUNTIF(stats_count >= t) AS count_run,
  ROUND(100 * COUNTIF(stats_count >= t) / COUNT(*), 1) AS pct_run
FROM stats
CROSS JOIN UNNEST([5, 10, 15, 20, 25, 30, 40, 50, 60, 75, 100, 150, 250, 500, 1000]) AS t
WHERE stats_count IS NOT NULL
GROUP BY t
ORDER BY t
```

`statsCount >= 75` covered 0.6% of samples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
