### PR TITLE
chore: lower well-known stats threshold to 40

### DIFF
--- a/internal/app/get_and_persist.go
+++ b/internal/app/get_and_persist.go
@@ -42,7 +42,7 @@ const (
 // wellKnownStatsThreshold is the minimum number of stored stat records a player
 // must have for ProviderModeWellKnown to treat them as well-known and query the
 // provider for fresh data.
-const wellKnownStatsThreshold = 75
+const wellKnownStatsThreshold = 40
 
 func (m ProviderMode) validate() error {
 	switch m {


### PR DESCRIPTION
Lower `wellKnownStatsThreshold` from 75 to 40 so `ProviderModeWellKnown` treats players with at least 40 stored stat records as well-known (querying the provider for fresh data); everyone below the threshold behaves like `ProviderModeNever`.

## Methodology

Sampled the `statsCount` emitted by the "Counted stored player stats for well-known provider mode" log line via Cloud Logging Analytics, over the last 12 hours as of 2026-07-12 14:59 CEST:

| threshold | count_run | pct_run |
|----------:|----------:|--------:|
| 5 | 52850 | 39.7 |
| 10 | 28112 | 21.1 |
| 15 | 18428 | 13.8 |
| 20 | 13276 | 10.0 |
| 25 | 10371 | 7.8 |
| 30 | 7908 | 5.9 |
| **40** | **4531** | **3.4** |
| 50 | 2872 | 2.2 |
| 60 | 1885 | 1.4 |
| 75 | 1085 | 0.8 |
| 100 | 636 | 0.5 |
| 150 | 309 | 0.2 |
| 250 | 179 | 0.1 |
| 500 | 70 | 0.1 |
| 1000 | 6 | 0.0 |

`statsCount >= 40` covers 3.4% of samples, up from 0.6% at the previous threshold of 75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)